### PR TITLE
Reformat code in DataStructures

### DIFF
--- a/Microsoft.Research/DataStructures/ArrayMap.cs
+++ b/Microsoft.Research/DataStructures/ArrayMap.cs
@@ -1,109 +1,102 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Research.DataStructures {
-
-  [ContractVerification(true)]
-  public class ArrayMap<T> {
-
-    T[] data;
-    bool[] present;
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+namespace Microsoft.Research.DataStructures
+{
+    [ContractVerification(true)]
+    public class ArrayMap<T>
     {
-      Contract.Invariant(this.data != null);
-      Contract.Invariant(this.present != null);
-      Contract.Invariant(data.Length == present.Length);
+        private T[] data;
+        private bool[] present;
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(data != null);
+            Contract.Invariant(present != null);
+            Contract.Invariant(data.Length == present.Length);
+        }
+
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() == data.Length);
+                Contract.Ensures(Contract.Result<int>() >= 0);
+
+                return data.Length;
+            }
+        }
+
+        public ArrayMap(int capacity)
+        {
+            Contract.Requires(capacity >= 0);
+
+            data = new T[capacity];
+            present = new bool[capacity];
+        }
+
+        [Pure]
+        public bool ContainsKey(int key)
+        {
+            Contract.Requires(key >= 0);
+            Contract.Requires(key < Count);
+
+            Contract.Ensures(Contract.Result<bool>() == present[key]);
+
+            return present[key];
+        }
+
+
+        public T this[int key]
+        {
+            get
+            {
+                Contract.Requires(key >= 0);
+                Contract.Requires(key < this.Count);
+                Contract.Requires(ContainsKey(key));
+
+                if (present[key]) return data[key];
+                throw new NotSupportedException("key not in map");
+            }
+
+            set
+            {
+                Contract.Requires(key >= 0);
+                Contract.Requires(key < Count);
+
+                Contract.Ensures(ContainsKey(key));
+
+                data[key] = value;
+                present[key] = true;
+            }
+        }
+
+        public bool TryGetValue(int key, out T value)
+        {
+            Contract.Requires(key >= 0);
+            Contract.Requires(key < Count);
+            Contract.Ensures(Contract.Result<bool>() || !ContainsKey(key));
+
+            if (present[key]) { value = data[key]; return true; }
+            value = default(T);
+            return false;
+        }
+
+        public void Add(int key, T value)
+        {
+            Contract.Requires(key >= 0);
+            Contract.Requires(key < Count);
+            Contract.Requires(!ContainsKey(key));
+
+            if (present[key]) throw new NotSupportedException("key already present");
+            present[key] = true;
+            data[key] = value;
+        }
     }
-
-    public int Count { get {
-      Contract.Ensures(Contract.Result<int>() == this.data.Length);
-      Contract.Ensures(Contract.Result<int>() >= 0);
-
-      return this.data.Length; 
-    } }
-
-    public ArrayMap(int capacity)
-    {
-      Contract.Requires(capacity >= 0);
-     
-      data = new T[capacity];
-      present = new bool[capacity];
-    }
-
-    [Pure]
-    public bool ContainsKey(int key)
-    {
-      Contract.Requires(key >= 0);
-      Contract.Requires(key < Count);
-
-      Contract.Ensures(Contract.Result<bool>() == this.present[key]);
-
-      return present[key];
-    }
-
-
-    public T this[int key]
-    {
-      get
-      {
-        Contract.Requires(key >= 0);
-        Contract.Requires(key < this.Count);
-        Contract.Requires(ContainsKey(key));
-
-        if (present[key]) return data[key];
-        throw new NotSupportedException("key not in map");
-      }
-
-      set
-      {
-        Contract.Requires(key >= 0);
-        Contract.Requires(key < Count);
-
-        Contract.Ensures(ContainsKey(key));
-
-        data[key] = value;
-        present[key] = true;
-      }
-    }
-
-    public bool TryGetValue(int key, out T value)
-    {
-      Contract.Requires(key >= 0);
-      Contract.Requires(key < Count);
-      Contract.Ensures(Contract.Result<bool>() || !ContainsKey(key));
-
-      if (present[key]) { value = data[key]; return true; }
-      value = default(T);
-      return false;
-    }
-
-    public void Add(int key, T value)
-    {
-      Contract.Requires(key >= 0);
-      Contract.Requires(key < Count);
-      Contract.Requires(!ContainsKey(key));
-
-      if (present[key]) throw new NotSupportedException("key already present");
-      present[key] = true;
-      data[key] = value;
-    }
-  }
 }

--- a/Microsoft.Research/DataStructures/Basics.cs
+++ b/Microsoft.Research/DataStructures/Basics.cs
@@ -1,734 +1,729 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Research.DataStructures
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Diagnostics;
-  using System.Text;
-  using System.IO;
-  using System.Linq;
-  using System.Diagnostics.Contracts;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using System.IO;
+    using System.Linq;
+    using System.Diagnostics.Contracts;
 
-
-  /// <summary>
-  /// A dummy empty type like void that can be used for generic instances
-  /// </summary>
-  public struct Unit : IEquatable<Unit>
-  {
-
-    public static readonly Unit Value; // Thread-safe
-
-    #region IEquatable<Unit> Members
-
-    public bool Equals(Unit other)
-    {
-      return true;
-    }
-
-    #endregion
-  }
-
-
-
-  /// <summary>
-  /// An abstraction over sequences
-  /// </summary>
-  public partial interface IIndexable<T> {
-    int Count { get; }
-    T this[int index] { get; }
-  }
-  #region IIndexable contract binding
-  [ContractClass(typeof(IIndexableContract<>))]
-  public partial interface IIndexable<T>
-  {
-  }
-
-  [ContractClassFor(typeof(IIndexable<>))]
-  abstract class IIndexableContract<T> : IIndexable<T>
-  {
-    public int Count
-    {
-      get {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        throw new NotImplementedException();
-      }
-    }
-
-    public T this[int index]
-    {
-      get {
-        Contract.Requires(index >= 0);
-        Contract.Requires(index < this.Count);
-
-        throw new NotImplementedException();
-      }
-    }
-  }
-  #endregion
-
-  public struct IndexableEnumerable<T, IndexT> : IEnumerable<T>
-    where IndexT : IIndexable<T>
-  {
-    IndexT indexable;
-
-    public IndexableEnumerable(IndexT indexable)
-    {
-      Contract.Requires(indexable != null);
-      this.indexable = indexable;
-    }
-
-    public struct Enumerator : IEnumerator<T>
-    {
-      IndexT indexable;
-      int position;
-
-      public Enumerator(IndexT indexable)
-      {
-        this.indexable = indexable;
-        this.position = -1;
-      }
-
-      public T Current
-      {
-        get
-        {
-          if (position >= 0 && position < indexable.Count)
-          {
-            return this.indexable[this.position];
-          }
-          throw new InvalidOperationException();
-        }
-      }
-      object System.Collections.IEnumerator.Current
-      {
-        get
-        {
-          return this.Current;
-        }
-      }
-
-      public bool MoveNext()
-      {
-        position++;
-        return position < indexable.Count;
-      }
-
-      public void Reset()
-      {
-        this.position = -1;
-      }
-
-      void IDisposable.Dispose()
-      {
-      }
-    }
-    public Enumerator GetEnumerator() { return new Enumerator(this.indexable); }
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      return this.GetEnumerator();
-    }
-    IEnumerator<T> IEnumerable<T>.GetEnumerator()
-    {
-      return this.GetEnumerator();
-    }
-  }
-
-  [Serializable]
-  public struct EmptyIndexable<T> : IIndexable<T>, IEnumerable<T>
-  {
-    #region IIndexable<T> Members
-
-    public int Count {
-      get { return 0; }
-    }
-
-    public T this[int index] {
-      get { throw new IndexOutOfRangeException(); }
-    }
-
-    #endregion
-
-    public static readonly EmptyIndexable<T> Empty = new EmptyIndexable<T>(); // Thread-safe
-
-    public IEnumerator<T> GetEnumerator() { yield break; }
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { yield break; }
-  }
-
-  public struct ThreeValued
-  {
-    int value; // 0 undetermined, 1 false, 2 true
-
-    public ThreeValued(bool truth)
-    {
-      if (truth) value = 2;
-      else value = 1;
-    }
-
-    public bool IsTrue { get { return value == 2; } }
-    public bool IsFalse { get { return value == 1; } }
-    public bool IsDetermined { get { return value != 0; } }
-    public bool Truth { get { if (IsTrue) return true; if (IsFalse) return false; throw new InvalidOperationException(); } }
-  }
-
-  [Serializable]
-  public struct UnitIndexable : IIndexable<Unit>, IEnumerable<Unit>
-  {
-    int count;
-
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(count >= 0);
-    }
-
-    public UnitIndexable(int count)
-    {
-      Contract.Requires(count >= 0);
-      this.count = count;
-    }
-
-    #region IIndexable<Unit> Members
-
-    public int Count
-    {
-      get { return this.count; }
-    }
-
-    public Unit this[int index]
-    {
-      get { return Unit.Value; }
-    }
-
-    #endregion
-
-    #region IEnumerable<Unit> Members
-
-    public IEnumerator<Unit> GetEnumerator()
-    {
-      for (int i = 0; i < count; i++)
-      {
-        yield return Unit.Value;
-      }
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      for (int i = 0; i < count; i++)
-      {
-        yield return Unit.Value;
-      }
-    }
-
-    #endregion
-  }
-
-  [Serializable]
-  public struct TailIndexable<T> : IIndexable<T>, IEnumerable<T>
-  {
-    IIndexable<T> underlying;
-
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(underlying != null);
-    }
-
-    public TailIndexable(IIndexable<T> underlying)
-    {
-      Contract.Requires(underlying != null);
-      this.underlying = underlying;
-    }
-
-    #region IIndexable<T> Members
-
-    public int Count
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() == 0 || Contract.Result<int>() == underlying.Count - 1);
-
-        var c = underlying.Count;
-        if (c > 0) return c - 1;
-        return 0;
-      }
-    }
-
-    public T this[int index]
-    {
-      get
-      {
-        Contract.Assert(this.Count > 0, "helping the static checker");
-        return underlying[index + 1];
-      }
-    }
-
-    #endregion
-
-    #region IEnumerable<T> Members
-
-    public IEnumerator<T> GetEnumerator()
-    {
-      for (int i = 0; i < this.Count; i++)
-      {
-        yield return this[i];
-      }
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      return this.GetEnumerator();
-    }
-
-    #endregion
-  }
-
-  [Serializable]
-  public struct ArrayIndexable<T> : IIndexable<T>, IEnumerable<T>
-  {
-
-    T[]/*?*/ array;
-
-    public ArrayIndexable(T[]/*?*/ array) {
-      Contract.Ensures(array == null && Contract.ValueAtReturn(out this).Count == 0 || 
-                       Contract.ValueAtReturn(out this).Count == array.Length);
-      this.array = array;
-    }
-
-    public int Count
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() == 0 || this.array != null && Contract.Result<int>() == this.array.Length);
-        return (this.array == null) ? 0 : this.array.Length;
-      }
-    }
-
-    public T this[int index]
-    {
-      get
-      {
-        Contract.Assert(this.Count > 0, "helping the static checker");
-        return this.array[index];
-      }
-    }
-
-    #region IEnumerable<T> Members
-
-    public IEnumerator<T> GetEnumerator()
-    {
-      for (int i = 0; i < this.Count; i++)
-      {
-        yield return this.array[i];
-      }
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      return this.GetEnumerator();
-    }
-
-    #endregion
-  }
-
-  [Serializable]
-  public struct EnumerableIndexable<T> : IIndexable<T>, IEnumerable<T>
-  {
-    List<T> list;
-    [NonSerialized] IEnumerator<T> enumerator;
 
     /// <summary>
-    /// Produce an IIndexable from the given IEnumerable. The IEnumerable is expanded on
-    /// demand up to capacity elements. The count of the IIndexable is the minimum of either the
-    /// actual number of elements in the enumeration, or the capacity specified.
+    /// A dummy empty type like void that can be used for generic instances
     /// </summary>
-    /// <param name="capacity">maximal expansion</param>
-    public EnumerableIndexable(IEnumerable<T> enumerable, int maxCapacity)
+    public struct Unit : IEquatable<Unit>
     {
-      Contract.Requires(enumerable != null);
-      Contract.Requires(maxCapacity >= 0);
+        public static readonly Unit Value; // Thread-safe
 
-      list = new List<T>(maxCapacity);
-      enumerator = enumerable.GetEnumerator();
-    }
+        #region IEquatable<Unit> Members
 
-    /// <summary>
-    /// Does enumerate the full enumerable and computes the final list
-    /// </summary>
-    /// <param name="enumerable"></param>
-    public EnumerableIndexable(IEnumerable<T> enumerable)
-    {
-      Contract.Requires(enumerable != null);
-
-      this.list = enumerable.ToList();
-      enumerator = null;
-    }
-
-
-    public T this[int index]
-    {
-      get
-      {
-      tryAgain:
-        if (index >= list.Count)
+        public bool Equals(Unit other)
         {
-          if (enumerator != null && index < list.Capacity)
-          {
-            if (enumerator.MoveNext())
-            {
-              list.Add(enumerator.Current);
-              goto tryAgain;
-            }
-            else
-            {
-              enumerator = null;
-            }
-          }
-          // done enumerating
-          throw new IndexOutOfRangeException();
-        }
-        return list[index];
-      }
-    }
-
-    public int Count
-    {
-      get
-      {
-        ForceEnumeration();
-        return this.list.Count;
-      }
-    }
-
-    private void ForceEnumeration()
-    {
-      while (enumerator != null && list.Count < list.Capacity)
-      {
-        if (enumerator.MoveNext())
-        {
-          list.Add(enumerator.Current);
-        }
-        else
-        {
-          enumerator = null;
-        }
-      }
-    }
-
-    [System.Runtime.Serialization.OnSerializing]
-    private void OnSerializing(System.Runtime.Serialization.StreamingContext context)
-    {
-      this.ForceEnumeration();
-    }
-
-    #region IEnumerable<T> Members
-
-    public IEnumerator<T> GetEnumerator()
-    {
-      for (int i = 0; i < this.Count; i++)
-      {
-        yield return this[i];
-      }
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      return this.GetEnumerator();
-    }
-
-    #endregion
-  }
-
-  [Serializable]
-  public struct ListIndexable<T> : IIndexable<T>, IEnumerable<T>
-  {
-    List<T> list;
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(list != null);
-    }
-
-    public ListIndexable(List<T> list) {
-      Contract.Requires(list != null);
-      Contract.Ensures(Contract.ValueAtReturn(out this).Count == list.Count);
-
-      this.list = list;
-    }
-    public int Count
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() == list.Count);
-        return list.Count;
-      }
-    }
-    public T this[int index]
-    {
-      get
-      {
-        Contract.Assert(this.Count > 0, "help static checker");
-        return list[index];
-      }
-    }
-
-    #region IEnumerable<T> Members
-
-    public IEnumerator<T> GetEnumerator()
-    {
-      return this.list.GetEnumerator();
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      return this.GetEnumerator();
-    }
-
-    #endregion
-  }
-
-  public static class IndexableExtensions
-  {
-    public static IndexableEnumerable<T, IIndexable<T>> Enumerate<T>(this IIndexable<T> arg)
-    {
-      return new IndexableEnumerable<T, IIndexable<T>>(arg);
-    }
-
-    public static EnumerableIndexable<T> AsIndexable<T>(this IEnumerable<T> arg, int capacity)
-    {
-      return new EnumerableIndexable<T>(arg, capacity);
-    }
-
-    public static EnumerableIndexable<T> AsIndexable<T>(this IEnumerable<T> arg)
-    {
-      return new EnumerableIndexable<T>(arg);
-    }
-
-    public static EnumerableIndexable<T> AsIndexable<From,T>(this IEnumerable<From> arg, Func<From, T> convert)
-    {
-      return new EnumerableIndexable<T>(arg.Select(convert));
-    }
-
-    public static ListIndexable<T> AsIndexable<T>(this List<T> list)
-    {
-      return new ListIndexable<T>(list);
-    }
-
-    public static TailIndexable<T> Tail<T>(this IIndexable<T> underlying)
-    {
-      return new TailIndexable<T>(underlying);
-    }
-
-    public static ArrayIndexable<T> AsIndexable<T>(this T[] array)
-    {
-      return new ArrayIndexable<T>(array);
-    }
-  }
-
-  /// <summary>
-  /// Optional struct that works for all T, not just value types.
-  /// </summary>
-  [Serializable]
-  public struct Optional<T>
-  {
-    public readonly bool IsValid;
-    T value;
-    public Optional(T value) {
-      this.value = value;
-      IsValid = true;
-    }
-    public T Value { get { return this.value; } }
-
-    public static implicit operator Optional<T>(T value) { return new Optional<T>(value); }
-
-  }
-
-  public interface IVisibilityCheck<Member>
-  {
-    bool IsAsVisibleAs(Member member);
-    bool IsVisibleFrom(Member member);
-    bool RootImpliesParameterOrResultOrStatic { get; }
-    bool IsTopOfStack(int localStackDepth);
-    bool IsStackTemp { get; }
-  }
-
-  /// <summary>
-  /// Filter for access paths
-  /// </summary>
-  public class AccessPathFilter<Member, Type>
-  {
-    enum MemberFilter
-    {
-      NO_FILTER,
-      FROM_PRECONDITION,
-      FROM_POSTCONDITION,
-      FROM_INSIDE_METHOD,
-      FROM_INSIDE_METHOD_OR_CALLED_POST,
-    }
-
-    [Flags]
-    private enum Flags
-    {
-      AllowLocals = 0x01,
-      RequireParameter = 0x02,
-      AvoidCompilerGenerated = 0x04
-    }
-
-    private readonly Member member;
-    private readonly MemberFilter memberFilter;
-    private readonly Flags flags;
-    private Type returnType;
-    public int LocalStackDepth { get; private set; }
-
-    public static AccessPathFilter<Member, Type> NoFilter = new AccessPathFilter<Member, Type>(); // Thread-safe
-    public static AccessPathFilter<Member, Type> FromPrecondition(Member member) 
-    {
-      Contract.Ensures(Contract.Result<AccessPathFilter<Member, Type>>() != null);
-  
-      return new AccessPathFilter<Member, Type>(member, MemberFilter.FROM_PRECONDITION);     
-    }    
-    public static AccessPathFilter<Member, Type> FromPostcondition(Member member, Type returnType) 
-    {
-      Contract.Ensures(Contract.Result<AccessPathFilter<Member, Type>>() != null);
-      
-      return new AccessPathFilter<Member, Type>(member, MemberFilter.FROM_POSTCONDITION, returnType) { LocalStackDepth = 1 };
-    }
-    public static AccessPathFilter<Member, Type> IsVisibleFrom(Member member) 
-    {
-      Contract.Ensures(Contract.Result<AccessPathFilter<Member, Type>>() != null);
-      
-      return new AccessPathFilter<Member, Type>(member, MemberFilter.FROM_INSIDE_METHOD); 
-    }
-    public static AccessPathFilter<Member, Type> IsVisibleFromMethodOrCalledPost(Member member, Type returnType, int localStackDepth) 
-    {
-      Contract.Ensures(Contract.Result<AccessPathFilter<Member, Type>>() != null);
-      
-      return new AccessPathFilter<Member, Type>(member, MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST, returnType) { LocalStackDepth = localStackDepth }; 
-    }
-
-    private AccessPathFilter(Member member, MemberFilter memberFilter)
-    {
-      this.member = member;
-      this.memberFilter = memberFilter;
-    }
-    private AccessPathFilter(Member member, MemberFilter memberFilter, Type returnType) : this(member, memberFilter)
-    {
-      // We do not want compiler generated in postconditions
-      if(memberFilter.HasFlag(MemberFilter.FROM_POSTCONDITION)) 
-      {
-        this.flags |= Flags.AvoidCompilerGenerated;
-      }
-
-      this.returnType = returnType;
-    }
-    private AccessPathFilter()
-    {
-      flags |= Flags.AllowLocals;
-      memberFilter = MemberFilter.NO_FILTER;
-    }
-
-    public bool FilterOutPathElement<P>(P element) where P:IVisibilityCheck<Member>
-    {
-      switch (memberFilter)
-      {
-        case MemberFilter.FROM_INSIDE_METHOD:
-          return element.IsStackTemp || !element.IsVisibleFrom(this.member);
-        case MemberFilter.FROM_PRECONDITION:
-          return element.IsStackTemp || !element.IsAsVisibleAs(this.member);
-        case MemberFilter.FROM_POSTCONDITION:
-          return !element.RootImpliesParameterOrResultOrStatic || !element.IsVisibleFrom(this.member);
-        case MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST:
-          return element.IsStackTemp && !element.IsTopOfStack(this.LocalStackDepth) || !element.IsVisibleFrom(this.member);
-        case MemberFilter.NO_FILTER:
-        default:
-          return element.IsStackTemp; // ignore stack temporaries (s0, s1, ...)
-      }
-    }
-
-    public bool AllowLocal
-    {
-      get
-      {
-        return (this.memberFilter == MemberFilter.NO_FILTER && ((flags & Flags.AllowLocals) != 0))
-          || this.memberFilter == MemberFilter.FROM_INSIDE_METHOD
-          || this.memberFilter == MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST;
-      }
-    }
-
-    public bool AvoidCompilerGenerated { get { return (this.flags & Flags.AvoidCompilerGenerated) != 0; } }
-
-    public bool HasVisibilityMember { get { return this.memberFilter != MemberFilter.NO_FILTER; } }
-
-    public bool AllowReturnValue
-    {
-      get
-      {
-        switch (this.memberFilter)
-        {
-          case MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST:
-          case MemberFilter.FROM_POSTCONDITION:
             return true;
-          default:
-            return false;
         }
-      }
+
+        #endregion
     }
+
+
+
     /// <summary>
-    /// Returns the underlying member used to determine visibility.
+    /// An abstraction over sequences
     /// </summary>
-    public Member VisibilityMember { get { return this.member; } }
-
-    public Type ReturnValueType
+    public partial interface IIndexable<T>
     {
-      get
-      {
-        Contract.Requires(this.AllowReturnValue);
-
-        return this.returnType;
-      }
+        int Count { get; }
+        T this[int index] { get; }
+    }
+    #region IIndexable contract binding
+    [ContractClass(typeof(IIndexableContract<>))]
+    public partial interface IIndexable<T>
+    {
     }
 
-    public bool AllowCompilerLocal
+    [ContractClassFor(typeof(IIndexable<>))]
+    internal abstract class IIndexableContract<T> : IIndexable<T>
     {
-      get
-      {
-        return this.memberFilter == MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST;
-      }
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                throw new NotImplementedException();
+            }
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                Contract.Requires(index >= 0);
+                Contract.Requires(index < this.Count);
+
+                throw new NotImplementedException();
+            }
+        }
     }
-  }
+    #endregion
+
+    public struct IndexableEnumerable<T, IndexT> : IEnumerable<T>
+      where IndexT : IIndexable<T>
+    {
+        private IndexT indexable;
+
+        public IndexableEnumerable(IndexT indexable)
+        {
+            Contract.Requires(indexable != null);
+            this.indexable = indexable;
+        }
+
+        public struct Enumerator : IEnumerator<T>
+        {
+            private IndexT indexable;
+            private int position;
+
+            public Enumerator(IndexT indexable)
+            {
+                this.indexable = indexable;
+                position = -1;
+            }
+
+            public T Current
+            {
+                get
+                {
+                    if (position >= 0 && position < indexable.Count)
+                    {
+                        return this.indexable[position];
+                    }
+                    throw new InvalidOperationException();
+                }
+            }
+            object System.Collections.IEnumerator.Current
+            {
+                get
+                {
+                    return this.Current;
+                }
+            }
+
+            public bool MoveNext()
+            {
+                position++;
+                return position < indexable.Count;
+            }
+
+            public void Reset()
+            {
+                position = -1;
+            }
+
+            void IDisposable.Dispose()
+            {
+            }
+        }
+        public Enumerator GetEnumerator() { return new Enumerator(indexable); }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+
+    [Serializable]
+    public struct EmptyIndexable<T> : IIndexable<T>, IEnumerable<T>
+    {
+        #region IIndexable<T> Members
+
+        public int Count
+        {
+            get { return 0; }
+        }
+
+        public T this[int index]
+        {
+            get { throw new IndexOutOfRangeException(); }
+        }
+
+        #endregion
+
+        public static readonly EmptyIndexable<T> Empty = new EmptyIndexable<T>(); // Thread-safe
+
+        public IEnumerator<T> GetEnumerator() { yield break; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { yield break; }
+    }
+
+    public struct ThreeValued
+    {
+        private int value; // 0 undetermined, 1 false, 2 true
+
+        public ThreeValued(bool truth)
+        {
+            if (truth) value = 2;
+            else value = 1;
+        }
+
+        public bool IsTrue { get { return value == 2; } }
+        public bool IsFalse { get { return value == 1; } }
+        public bool IsDetermined { get { return value != 0; } }
+        public bool Truth { get { if (IsTrue) return true; if (IsFalse) return false; throw new InvalidOperationException(); } }
+    }
+
+    [Serializable]
+    public struct UnitIndexable : IIndexable<Unit>, IEnumerable<Unit>
+    {
+        private int count;
+
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(count >= 0);
+        }
+
+        public UnitIndexable(int count)
+        {
+            Contract.Requires(count >= 0);
+            this.count = count;
+        }
+
+        #region IIndexable<Unit> Members
+
+        public int Count
+        {
+            get { return count; }
+        }
+
+        public Unit this[int index]
+        {
+            get { return Unit.Value; }
+        }
+
+        #endregion
+
+        #region IEnumerable<Unit> Members
+
+        public IEnumerator<Unit> GetEnumerator()
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return Unit.Value;
+            }
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return Unit.Value;
+            }
+        }
+
+        #endregion
+    }
+
+    [Serializable]
+    public struct TailIndexable<T> : IIndexable<T>, IEnumerable<T>
+    {
+        private IIndexable<T> underlying;
+
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(underlying != null);
+        }
+
+        public TailIndexable(IIndexable<T> underlying)
+        {
+            Contract.Requires(underlying != null);
+            this.underlying = underlying;
+        }
+
+        #region IIndexable<T> Members
+
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() == 0 || Contract.Result<int>() == underlying.Count - 1);
+
+                var c = underlying.Count;
+                if (c > 0) return c - 1;
+                return 0;
+            }
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                Contract.Assert(this.Count > 0, "helping the static checker");
+                return underlying[index + 1];
+            }
+        }
+
+        #endregion
+
+        #region IEnumerable<T> Members
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (int i = 0; i < this.Count; i++)
+            {
+                yield return this[i];
+            }
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        #endregion
+    }
+
+    [Serializable]
+    public struct ArrayIndexable<T> : IIndexable<T>, IEnumerable<T>
+    {
+        private T[]/*?*/ array;
+
+        public ArrayIndexable(T[]/*?*/ array)
+        {
+            Contract.Ensures(array == null && Contract.ValueAtReturn(out this).Count == 0 ||
+                             Contract.ValueAtReturn(out this).Count == array.Length);
+            this.array = array;
+        }
+
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() == 0 || array != null && Contract.Result<int>() == array.Length);
+                return (array == null) ? 0 : array.Length;
+            }
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                Contract.Assert(this.Count > 0, "helping the static checker");
+                return array[index];
+            }
+        }
+
+        #region IEnumerable<T> Members
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (int i = 0; i < this.Count; i++)
+            {
+                yield return array[i];
+            }
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        #endregion
+    }
+
+    [Serializable]
+    public struct EnumerableIndexable<T> : IIndexable<T>, IEnumerable<T>
+    {
+        private List<T> list;
+        [NonSerialized]
+        private IEnumerator<T> enumerator;
+
+        /// <summary>
+        /// Produce an IIndexable from the given IEnumerable. The IEnumerable is expanded on
+        /// demand up to capacity elements. The count of the IIndexable is the minimum of either the
+        /// actual number of elements in the enumeration, or the capacity specified.
+        /// </summary>
+        /// <param name="capacity">maximal expansion</param>
+        public EnumerableIndexable(IEnumerable<T> enumerable, int maxCapacity)
+        {
+            Contract.Requires(enumerable != null);
+            Contract.Requires(maxCapacity >= 0);
+
+            list = new List<T>(maxCapacity);
+            enumerator = enumerable.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Does enumerate the full enumerable and computes the final list
+        /// </summary>
+        /// <param name="enumerable"></param>
+        public EnumerableIndexable(IEnumerable<T> enumerable)
+        {
+            Contract.Requires(enumerable != null);
+
+            list = enumerable.ToList();
+            enumerator = null;
+        }
+
+
+        public T this[int index]
+        {
+            get
+            {
+            tryAgain:
+                if (index >= list.Count)
+                {
+                    if (enumerator != null && index < list.Capacity)
+                    {
+                        if (enumerator.MoveNext())
+                        {
+                            list.Add(enumerator.Current);
+                            goto tryAgain;
+                        }
+                        else
+                        {
+                            enumerator = null;
+                        }
+                    }
+                    // done enumerating
+                    throw new IndexOutOfRangeException();
+                }
+                return list[index];
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                ForceEnumeration();
+                return list.Count;
+            }
+        }
+
+        private void ForceEnumeration()
+        {
+            while (enumerator != null && list.Count < list.Capacity)
+            {
+                if (enumerator.MoveNext())
+                {
+                    list.Add(enumerator.Current);
+                }
+                else
+                {
+                    enumerator = null;
+                }
+            }
+        }
+
+        [System.Runtime.Serialization.OnSerializing]
+        private void OnSerializing(System.Runtime.Serialization.StreamingContext context)
+        {
+            this.ForceEnumeration();
+        }
+
+        #region IEnumerable<T> Members
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (int i = 0; i < this.Count; i++)
+            {
+                yield return this[i];
+            }
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        #endregion
+    }
+
+    [Serializable]
+    public struct ListIndexable<T> : IIndexable<T>, IEnumerable<T>
+    {
+        private List<T> list;
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(list != null);
+        }
+
+        public ListIndexable(List<T> list)
+        {
+            Contract.Requires(list != null);
+            Contract.Ensures(Contract.ValueAtReturn(out this).Count == list.Count);
+
+            this.list = list;
+        }
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() == list.Count);
+                return list.Count;
+            }
+        }
+        public T this[int index]
+        {
+            get
+            {
+                Contract.Assert(this.Count > 0, "help static checker");
+                return list[index];
+            }
+        }
+
+        #region IEnumerable<T> Members
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return list.GetEnumerator();
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        #endregion
+    }
+
+    public static class IndexableExtensions
+    {
+        public static IndexableEnumerable<T, IIndexable<T>> Enumerate<T>(this IIndexable<T> arg)
+        {
+            return new IndexableEnumerable<T, IIndexable<T>>(arg);
+        }
+
+        public static EnumerableIndexable<T> AsIndexable<T>(this IEnumerable<T> arg, int capacity)
+        {
+            return new EnumerableIndexable<T>(arg, capacity);
+        }
+
+        public static EnumerableIndexable<T> AsIndexable<T>(this IEnumerable<T> arg)
+        {
+            return new EnumerableIndexable<T>(arg);
+        }
+
+        public static EnumerableIndexable<T> AsIndexable<From, T>(this IEnumerable<From> arg, Func<From, T> convert)
+        {
+            return new EnumerableIndexable<T>(arg.Select(convert));
+        }
+
+        public static ListIndexable<T> AsIndexable<T>(this List<T> list)
+        {
+            return new ListIndexable<T>(list);
+        }
+
+        public static TailIndexable<T> Tail<T>(this IIndexable<T> underlying)
+        {
+            return new TailIndexable<T>(underlying);
+        }
+
+        public static ArrayIndexable<T> AsIndexable<T>(this T[] array)
+        {
+            return new ArrayIndexable<T>(array);
+        }
+    }
+
+    /// <summary>
+    /// Optional struct that works for all T, not just value types.
+    /// </summary>
+    [Serializable]
+    public struct Optional<T>
+    {
+        public readonly bool IsValid;
+        private T value;
+        public Optional(T value)
+        {
+            this.value = value;
+            IsValid = true;
+        }
+        public T Value { get { return value; } }
+
+        public static implicit operator Optional<T>(T value) { return new Optional<T>(value); }
+    }
+
+    public interface IVisibilityCheck<Member>
+    {
+        bool IsAsVisibleAs(Member member);
+        bool IsVisibleFrom(Member member);
+        bool RootImpliesParameterOrResultOrStatic { get; }
+        bool IsTopOfStack(int localStackDepth);
+        bool IsStackTemp { get; }
+    }
+
+    /// <summary>
+    /// Filter for access paths
+    /// </summary>
+    public class AccessPathFilter<Member, Type>
+    {
+        private enum MemberFilter
+        {
+            NO_FILTER,
+            FROM_PRECONDITION,
+            FROM_POSTCONDITION,
+            FROM_INSIDE_METHOD,
+            FROM_INSIDE_METHOD_OR_CALLED_POST,
+        }
+
+        [Flags]
+        private enum Flags
+        {
+            AllowLocals = 0x01,
+            RequireParameter = 0x02,
+            AvoidCompilerGenerated = 0x04
+        }
+
+        private readonly Member member;
+        private readonly MemberFilter memberFilter;
+        private readonly Flags flags;
+        private Type returnType;
+        public int LocalStackDepth { get; private set; }
+
+        public static AccessPathFilter<Member, Type> NoFilter = new AccessPathFilter<Member, Type>(); // Thread-safe
+        public static AccessPathFilter<Member, Type> FromPrecondition(Member member)
+        {
+            Contract.Ensures(Contract.Result<AccessPathFilter<Member, Type>>() != null);
+
+            return new AccessPathFilter<Member, Type>(member, MemberFilter.FROM_PRECONDITION);
+        }
+        public static AccessPathFilter<Member, Type> FromPostcondition(Member member, Type returnType)
+        {
+            Contract.Ensures(Contract.Result<AccessPathFilter<Member, Type>>() != null);
+
+            return new AccessPathFilter<Member, Type>(member, MemberFilter.FROM_POSTCONDITION, returnType) { LocalStackDepth = 1 };
+        }
+        public static AccessPathFilter<Member, Type> IsVisibleFrom(Member member)
+        {
+            Contract.Ensures(Contract.Result<AccessPathFilter<Member, Type>>() != null);
+
+            return new AccessPathFilter<Member, Type>(member, MemberFilter.FROM_INSIDE_METHOD);
+        }
+        public static AccessPathFilter<Member, Type> IsVisibleFromMethodOrCalledPost(Member member, Type returnType, int localStackDepth)
+        {
+            Contract.Ensures(Contract.Result<AccessPathFilter<Member, Type>>() != null);
+
+            return new AccessPathFilter<Member, Type>(member, MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST, returnType) { LocalStackDepth = localStackDepth };
+        }
+
+        private AccessPathFilter(Member member, MemberFilter memberFilter)
+        {
+            this.member = member;
+            this.memberFilter = memberFilter;
+        }
+        private AccessPathFilter(Member member, MemberFilter memberFilter, Type returnType) : this(member, memberFilter)
+        {
+            // We do not want compiler generated in postconditions
+            if (memberFilter.HasFlag(MemberFilter.FROM_POSTCONDITION))
+            {
+                flags |= Flags.AvoidCompilerGenerated;
+            }
+
+            this.returnType = returnType;
+        }
+        private AccessPathFilter()
+        {
+            flags |= Flags.AllowLocals;
+            memberFilter = MemberFilter.NO_FILTER;
+        }
+
+        public bool FilterOutPathElement<P>(P element) where P : IVisibilityCheck<Member>
+        {
+            switch (memberFilter)
+            {
+                case MemberFilter.FROM_INSIDE_METHOD:
+                    return element.IsStackTemp || !element.IsVisibleFrom(member);
+                case MemberFilter.FROM_PRECONDITION:
+                    return element.IsStackTemp || !element.IsAsVisibleAs(member);
+                case MemberFilter.FROM_POSTCONDITION:
+                    return !element.RootImpliesParameterOrResultOrStatic || !element.IsVisibleFrom(member);
+                case MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST:
+                    return element.IsStackTemp && !element.IsTopOfStack(this.LocalStackDepth) || !element.IsVisibleFrom(member);
+                case MemberFilter.NO_FILTER:
+                default:
+                    return element.IsStackTemp; // ignore stack temporaries (s0, s1, ...)
+            }
+        }
+
+        public bool AllowLocal
+        {
+            get
+            {
+                return (memberFilter == MemberFilter.NO_FILTER && ((flags & Flags.AllowLocals) != 0))
+                  || memberFilter == MemberFilter.FROM_INSIDE_METHOD
+                  || memberFilter == MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST;
+            }
+        }
+
+        public bool AvoidCompilerGenerated { get { return (flags & Flags.AvoidCompilerGenerated) != 0; } }
+
+        public bool HasVisibilityMember { get { return memberFilter != MemberFilter.NO_FILTER; } }
+
+        public bool AllowReturnValue
+        {
+            get
+            {
+                switch (memberFilter)
+                {
+                    case MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST:
+                    case MemberFilter.FROM_POSTCONDITION:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+        /// <summary>
+        /// Returns the underlying member used to determine visibility.
+        /// </summary>
+        public Member VisibilityMember { get { return member; } }
+
+        public Type ReturnValueType
+        {
+            get
+            {
+                Contract.Requires(this.AllowReturnValue);
+
+                return returnType;
+            }
+        }
+
+        public bool AllowCompilerLocal
+        {
+            get
+            {
+                return memberFilter == MemberFilter.FROM_INSIDE_METHOD_OR_CALLED_POST;
+            }
+        }
+    }
 }

--- a/Microsoft.Research/DataStructures/BijectionDictionary.cs
+++ b/Microsoft.Research/DataStructures/BijectionDictionary.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The implementation for a bijection map
 
@@ -22,373 +11,373 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Collections.Generic
 {
-  [ContractVerification(true)]
-  public sealed class BijectiveMap<TKey, TValue>
-    : IDictionary<TKey, TValue>
-  {
-    #region Object Invariant
-    [Pure]
-    public bool IsConsistent()
+    [ContractVerification(true)]
+    public sealed class BijectiveMap<TKey, TValue>
+      : IDictionary<TKey, TValue>
     {
-      if (this.directMap.Count != this.inverseMap.Count)
-        return false;
-
-      foreach (var key in this.DirectMap.Keys)
-      {
-        if (!this.InverseMap.ContainsKey(this.DirectMap[key]))
-          return false;
-      }
-
-      foreach (var key in this.InverseMap.Keys)
-      {
-        if (!this.DirectMap.ContainsKey(this.InverseMap[key]))
-          return false;
-      }
-
-      return true;
-    }
-
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.inverseMap != null);
-      Contract.Invariant(this.directMap != null);
-      //Contract.Invariant(this.IsConsistent());
-    }
-    #endregion
-
-    #region Private state
-    private Dictionary<TKey, TValue> directMap;                // The direct map
-    private Dictionary<TValue, TKey> inverseMap;               // The inverse map
-    #endregion
-
-    #region Constructors
-    /// <summary>
-    /// Construct a Bijective Map of default size
-    /// </summary>
-    public BijectiveMap()
-    {
-      this.directMap = new Dictionary<TKey, TValue>();
-      this.inverseMap = new Dictionary<TValue, TKey>();
-    }
-
-    /// <summary>
-    /// Construct a Bijective Map of size <code>n</code>
-    /// </summary>
-    public BijectiveMap(int size)
-    {
-      Contract.Requires(size >= 0);
-
-      this.directMap = new Dictionary<TKey, TValue>(size);
-      this.inverseMap = new Dictionary<TValue, TKey>(size);
-    }
-
-    /// <summary>
-    /// Copy constructor
-    /// </summary>
-    public BijectiveMap(BijectiveMap<TKey, TValue> toClone)
-    {
-      Contract.Requires(toClone != null);
-
-      this.directMap = new Dictionary<TKey, TValue>(toClone.DirectMap);
-      this.inverseMap = new Dictionary<TValue, TKey>(toClone.InverseMap);
-    }
-    #endregion
-
-    #region IBijectiveMap<TKey,TValue> Members
-
-    /// <returns>The key associated with <code>value</code></returns>
-    public TKey KeyForValue(TValue value)
-    {
-      return inverseMap[value];
-    }
-
-    /// <returns>
-    /// <code>true</code> iff the co-domain of the map contains the value <code>value</code>
-    /// </returns>
-    public bool ContainsValue(TValue value)
-    {
-      return this.inverseMap.ContainsKey(value);
-    }
-
-    /// <summary>
-    /// Get the direct map
-    /// </summary>
-    public Dictionary<TKey, TValue> DirectMap
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Dictionary<TKey, TValue>>() != null);
-        
-        return this.directMap;
-      }
-    }
-
-    /// <summary>
-    /// Get the inverse map
-    /// </summary>
-    public Dictionary<TValue, TKey> InverseMap
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Dictionary<TValue, TKey>>() != null);
-        
-        return this.inverseMap;
-      }
-    }
-
-    public BijectiveMap<TKey, TValue> Duplicate()
-    {
-      var result = new BijectiveMap<TKey, TValue>();
-
-      foreach (var pair in this.directMap)
-      {
-        result[pair.Key] = pair.Value;
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region IDictionary<TKey,TValue> Members
-
-    /// <summary>
-    /// Add the pair <code>(key, value)</code> to the map
-    /// </summary>
-    public void Add(TKey key, TValue value)
-    {
-      this.directMap.Add(key, value);
-      if (!inverseMap.ContainsKey(value)) 
-        this.inverseMap.Add(value, key);
-    }
-
-    /// <returns><code>true</code> iff <code>key</code> is in the map</returns>
-    public bool ContainsKey(TKey key)
-    {
-      return this.directMap.ContainsKey(key);
-    }
-
-    /// <summary>
-    /// Gets the keys in this map
-    /// </summary>
-    public ICollection<TKey> Keys
-    {
-      get
-      {
-        return this.directMap.Keys;
-      }
-    }
-
-    /// <summary>
-    /// Remove the entry corresponding to <code>key</code>
-    /// </summary>
-    /// <returns>true if the element is successfully removed; otherwise, false. This method also returns false if key was not found in the IDictionary</returns> 
-    // [SuppressMessage("Microsoft.Contracts", "Ensures-31-220")] // It seems we can prove it now
-    public bool Remove(TKey key)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || this.Count == Contract.OldValue(this.Count) - 1);
-
-      TValue valForKey = this.directMap[key];
-      bool bDirect = this.directMap.Remove(key);
-      bool bInverse = inverseMap[valForKey].Equals(key) ? this.inverseMap.Remove(valForKey) : false;
-
-      if (bInverse)
-      {
-        foreach (TKey otherKey in this.directMap.Keys)
+        #region Object Invariant
+        [Pure]
+        public bool IsConsistent()
         {
-          if (directMap[otherKey].Equals(valForKey))
-          {
-            inverseMap[valForKey] = otherKey;
-            break;
-          }
-        }
-      }
+            if (directMap.Count != inverseMap.Count)
+                return false;
 
-      return bDirect;
-    }
+            foreach (var key in this.DirectMap.Keys)
+            {
+                if (!this.InverseMap.ContainsKey(this.DirectMap[key]))
+                    return false;
+            }
 
-    /// <summary>
-    /// Tries to get a value corresponding to <code>key</code>. If found, the output is in value;
-    /// </summary>
-    /// <returns>true if the object that implements IDictionary contains an element with the specified key; otherwise, false. </returns>
-    [SuppressMessage("Microsoft.Contracts", "Ensures-Contract.Result<bool>() == @this.ContainsKey(key)")]
-    public bool TryGetValue(TKey key, out TValue value)
-    {
-      return this.directMap.TryGetValue(key, out value);
-    }
+            foreach (var key in this.InverseMap.Keys)
+            {
+                if (!this.DirectMap.ContainsKey(this.InverseMap[key]))
+                    return false;
+            }
 
-    /// <summary>
-    /// Get the values in this map
-    /// </summary>
-    public ICollection<TValue> Values
-    {
-      get
-      {
-        return this.directMap.Values;
-      }
-    }
-
-    /// <summary>
-    /// Get/Sets values in this map
-    /// </summary>
-    /// <param name="key"></param>
-    /// <returns></returns>
-    public TValue this[TKey key]
-    {
-      get
-      {
-        return this.directMap[key];
-      }
-      set
-      {
-        TValue oldVal;
-        if (this.directMap.TryGetValue(key, out oldVal))
-        {
-          this.inverseMap.Remove(oldVal);
-        }
-        
-        TKey oldKey;
-        if (this.inverseMap.TryGetValue(value, out oldKey))
-        {
-          this.directMap.Remove(oldKey);
+            return true;
         }
 
-        this.directMap[key] = value;
-        this.inverseMap[value] = key;
-      }
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(inverseMap != null);
+            Contract.Invariant(directMap != null);
+            //Contract.Invariant(this.IsConsistent());
+        }
+        #endregion
+
+        #region Private state
+        private Dictionary<TKey, TValue> directMap;                // The direct map
+        private Dictionary<TValue, TKey> inverseMap;               // The inverse map
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Construct a Bijective Map of default size
+        /// </summary>
+        public BijectiveMap()
+        {
+            directMap = new Dictionary<TKey, TValue>();
+            inverseMap = new Dictionary<TValue, TKey>();
+        }
+
+        /// <summary>
+        /// Construct a Bijective Map of size <code>n</code>
+        /// </summary>
+        public BijectiveMap(int size)
+        {
+            Contract.Requires(size >= 0);
+
+            directMap = new Dictionary<TKey, TValue>(size);
+            inverseMap = new Dictionary<TValue, TKey>(size);
+        }
+
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        public BijectiveMap(BijectiveMap<TKey, TValue> toClone)
+        {
+            Contract.Requires(toClone != null);
+
+            directMap = new Dictionary<TKey, TValue>(toClone.DirectMap);
+            inverseMap = new Dictionary<TValue, TKey>(toClone.InverseMap);
+        }
+        #endregion
+
+        #region IBijectiveMap<TKey,TValue> Members
+
+        /// <returns>The key associated with <code>value</code></returns>
+        public TKey KeyForValue(TValue value)
+        {
+            return inverseMap[value];
+        }
+
+        /// <returns>
+        /// <code>true</code> iff the co-domain of the map contains the value <code>value</code>
+        /// </returns>
+        public bool ContainsValue(TValue value)
+        {
+            return inverseMap.ContainsKey(value);
+        }
+
+        /// <summary>
+        /// Get the direct map
+        /// </summary>
+        public Dictionary<TKey, TValue> DirectMap
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Dictionary<TKey, TValue>>() != null);
+
+                return directMap;
+            }
+        }
+
+        /// <summary>
+        /// Get the inverse map
+        /// </summary>
+        public Dictionary<TValue, TKey> InverseMap
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Dictionary<TValue, TKey>>() != null);
+
+                return inverseMap;
+            }
+        }
+
+        public BijectiveMap<TKey, TValue> Duplicate()
+        {
+            var result = new BijectiveMap<TKey, TValue>();
+
+            foreach (var pair in directMap)
+            {
+                result[pair.Key] = pair.Value;
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region IDictionary<TKey,TValue> Members
+
+        /// <summary>
+        /// Add the pair <code>(key, value)</code> to the map
+        /// </summary>
+        public void Add(TKey key, TValue value)
+        {
+            directMap.Add(key, value);
+            if (!inverseMap.ContainsKey(value))
+                inverseMap.Add(value, key);
+        }
+
+        /// <returns><code>true</code> iff <code>key</code> is in the map</returns>
+        public bool ContainsKey(TKey key)
+        {
+            return directMap.ContainsKey(key);
+        }
+
+        /// <summary>
+        /// Gets the keys in this map
+        /// </summary>
+        public ICollection<TKey> Keys
+        {
+            get
+            {
+                return directMap.Keys;
+            }
+        }
+
+        /// <summary>
+        /// Remove the entry corresponding to <code>key</code>
+        /// </summary>
+        /// <returns>true if the element is successfully removed; otherwise, false. This method also returns false if key was not found in the IDictionary</returns> 
+        // [SuppressMessage("Microsoft.Contracts", "Ensures-31-220")] // It seems we can prove it now
+        public bool Remove(TKey key)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || this.Count == Contract.OldValue(this.Count) - 1);
+
+            TValue valForKey = directMap[key];
+            bool bDirect = directMap.Remove(key);
+            bool bInverse = inverseMap[valForKey].Equals(key) ? inverseMap.Remove(valForKey) : false;
+
+            if (bInverse)
+            {
+                foreach (TKey otherKey in directMap.Keys)
+                {
+                    if (directMap[otherKey].Equals(valForKey))
+                    {
+                        inverseMap[valForKey] = otherKey;
+                        break;
+                    }
+                }
+            }
+
+            return bDirect;
+        }
+
+        /// <summary>
+        /// Tries to get a value corresponding to <code>key</code>. If found, the output is in value;
+        /// </summary>
+        /// <returns>true if the object that implements IDictionary contains an element with the specified key; otherwise, false. </returns>
+        [SuppressMessage("Microsoft.Contracts", "Ensures-Contract.Result<bool>() == @this.ContainsKey(key)")]
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return directMap.TryGetValue(key, out value);
+        }
+
+        /// <summary>
+        /// Get the values in this map
+        /// </summary>
+        public ICollection<TValue> Values
+        {
+            get
+            {
+                return directMap.Values;
+            }
+        }
+
+        /// <summary>
+        /// Get/Sets values in this map
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public TValue this[TKey key]
+        {
+            get
+            {
+                return directMap[key];
+            }
+            set
+            {
+                TValue oldVal;
+                if (directMap.TryGetValue(key, out oldVal))
+                {
+                    inverseMap.Remove(oldVal);
+                }
+
+                TKey oldKey;
+                if (inverseMap.TryGetValue(value, out oldKey))
+                {
+                    directMap.Remove(oldKey);
+                }
+
+                directMap[key] = value;
+                inverseMap[value] = key;
+            }
+        }
+
+        #endregion
+
+        #region ICollection<KeyValuePair<TKey,TValue>> Members
+
+        /// <summary>
+        /// Add the KeyValuePair <code>item</code>
+        /// </summary>
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            this[item.Key] = item.Value;
+        }
+
+        /// <summary>
+        /// Clear the map
+        /// </summary>
+        public void Clear()
+        {
+            directMap.Clear();
+            inverseMap.Clear();
+        }
+
+        /// <summary>
+        /// Does this map contain the <code>item</code>?
+        /// </summary>
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            TValue val;
+            if (directMap.TryGetValue(item.Key, out val) && val.Equals(item.Value))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Copy all the elements of this collection into the <code>array</code>, starting from <code>arrayIndex</code>
+        /// </summary>
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            int i = 0;
+            foreach (var pair in directMap)
+            {// F: we do not know that i ranges over the elements of the collection
+                Contract.Assume(arrayIndex + i < array.Length);
+                array[arrayIndex + (i++)] = pair;
+            }
+        }
+
+        /// <summary>
+        /// The number of items in the map
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                Contract.Ensures(Contract.Result<int>() == directMap.Count);
+
+                return directMap.Count;
+            }
+        }
+
+        /// <summary>
+        /// Always <code>false</code>
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Remove the <code>item</code> from the collection
+        /// </summary>
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            var b1 = directMap.Remove(item.Key);
+            var b2 = inverseMap.Remove(item.Value);
+
+            return b1 && b2;
+        }
+
+        #endregion
+
+        #region IEnumerable<KeyValuePair<TKey,TValue>> Members
+
+        [Pure]
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return directMap.GetEnumerator();
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        //^ [Pure]
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return directMap.GetEnumerator();
+        }
+
+        #endregion
+
+        #region Overridden
+        public override string ToString()
+        {
+            var consistent = IsConsistent() ? "Map Consistent" : "WARNING: Map inconsistent";
+            var direct = ToString<TKey, TValue>(directMap);
+            var indirect = ToString<TValue, TKey>(inverseMap);
+
+            return string.Format("{0}" + Environment.NewLine + "({1}, {2})", consistent, direct, indirect);
+        }
+
+        static private string ToString<A, B>(IDictionary<A, B> s)
+        {
+            Contract.Requires(s != null);
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            var result = new StringBuilder();
+
+            foreach (var key in s.Keys)
+            {
+                result.Append("(" + key.ToString() + "," + s[key] + ")");
+            }
+
+            return result.ToString();
+        }
+        #endregion
     }
-
-    #endregion
-
-    #region ICollection<KeyValuePair<TKey,TValue>> Members
-
-    /// <summary>
-    /// Add the KeyValuePair <code>item</code>
-    /// </summary>
-    public void Add(KeyValuePair<TKey, TValue> item)
-    {
-      this[item.Key] = item.Value;
-    }
-
-    /// <summary>
-    /// Clear the map
-    /// </summary>
-    public void Clear()
-    {
-      this.directMap.Clear();
-      this.inverseMap.Clear();
-    }
-
-    /// <summary>
-    /// Does this map contain the <code>item</code>?
-    /// </summary>
-    public bool Contains(KeyValuePair<TKey, TValue> item)
-    {
-      TValue val;
-      if (this.directMap.TryGetValue(item.Key, out val) && val.Equals(item.Value))
-      {
-        return true;
-      }
-      return false;
-    }
-
-    /// <summary>
-    /// Copy all the elements of this collection into the <code>array</code>, starting from <code>arrayIndex</code>
-    /// </summary>
-    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
-    {
-      int i = 0;
-      foreach (var pair in this.directMap)
-      {// F: we do not know that i ranges over the elements of the collection
-        Contract.Assume(arrayIndex + i < array.Length);
-        array[arrayIndex + (i++)] = pair;
-      }
-    }
-
-    /// <summary>
-    /// The number of items in the map
-    /// </summary>
-    public int Count
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        Contract.Ensures(Contract.Result<int>() == this.directMap.Count);
-
-        return this.directMap.Count;
-      }
-    }
-
-    /// <summary>
-    /// Always <code>false</code>
-    /// </summary>
-    public bool IsReadOnly
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// Remove the <code>item</code> from the collection
-    /// </summary>
-    public bool Remove(KeyValuePair<TKey, TValue> item)
-    {
-      var b1 = this.directMap.Remove(item.Key);
-      var b2 = this.inverseMap.Remove(item.Value);
-
-      return b1 && b2;
-    }
-
-    #endregion
-
-    #region IEnumerable<KeyValuePair<TKey,TValue>> Members
-
-    [Pure]
-    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
-    {
-      return this.directMap.GetEnumerator();
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    //^ [Pure]
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      return this.directMap.GetEnumerator();
-    }
-
-    #endregion
-
-    #region Overridden
-    public override string ToString()
-    {
-      var consistent = IsConsistent() ? "Map Consistent" : "WARNING: Map inconsistent";
-      var direct = ToString<TKey, TValue>(this.directMap);
-      var indirect = ToString<TValue, TKey>(this.inverseMap);
-
-      return string.Format("{0}" + Environment.NewLine + "({1}, {2})", consistent, direct, indirect);
-    }
-
-    static private string ToString<A, B>(IDictionary<A, B> s)
-    {
-      Contract.Requires(s != null);
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      var result = new StringBuilder();
-
-      foreach (var key in s.Keys)
-      {
-        result.Append("(" + key.ToString() + "," + s[key] + ")");
-      }
-
-      return result.ToString();
-    }
-    #endregion
-  }
 }

--- a/Microsoft.Research/DataStructures/ByteArray.cs
+++ b/Microsoft.Research/DataStructures/ByteArray.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections;
@@ -18,73 +7,73 @@ using System.Collections.Generic;
 
 namespace Microsoft.Research.DataStructures
 {
-  public class ByteArray : IEquatable<ByteArray>, IComparable<ByteArray>
-  {
-    private static readonly byte[] EmptyByteArray = new byte[0];
-
-    private readonly byte[] bytes;
-
-    public ByteArray(ByteArray byteArray) { this.bytes = byteArray == null ? null : byteArray.bytes; }
-    public ByteArray(byte[] bytes) { this.bytes = bytes; }
-    public ByteArray(string base64) { this.bytes = base64 == null ? null : Convert.FromBase64String(base64); }
-
-    public ByteArray(params object[] objects)
+    public class ByteArray : IEquatable<ByteArray>, IComparable<ByteArray>
     {
-      if (objects == null)
-        this.bytes = null;
-      else if (objects.Length == 0)
-        this.bytes = EmptyByteArray;
-      else
-      {
-        List<byte> b = new List<byte>();
-        foreach (var obj in objects)
+        private static readonly byte[] EmptyByteArray = new byte[0];
+
+        private readonly byte[] bytes;
+
+        public ByteArray(ByteArray byteArray) { bytes = byteArray == null ? null : byteArray.bytes; }
+        public ByteArray(byte[] bytes) { this.bytes = bytes; }
+        public ByteArray(string base64) { bytes = base64 == null ? null : Convert.FromBase64String(base64); }
+
+        public ByteArray(params object[] objects)
         {
-          if (obj == null)
-            continue;
-          byte[] toadd;
-          if (obj is ByteArray)
-            toadd = ((ByteArray)obj).Bytes;
-          else if (obj is byte[])
-            toadd = (byte[])obj;
-          else if (obj is bool)
-            toadd = BitConverter.GetBytes((bool)obj);
-          else if (obj is int)
-            toadd = BitConverter.GetBytes((int)obj);
-          else if (obj is long)
-            toadd = BitConverter.GetBytes((long)obj);
-          else
-            throw new NotImplementedException();
-          if (toadd != null)
-            b.AddRange(toadd);
+            if (objects == null)
+                bytes = null;
+            else if (objects.Length == 0)
+                bytes = EmptyByteArray;
+            else
+            {
+                List<byte> b = new List<byte>();
+                foreach (var obj in objects)
+                {
+                    if (obj == null)
+                        continue;
+                    byte[] toadd;
+                    if (obj is ByteArray)
+                        toadd = ((ByteArray)obj).Bytes;
+                    else if (obj is byte[])
+                        toadd = (byte[])obj;
+                    else if (obj is bool)
+                        toadd = BitConverter.GetBytes((bool)obj);
+                    else if (obj is int)
+                        toadd = BitConverter.GetBytes((int)obj);
+                    else if (obj is long)
+                        toadd = BitConverter.GetBytes((long)obj);
+                    else
+                        throw new NotImplementedException();
+                    if (toadd != null)
+                        b.AddRange(toadd);
+                }
+                bytes = b.ToArray();
+            }
         }
-        this.bytes = b.ToArray();
-      }
+
+        public byte[] Bytes { get { return bytes; } }
+
+        public override int GetHashCode() { return StructuralComparisons.StructuralEqualityComparer.GetHashCode(bytes); }
+
+        public override bool Equals(object obj) { return this.Equals(obj as ByteArray); }
+
+        public bool Equals(ByteArray other) { return other != null && StructuralComparisons.StructuralEqualityComparer.Equals(bytes, other.bytes); }
+
+        public int CompareTo(ByteArray other) { return other == null ? 1 : StructuralComparisons.StructuralComparer.Compare(bytes, other.bytes); }
+
+        public override string ToString() { return bytes == null ? String.Empty : Convert.ToBase64String(bytes); }
+        // alternative: BitConverter.ToString(this.bytes); }
+
+        public static implicit operator ByteArray(byte[] bytes)
+        {
+            return new ByteArray(bytes);
+        }
+
+        public string ToStringHex()
+        {
+            if (bytes == null)
+                return String.Empty;
+
+            return BitConverter.ToString(bytes);
+        }
     }
-
-    public byte[] Bytes { get { return this.bytes; } }
-
-    public override int GetHashCode() { return StructuralComparisons.StructuralEqualityComparer.GetHashCode(this.bytes); }
-
-    public override bool Equals(object obj) { return this.Equals(obj as ByteArray); }
-
-    public bool Equals(ByteArray other) { return other != null && StructuralComparisons.StructuralEqualityComparer.Equals(this.bytes, other.bytes); }
-
-    public int CompareTo(ByteArray other) { return other == null ? 1 : StructuralComparisons.StructuralComparer.Compare(this.bytes, other.bytes); }
-
-    public override string ToString() { return this.bytes == null ? String.Empty : Convert.ToBase64String(this.bytes); }
-    // alternative: BitConverter.ToString(this.bytes); }
-
-    public static implicit operator ByteArray(byte[] bytes)
-    {
-      return new ByteArray(bytes);
-    }
-
-    public string ToStringHex()
-    {
-      if (this.bytes == null)
-        return String.Empty;
-
-      return BitConverter.ToString(this.bytes);
-    }
-  }
 }

--- a/Microsoft.Research/DataStructures/CArray.cs
+++ b/Microsoft.Research/DataStructures/CArray.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -24,7 +13,7 @@ namespace Microsoft.Research.DataStructures
     /// </summary>
     public static class CArray
     {
-        static class Helper<T>
+        private static class Helper<T>
         {
             public static readonly T[] Empty = new T[0];
         }

--- a/Microsoft.Research/DataStructures/CDictionary.cs
+++ b/Microsoft.Research/DataStructures/CDictionary.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -450,7 +439,7 @@ namespace Microsoft.Research.DataStructures
         public CDictionary<TKey, TValue> Clone()
         {
             int count = this.count;
-            CDictionary<TKey, TValue> res = new CDictionary<TKey, TValue>(this.Count, this.comparer);
+            CDictionary<TKey, TValue> res = new CDictionary<TKey, TValue>(this.Count, comparer);
             Entry[] entries = this.entries;
             for (int i = 0; i < count; i++)
             {
@@ -476,7 +465,7 @@ namespace Microsoft.Research.DataStructures
 
         private void Initialize(int capacity)
         {
-            Contract.Requires(capacity>=0);
+            Contract.Requires(capacity >= 0);
             int size = HashHelpers.GetPrime(capacity);
             buckets = new int[size];
             for (int i = 0; i < buckets.Length; i++) buckets[i] = -1;
@@ -538,22 +527,22 @@ namespace Microsoft.Research.DataStructures
             int newCount = 0;
             for (int i = 0; i < count; i++)
             {
-                int hashCode = this.entries[i].hashCode;
+                int hashCode = entries[i].hashCode;
                 if (hashCode >= 0)
                 {
-                    newEntries[newCount].key = this.entries[i].key;
+                    newEntries[newCount].key = entries[i].key;
                     newEntries[newCount].hashCode = hashCode;
                     int bucket = hashCode % newSize;
-                    newEntries[newCount].value = this.entries[i].value;
+                    newEntries[newCount].value = entries[i].value;
                     newEntries[newCount].next = newBuckets[bucket];
                     newBuckets[bucket] = newCount++;
                 }
             }
             this.count = newCount;
-            this.buckets = newBuckets;
-            this.entries = newEntries;
-            this.freeList = -1;
-            this.freeCount = 0;
+            buckets = newBuckets;
+            entries = newEntries;
+            freeList = -1;
+            freeCount = 0;
         }
 
         private void Grow()
@@ -563,15 +552,15 @@ namespace Microsoft.Research.DataStructures
             for (int i = 0; i < newBuckets.Length; i++) newBuckets[i] = -1;
             int count = this.count;
             Entry[] newEntries = new Entry[newSize];
-            Array.Copy(this.entries, 0, newEntries, 0, count);
+            Array.Copy(entries, 0, newEntries, 0, count);
             for (int i = 0; i < count; i++)
             {
                 int bucket = newEntries[i].hashCode % newSize;
                 newEntries[i].next = newBuckets[bucket];
                 newBuckets[bucket] = i;
             }
-            this.buckets = newBuckets;
-            this.entries = newEntries;
+            buckets = newBuckets;
+            entries = newEntries;
         }
 
         /// <summary>
@@ -749,15 +738,15 @@ namespace Microsoft.Research.DataStructures
             /// <returns></returns>
             public bool MoveNext()
             {
-                Contract.Assume(this.dictionary != null);
+                Contract.Assume(dictionary != null);
 #if DEBUG
                 Contract.Assert(version == dictionary.version, "invalid operation");
 #endif
 
                 // Use unsigned comparison since we set index to dictionary.count+1 when the enumeration ends.
                 // dictionary.count+1 could be negative if dictionary.count is Int32.MaxValue
-                var count = this.dictionary.count;
-                var entries = this.dictionary.entries;
+                var count = dictionary.count;
+                var entries = dictionary.entries;
                 while ((uint)index < (uint)count)
                 {
                     if (entries[index].hashCode >= 0)
@@ -787,8 +776,8 @@ namespace Microsoft.Research.DataStructures
             /// </summary>
             public void Dispose()
             {
-                if (this.dictionary != null)
-                    this.dictionary = null;
+                if (dictionary != null)
+                    dictionary = null;
             }
 
             object IEnumerator.Current
@@ -811,7 +800,7 @@ namespace Microsoft.Research.DataStructures
 
             void IEnumerator.Reset()
             {
-                Contract.Assume(this.dictionary != null);
+                Contract.Assume(dictionary != null);
 #if DEBUG
                 Contract.Assert(version == dictionary.version, "invalid operation");
 #endif
@@ -825,7 +814,7 @@ namespace Microsoft.Research.DataStructures
                 get
                 {
                     Contract.Assume(current.Key != null);
-                    Contract.Assert(this.dictionary != null);
+                    Contract.Assert(dictionary != null);
                     Contract.Assert(index != 0 && (index != dictionary.count + 1), "invalid operation");
 
                     return new DictionaryEntry(current.Key, current.Value);
@@ -836,7 +825,7 @@ namespace Microsoft.Research.DataStructures
             {
                 get
                 {
-                    Contract.Assert(this.dictionary != null);
+                    Contract.Assert(dictionary != null);
                     Contract.Assert(index != 0 && (index != dictionary.count + 1), "invalid operation");
 
                     return current.Key;
@@ -847,7 +836,7 @@ namespace Microsoft.Research.DataStructures
             {
                 get
                 {
-                    Contract.Assert(this.dictionary != null);
+                    Contract.Assert(dictionary != null);
                     Contract.Assert(index != 0 && (index != dictionary.count + 1), "invalid operation");
 
                     return current.Value;
@@ -1034,8 +1023,8 @@ namespace Microsoft.Research.DataStructures
                     Contract.Assert(version == dictionary.version, "invalid operation");
 #endif
 
-                    var count = this.dictionary.count;
-                    var entries = this.dictionary.entries;
+                    var count = dictionary.count;
+                    var entries = dictionary.entries;
                     while ((uint)index < (uint)count)
                     {
                         if (entries[index].hashCode >= 0)
@@ -1258,13 +1247,13 @@ namespace Microsoft.Research.DataStructures
                 /// <returns></returns>
                 public bool MoveNext()
                 {
-                    Contract.Assume(this.dictionary != null);
+                    Contract.Assume(dictionary != null);
 #if DEBUG
                     Contract.Assert(version == dictionary.version, "invalid operation");
 #endif
 
-                    var count = this.dictionary.count;
-                    var entries = this.dictionary.entries;
+                    var count = dictionary.count;
+                    var entries = dictionary.entries;
                     while ((uint)index < (uint)count)
                     {
                         if (entries[index].hashCode >= 0)
@@ -1303,7 +1292,7 @@ namespace Microsoft.Research.DataStructures
 
                 void System.Collections.IEnumerator.Reset()
                 {
-                    Contract.Assume(this.dictionary != null);
+                    Contract.Assume(dictionary != null);
 #if DEBUG
                     Contract.Assert(version == dictionary.version, "invalid operation");
 #endif

--- a/Microsoft.Research/DataStructures/Cache.cs
+++ b/Microsoft.Research/DataStructures/Cache.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The interface and the implementation of a Cache of objects
 
@@ -23,192 +12,192 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.DataStructures
 {
-  /// <summary>
-  /// The interface for a cache
-  /// </summary>
-  public interface ICache<In, Out>
-  {
-    void Add(In index, Out output);
-
     /// <summary>
-    /// Set/Get an element in the cache.
-    /// When setting, if the element is there, is replaced, otherwise it is created.
-    /// When getting, if the element is not there, an exception is thrown.
+    /// The interface for a cache
     /// </summary>
-    Out this[In index]
+    public interface ICache<In, Out>
     {
-      get;
-      set;
+        void Add(In index, Out output);
+
+        /// <summary>
+        /// Set/Get an element in the cache.
+        /// When setting, if the element is there, is replaced, otherwise it is created.
+        /// When getting, if the element is not there, an exception is thrown.
+        /// </summary>
+        Out this[In index]
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Is the <code>index</code> in the cache?
+        /// </summary>
+        bool ContainsKey(In index);
+
+        bool TryGetValue(In index, out Out value);
     }
 
-    /// <summary>
-    /// Is the <code>index</code> in the cache?
-    /// </summary>
-    bool ContainsKey(In index);
 
-    bool TryGetValue(In index, out Out value);
-  }
-
-
-  public abstract class GenericCache
-  {
-    #region Static fields
-    [ThreadStatic]
-    static public int DEFAULT_CACHE_SIZE;
-
-    [ThreadStatic]
-    protected static int cacheHit;
-    [ThreadStatic]
-    protected static int cacheMiss;
-    [ThreadStatic]
-    protected static int totalCacheAccesses;
-
-    #endregion
-
-    /// <summary>
-    /// Get the usage statistics of this cache
-    /// </summary>
-    static public string Statistics
+    public abstract class GenericCache
     {
-      get
-      {
-        StringBuilder output = new StringBuilder();
+        #region Static fields
+        [ThreadStatic]
+        static public int DEFAULT_CACHE_SIZE;
 
-        output.Append("Overall use of the FIFO cache:" + Environment.NewLine);
-        output.AppendFormat("Cache accesses : {0}" + Environment.NewLine, totalCacheAccesses);
-        output.AppendFormat("Cache Hit : {0} ({1:P})" + Environment.NewLine, cacheHit, totalCacheAccesses != 0 ? cacheHit / (double)totalCacheAccesses: 0);
-        output.AppendFormat("Cache Miss: {0}" + Environment.NewLine, totalCacheAccesses - cacheHit);
+        [ThreadStatic]
+        protected static int cacheHit;
+        [ThreadStatic]
+        protected static int cacheMiss;
+        [ThreadStatic]
+        protected static int totalCacheAccesses;
 
-        return output.ToString();
-      }
-    }
-  }
+        #endregion
 
-  /// <summary>
-  /// A cache where the politics for removing elements if a <code>FIFO</code>
-  /// </summary>
-  public class FIFOCache<In, Out> : GenericCache, ICache<In, Out>
-  {
-    #region Invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.elements != null);
-      Contract.Invariant(this.fifo != null);
-    }
+        /// <summary>
+        /// Get the usage statistics of this cache
+        /// </summary>
+        static public string Statistics
+        {
+            get
+            {
+                StringBuilder output = new StringBuilder();
 
-    #endregion
+                output.Append("Overall use of the FIFO cache:" + Environment.NewLine);
+                output.AppendFormat("Cache accesses : {0}" + Environment.NewLine, totalCacheAccesses);
+                output.AppendFormat("Cache Hit : {0} ({1:P})" + Environment.NewLine, cacheHit, totalCacheAccesses != 0 ? cacheHit / (double)totalCacheAccesses : 0);
+                output.AppendFormat("Cache Miss: {0}" + Environment.NewLine, totalCacheAccesses - cacheHit);
 
-    #region Private state
-    readonly private Dictionary<In, Out> elements;
-    readonly private LinkedList<In> fifo;
-    private int size;
-    #endregion
-
-    #region Constructor
-    /// <summary>
-    /// The size of the cache
-    /// </summary>
-    /// <param name="size">Must be strictly positive</param>
-    public FIFOCache(int size)
-    {
-      Contract.Requires(size > 0, "The size of the cache must be strictly positive.");
-
-      this.elements = new Dictionary<In, Out>(size);
-      this.fifo = new LinkedList<In>();
-      this.size = size;
+                return output.ToString();
+            }
+        }
     }
 
     /// <summary>
-    /// Construct a cache of default size
+    /// A cache where the politics for removing elements if a <code>FIFO</code>
     /// </summary>
-    public FIFOCache()
-      : this(DEFAULT_CACHE_SIZE)
+    public class FIFOCache<In, Out> : GenericCache, ICache<In, Out>
     {
+        #region Invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(elements != null);
+            Contract.Invariant(fifo != null);
+        }
+
+        #endregion
+
+        #region Private state
+        readonly private Dictionary<In, Out> elements;
+        readonly private LinkedList<In> fifo;
+        private int size;
+        #endregion
+
+        #region Constructor
+        /// <summary>
+        /// The size of the cache
+        /// </summary>
+        /// <param name="size">Must be strictly positive</param>
+        public FIFOCache(int size)
+        {
+            Contract.Requires(size > 0, "The size of the cache must be strictly positive.");
+
+            elements = new Dictionary<In, Out>(size);
+            fifo = new LinkedList<In>();
+            this.size = size;
+        }
+
+        /// <summary>
+        /// Construct a cache of default size
+        /// </summary>
+        public FIFOCache()
+          : this(DEFAULT_CACHE_SIZE)
+        {
+        }
+
+        #endregion
+
+        #region ICache<In,Out> Members
+
+        /// <summary>
+        /// Add an element to the cache.
+        /// If <code>index</code> is in the cache, then <code>this[index] == output</code>
+        /// </summary>
+        public void Add(In index, Out output)
+        {
+            if (elements.ContainsKey(index))
+            {
+                // Contract.Assert(!Object.Equals(this.elements[index], output), "Error: trying to set a different value in the cache for the same input");
+                return;
+            }
+
+            if (elements.Count < size)    // there is still room for a new element in the cache
+            {
+                elements[index] = output;
+                fifo.AddLast(index);           // Add at the end of the queue
+            }
+            else
+            {
+                //^ assert this.fifo.First != null;
+                In toRemove = fifo.First.Value;
+                fifo.RemoveFirst();  // Remove the first element of the queue
+                elements.Remove(toRemove);
+
+                this.Add(index, output);                // Now there must be space, so we call ourselves recursively
+            }
+        }
+
+        public bool TryGetValue(In index, out Out value)
+        {
+            totalCacheAccesses++;
+
+            bool b = elements.TryGetValue(index, out value);
+            if (b)
+            {
+                cacheHit++;
+            }
+
+            return b;
+        }
+
+        /// <summary>
+        /// Get/Sets elements of the cache
+        /// </summary>
+        public Out this[In index]
+        {
+            get
+            {
+                totalCacheAccesses++;
+                return elements[index];
+            }
+            set
+            {
+                totalCacheAccesses++;
+                this.Add(index, value);
+            }
+        }
+
+        /// <summary>
+        /// Is the <code>index</code> in this cache
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public bool ContainsKey(In index)
+        {
+            bool b = elements.ContainsKey(index);
+
+            // Updates the statistics
+            totalCacheAccesses++;
+
+            if (b)
+                cacheHit++;
+            else
+                cacheMiss++;
+
+            return b;
+        }
+
+        #endregion
     }
-
-    #endregion
-
-    #region ICache<In,Out> Members
-
-    /// <summary>
-    /// Add an element to the cache.
-    /// If <code>index</code> is in the cache, then <code>this[index] == output</code>
-    /// </summary>
-    public void Add(In index, Out output)
-    {
-      if (this.elements.ContainsKey(index))
-      {
-        // Contract.Assert(!Object.Equals(this.elements[index], output), "Error: trying to set a different value in the cache for the same input");
-        return;
-      }
-
-      if (this.elements.Count < this.size)    // there is still room for a new element in the cache
-      {
-        this.elements[index] = output;
-        this.fifo.AddLast(index);           // Add at the end of the queue
-      }
-      else
-      {
-        //^ assert this.fifo.First != null;
-        In toRemove = this.fifo.First.Value;
-        this.fifo.RemoveFirst();  // Remove the first element of the queue
-        this.elements.Remove(toRemove);
-
-        this.Add(index, output);                // Now there must be space, so we call ourselves recursively
-      }
-    }
-
-    public bool TryGetValue(In index, out Out value)
-    {
-      totalCacheAccesses++;
-
-      bool b = this.elements.TryGetValue(index, out value);
-      if (b)
-      {
-        cacheHit++;
-      }
-
-      return b;
-    }
-
-    /// <summary>
-    /// Get/Sets elements of the cache
-    /// </summary>
-    public Out this[In index]
-    {
-      get
-      {
-        totalCacheAccesses++;
-        return this.elements[index];
-      }
-      set
-      {
-        totalCacheAccesses++;
-        this.Add(index, value);
-      }
-    }
-
-    /// <summary>
-    /// Is the <code>index</code> in this cache
-    /// </summary>
-    /// <param name="index"></param>
-    /// <returns></returns>
-    public bool ContainsKey(In index)
-    {
-      bool b = this.elements.ContainsKey(index);
-
-      // Updates the statistics
-      totalCacheAccesses++;
-
-      if (b)
-        cacheHit++;
-      else
-        cacheMiss++;
-
-      return b;
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/DataStructures/CallAdapter.cs
+++ b/Microsoft.Research/DataStructures/CallAdapter.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,198 +10,199 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.DataStructures
 {
-  public delegate TResult Func<Arg1,Arg2,Arg3,Arg4,Arg5,TResult>(Arg1 arg1, Arg2 arg2, Arg3 arg3, Arg4 arg4 ,Arg5 arg5);
+    public delegate TResult Func<Arg1, Arg2, Arg3, Arg4, Arg5, TResult>(Arg1 arg1, Arg2 arg2, Arg3 arg3, Arg4 arg4, Arg5 arg5);
 
-  [AttributeUsage(AttributeTargets.Interface)]
-  public class ContextAdapterAttribute : Attribute
-  {
-  }
+    [AttributeUsage(AttributeTargets.Interface)]
+    public class ContextAdapterAttribute : Attribute
+    {
+    }
 
-  public static class CallAdaption
-  {
+    public static class CallAdaption
+    {
 #if false
-    #region Old style Func call adapters
-    [ThreadStatic]
-    static FList<object> currentCallAdapters;
+        #region Old style Func call adapters
+        [ThreadStatic]
+        static FList<object> currentCallAdapters;
 
-    public static void Push<Arg0, Arg1, Arg2, Arg3, TResult>(Func<Func<Arg0, Arg1, Arg2, Arg3, TResult>, Arg0, Arg1, Arg2, Arg3, TResult> adapter)
-    {
-      currentCallAdapters = currentCallAdapters.Cons(adapter);
-    }
+        public static void Push<Arg0, Arg1, Arg2, Arg3, TResult>(Func<Func<Arg0, Arg1, Arg2, Arg3, TResult>, Arg0, Arg1, Arg2, Arg3, TResult> adapter)
+        {
+            currentCallAdapters = currentCallAdapters.Cons(adapter);
+        }
 
-    public static void Push<Arg0, Arg1, Arg2, TResult>(Func<Func<Arg0, Arg1, Arg2, TResult>, Arg0, Arg1, Arg2, TResult> adapter)
-    {
-      currentCallAdapters = currentCallAdapters.Cons(adapter);
-    }
+        public static void Push<Arg0, Arg1, Arg2, TResult>(Func<Func<Arg0, Arg1, Arg2, TResult>, Arg0, Arg1, Arg2, TResult> adapter)
+        {
+            currentCallAdapters = currentCallAdapters.Cons(adapter);
+        }
 
-    public static void Push<Arg0, Arg1, TResult>(Func<Func<Arg0, Arg1, TResult>, Arg0, Arg1, TResult> adapter)
-    {
-      currentCallAdapters = currentCallAdapters.Cons(adapter);
-    }
-
-
-    public static void Pop()
-    {
-      currentCallAdapters = currentCallAdapters.Tail;
-    }
+        public static void Push<Arg0, Arg1, TResult>(Func<Func<Arg0, Arg1, TResult>, Arg0, Arg1, TResult> adapter)
+        {
+            currentCallAdapters = currentCallAdapters.Cons(adapter);
+        }
 
 
-    public static TResult Dispatch<Arg0, Arg1, Arg2, TResult>(Func<Arg0, Arg1, Arg2, TResult> inner, Arg0 arg0, Arg1 arg1, Arg2 arg2)
-    {
-      var call = Wrap(inner, currentCallAdapters);
-      return call(arg0, arg1, arg2);
-    }
-
-    public static TResult Dispatch<Arg0, Arg1, Arg2, Arg3, TResult>(Func<Arg0, Arg1, Arg2, Arg3, TResult> inner, Arg0 arg0, Arg1 arg1, Arg2 arg2, Arg3 arg3)
-    {
-      var call = Wrap(inner, currentCallAdapters);
-      return call(arg0, arg1, arg2, arg3);
-    }
-
-    static Func<Arg0, Arg1, Arg2, Arg3, TResult> Wrap<Arg0, Arg1, Arg2, Arg3, TResult>(Func<Arg0, Arg1, Arg2, Arg3, TResult> inner, FList<object> adaptors)
-    {
-      if (adaptors == null)
-      {
-        return inner;
-      }
-      var head = adaptors.Head as Func<Func<Arg0, Arg1, Arg2, Arg3, TResult>, Arg0, Arg1, Arg2, Arg3, TResult>;
-      if (head != null)
-      {
-        var capturedInner = inner;
-        inner = (a0, a1, a2, a3) => head(capturedInner, a0, a1, a2, a3);
-      }
-      return Wrap(inner, adaptors.Tail);
-    }
-
-    static Func<Arg0, Arg1, Arg2, TResult> Wrap<Arg0, Arg1, Arg2, TResult>(Func<Arg0, Arg1, Arg2, TResult> inner, FList<object> adaptors)
-    {
-      if (adaptors == null)
-      {
-        return inner;
-      }
-      var head = adaptors.Head as Func<Func<Arg0, Arg1, Arg2, TResult>, Arg0, Arg1, Arg2, TResult>;
-      if (head != null)
-      {
-        inner = (a0, a1, a2) => head(inner, a0, a1, a2);
-      }
-      return Wrap(inner, adaptors.Tail);
-    }
+        public static void Pop()
+        {
+            currentCallAdapters = currentCallAdapters.Tail;
+        }
 
 
-    #endregion
+        public static TResult Dispatch<Arg0, Arg1, Arg2, TResult>(Func<Arg0, Arg1, Arg2, TResult> inner, Arg0 arg0, Arg1 arg1, Arg2 arg2)
+        {
+            var call = Wrap(inner, currentCallAdapters);
+            return call(arg0, arg1, arg2);
+        }
+
+        public static TResult Dispatch<Arg0, Arg1, Arg2, Arg3, TResult>(Func<Arg0, Arg1, Arg2, Arg3, TResult> inner, Arg0 arg0, Arg1 arg1, Arg2 arg2, Arg3 arg3)
+        {
+            var call = Wrap(inner, currentCallAdapters);
+            return call(arg0, arg1, arg2, arg3);
+        }
+
+        static Func<Arg0, Arg1, Arg2, Arg3, TResult> Wrap<Arg0, Arg1, Arg2, Arg3, TResult>(Func<Arg0, Arg1, Arg2, Arg3, TResult> inner, FList<object> adaptors)
+        {
+            if (adaptors == null)
+            {
+                return inner;
+            }
+            var head = adaptors.Head as Func<Func<Arg0, Arg1, Arg2, Arg3, TResult>, Arg0, Arg1, Arg2, Arg3, TResult>;
+            if (head != null)
+            {
+                var capturedInner = inner;
+                inner = (a0, a1, a2, a3) => head(capturedInner, a0, a1, a2, a3);
+            }
+            return Wrap(inner, adaptors.Tail);
+        }
+
+        static Func<Arg0, Arg1, Arg2, TResult> Wrap<Arg0, Arg1, Arg2, TResult>(Func<Arg0, Arg1, Arg2, TResult> inner, FList<object> adaptors)
+        {
+            if (adaptors == null)
+            {
+                return inner;
+            }
+            var head = adaptors.Head as Func<Func<Arg0, Arg1, Arg2, TResult>, Arg0, Arg1, Arg2, TResult>;
+            if (head != null)
+            {
+                inner = (a0, a1, a2) => head(inner, a0, a1, a2);
+            }
+            return Wrap(inner, adaptors.Tail);
+        }
+
+
+        #endregion
 #endif
 
-    #region Interface style call adaptors
+        #region Interface style call adaptors
 
-    [ThreadStatic]
-    static List<object> contextAdapters;
+        [ThreadStatic]
+        private static List<object> contextAdapters;
 
-    /// <summary>
-    /// Need to have this property because there needs to be a contextAdapters list
-    /// that is unique per thread. But the static field is initialized just once:
-    /// only in the thread that executes the class constructor. So all other threads
-    /// will see a null value.
-    /// </summary>
-    static List<object> ContextAdapters {
-      get {
-        if (contextAdapters == null)
-          contextAdapters = new List<object>();
-        return contextAdapters;
-      }
-    }
-
-
-    private static object Last
-    {
-      get
-      {
-        Contract.Assume(ContextAdapters.Count > 0);
-        return ContextAdapters[ContextAdapters.Count - 1];
-      }
-    }
-
-    public static void Push<T>(T @this) where T:class
-    {
-      Contract.Requires(@this != null);
-
-      ContextAdapters.Add(@this);
-    }
-
-    public static void Pop<T>(T @this) where T:class
-    {
-      Contract.Requires(@this != null);
-      Contract.Assume(ContextAdapters.Count > 0);
-      Contract.Assume(Last == @this || Last == null);
-
-      ContextAdapters.RemoveAt(ContextAdapters.Count -1);
-    }
-
-    public static T Dispatch<T>(T @this) where T:class
-    {
-      Contract.Requires(@this != null);
-      Contract.Ensures(Contract.Result<T>() != null);
-
-      Contract.Assume(ContextAdapters.Count > 0);
-      Contract.Assume(Last == @this || Last == null);
-
-      return FindAdaptorStartingAt<T>(@this, 0);
-    }
-
-    /// <summary>
-    /// We just return the first adapter. The duplicates are lazyily removed when Inner is used
-    /// </summary>
-    private static T FindAdaptorStartingAt<T>(T @default, int startIndex) where T : class
-    {
-      Contract.Requires(startIndex >= 0);
-      Contract.Ensures(Contract.Result<T>() != null || @default == null);
-
-      List<object> adapters = ContextAdapters;
-      for (int i = startIndex; i < adapters.Count; i++)
-      {
-        T adapter = adapters[i] as T;
-        if (adapter != null)
+        /// <summary>
+        /// Need to have this property because there needs to be a contextAdapters list
+        /// that is unique per thread. But the static field is initialized just once:
+        /// only in the thread that executes the class constructor. So all other threads
+        /// will see a null value.
+        /// </summary>
+        private static List<object> ContextAdapters
         {
-          return adapter;
+            get
+            {
+                if (contextAdapters == null)
+                    contextAdapters = new List<object>();
+                return contextAdapters;
+            }
         }
-      }
-      return @default;
-    }
 
-    /// <summary>
-    /// Clear duplicates below the current context
-    /// </summary>
-    public static T Inner<T>(T @this) where T : class
-    {
-      Contract.Ensures(Contract.Result<T>() != null);
 
-      // find current adapter position and search next one from there
-      for (int i = 0; i < ContextAdapters.Count; i++)
-      {
-        if (ContextAdapters[i] == @this)
+        private static object Last
         {
-          ClearDuplicates(@this, i + 1);
-          var result = FindAdaptorStartingAt<T>(null, i + 1);
-          if (result != null)
-          {
-            return result;
-          }
-          throw new InvalidOperationException("no inner context found");
+            get
+            {
+                Contract.Assume(ContextAdapters.Count > 0);
+                return ContextAdapters[ContextAdapters.Count - 1];
+            }
         }
-      }
-      throw new InvalidOperationException("@this is not a current adapter");
+
+        public static void Push<T>(T @this) where T : class
+        {
+            Contract.Requires(@this != null);
+
+            ContextAdapters.Add(@this);
+        }
+
+        public static void Pop<T>(T @this) where T : class
+        {
+            Contract.Requires(@this != null);
+            Contract.Assume(ContextAdapters.Count > 0);
+            Contract.Assume(Last == @this || Last == null);
+
+            ContextAdapters.RemoveAt(ContextAdapters.Count - 1);
+        }
+
+        public static T Dispatch<T>(T @this) where T : class
+        {
+            Contract.Requires(@this != null);
+            Contract.Ensures(Contract.Result<T>() != null);
+
+            Contract.Assume(ContextAdapters.Count > 0);
+            Contract.Assume(Last == @this || Last == null);
+
+            return FindAdaptorStartingAt<T>(@this, 0);
+        }
+
+        /// <summary>
+        /// We just return the first adapter. The duplicates are lazyily removed when Inner is used
+        /// </summary>
+        private static T FindAdaptorStartingAt<T>(T @default, int startIndex) where T : class
+        {
+            Contract.Requires(startIndex >= 0);
+            Contract.Ensures(Contract.Result<T>() != null || @default == null);
+
+            List<object> adapters = ContextAdapters;
+            for (int i = startIndex; i < adapters.Count; i++)
+            {
+                T adapter = adapters[i] as T;
+                if (adapter != null)
+                {
+                    return adapter;
+                }
+            }
+            return @default;
+        }
+
+        /// <summary>
+        /// Clear duplicates below the current context
+        /// </summary>
+        public static T Inner<T>(T @this) where T : class
+        {
+            Contract.Ensures(Contract.Result<T>() != null);
+
+            // find current adapter position and search next one from there
+            for (int i = 0; i < ContextAdapters.Count; i++)
+            {
+                if (ContextAdapters[i] == @this)
+                {
+                    ClearDuplicates(@this, i + 1);
+                    var result = FindAdaptorStartingAt<T>(null, i + 1);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                    throw new InvalidOperationException("no inner context found");
+                }
+            }
+            throw new InvalidOperationException("@this is not a current adapter");
+        }
+
+        private static void ClearDuplicates(object @this, int from)
+        {
+            Contract.Requires(from >= 0);
+
+            for (int i = from; i < ContextAdapters.Count; i++)
+            {
+                if (ContextAdapters[i] == @this) ContextAdapters[i] = null;
+            }
+        }
+
+        #endregion
     }
-
-    private static void ClearDuplicates(object @this, int from)
-    {
-      Contract.Requires(from >= 0);
-
-      for (int i = from; i < ContextAdapters.Count; i++)
-      {
-        if (ContextAdapters[i] == @this) ContextAdapters[i] = null;
-      }
-    }
-
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/DataStructures/DoubleTable.cs
+++ b/Microsoft.Research/DataStructures/DoubleTable.cs
@@ -1,92 +1,86 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Research.DataStructures
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Diagnostics;
-  using System.Text;
-  using System.IO;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using System.IO;
 
 
 
-  public class DoubleTable<KEY1, KEY2, ELEM> : Dictionary<KEY1, Dictionary<KEY2, ELEM>>
-  {
-    public DoubleTable() : base() { }
-
-    public void Add(KEY1 key1, KEY2 key2, ELEM element) {
-      Dictionary<KEY2, ELEM>/*?*/ table;
-      if (!(this.TryGetValue(key1, out table))) {
-        table = new Dictionary<KEY2, ELEM>();
-        this.Add(key1, table);
-      }
-      //^ assert table != null;
-      table.Add(key2, element);
-    }
-
-    public ELEM this[KEY1 key1, KEY2 key2]
+    public class DoubleTable<KEY1, KEY2, ELEM> : Dictionary<KEY1, Dictionary<KEY2, ELEM>>
     {
-      get
-      {
-        return this[key1][key2];
-      }
-      set
-      {
-        Dictionary<KEY2, ELEM>/*?*/ table;
-        if (!(this.TryGetValue(key1, out table))) {
-          table = new Dictionary<KEY2, ELEM>();
-          this.Add(key1, table);
+        public DoubleTable() : base() { }
+
+        public void Add(KEY1 key1, KEY2 key2, ELEM element)
+        {
+            Dictionary<KEY2, ELEM>/*?*/ table;
+            if (!(this.TryGetValue(key1, out table)))
+            {
+                table = new Dictionary<KEY2, ELEM>();
+                this.Add(key1, table);
+            }
+            //^ assert table != null;
+            table.Add(key2, element);
         }
-        //^ assert table != null;
-        table[key2] = value;
-      }
+
+        public ELEM this[KEY1 key1, KEY2 key2]
+        {
+            get
+            {
+                return this[key1][key2];
+            }
+            set
+            {
+                Dictionary<KEY2, ELEM>/*?*/ table;
+                if (!(this.TryGetValue(key1, out table)))
+                {
+                    table = new Dictionary<KEY2, ELEM>();
+                    this.Add(key1, table);
+                }
+                //^ assert table != null;
+                table[key2] = value;
+            }
+        }
+
+
+        public IEnumerable<KEY1> Keys1 { get { return this.Keys; } }
+
+        public IEnumerable<KEY2> Keys2(KEY1 key1)
+        {
+            Dictionary<KEY2, ELEM>/*?*/ range;
+            if (this.TryGetValue(key1, out range))
+            {
+                //^ assume range != null;
+                return range.Keys;
+            }
+            return new KEY2[0];
+        }
+
+        public bool ContainsKey(KEY1 key1, KEY2 key2)
+        {
+            Dictionary<KEY2, ELEM>/*?*/ range;
+            if (this.TryGetValue(key1, out range))
+            {
+                //^ assume range != null;
+                return range.ContainsKey(key2);
+            }
+            return false;
+        }
+
+        public bool TryGetValue(KEY1 key1, KEY2 key2, out ELEM/*?*/ result)
+        {
+            Dictionary<KEY2, ELEM>/*?*/ range;
+            if (this.TryGetValue(key1, out range))
+            {
+                //^ assume range != null;
+                return range.TryGetValue(key2, out result);
+            }
+            result = default(ELEM);
+            return false;
+        }
     }
-
-
-    public IEnumerable<KEY1> Keys1 { get { return this.Keys; } }
-
-    public IEnumerable<KEY2> Keys2(KEY1 key1)
-    {
-      Dictionary<KEY2, ELEM>/*?*/ range;
-      if (this.TryGetValue(key1, out range)) {
-        //^ assume range != null;
-        return range.Keys;
-      }
-      return new KEY2[0];
-    }
-
-    public bool ContainsKey(KEY1 key1, KEY2 key2)
-    {
-      Dictionary<KEY2, ELEM>/*?*/ range;
-      if (this.TryGetValue(key1, out range)) {
-        //^ assume range != null;
-        return range.ContainsKey(key2);
-      }
-      return false;
-    }
-
-    public bool TryGetValue(KEY1 key1, KEY2 key2, out ELEM/*?*/ result)
-    {
-      Dictionary<KEY2, ELEM>/*?*/ range;
-      if (this.TryGetValue(key1, out range)) {
-        //^ assume range != null;
-        return range.TryGetValue(key2, out result);
-      }
-      result = default(ELEM);
-      return false;
-    }
-  }
-
 }

--- a/Microsoft.Research/DataStructures/EquatableEqualityComparer.cs
+++ b/Microsoft.Research/DataStructures/EquatableEqualityComparer.cs
@@ -1,22 +1,12 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.Research.DataStructures {
+namespace Microsoft.Research.DataStructures
+{
     /// <summary>
     /// Equality comparer using the IEquatable interface
     /// </summary>

--- a/Microsoft.Research/DataStructures/Extensions.cs
+++ b/Microsoft.Research/DataStructures/Extensions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections;
@@ -21,249 +10,248 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.DataStructures
 {
-  public static class SetExtensions
-  {
+    public static class SetExtensions
+    {
+        [ContractVerification(true)]
+        static public Set<U> ConvertIf<T, U>(this Set<T> original, Predicate<T> condition, Converter<T, U> converter)
+        {
+            Contract.Requires(condition != null);
+            Contract.Requires(converter != null);
+
+            if (original != null)
+            {
+                var result = new Set<U>();
+
+                foreach (var element in original)
+                {
+                    if (condition(element))
+                        result.Add(converter(element));
+                }
+
+                return result;
+            }
+
+            return default(Set<U>);
+        }
+    }
+
     [ContractVerification(true)]
-    static public Set<U> ConvertIf<T, U>(this Set<T> original, Predicate<T> condition, Converter<T, U> converter)
+    public static class IEnumerableExtensions
     {
-      Contract.Requires(condition != null);
-      Contract.Requires(converter != null);
-
-      if (original != null)
-      {
-        var result = new Set<U>();
-
-        foreach (var element in original)
+        [Pure]
+        public static FList<T> ToFList<T>(this IEnumerable<T> coll)
         {
-          if (condition(element))
-            result.Add(converter(element));
+            Contract.Requires(coll != null);
+            // Contract.Ensures(Contract.Result<FList<T>>() != null);  // too strong postcondition, if coll is empty, it returns null
+
+            var result = FList<T>.Empty;
+
+            foreach (var x in coll)
+            {
+                result = result.Cons(x);
+            }
+
+            return result = result.Reverse();
         }
 
-        return result;
-      }
-
-      return default(Set<U>);
-    }
-  }
-
-  [ContractVerification(true)]
-  public static class IEnumerableExtensions
-  {
-    [Pure]
-    public static FList<T> ToFList<T>(this IEnumerable<T> coll)
-    {
-      Contract.Requires(coll != null);
-      // Contract.Ensures(Contract.Result<FList<T>>() != null);  // too strong postcondition, if coll is empty, it returns null
-
-      var result = FList<T>.Empty;
-
-      foreach (var x in coll)
-      {
-        result = result.Cons(x);
-      }
-
-      return result = result.Reverse();
-    }
-
-    [Pure]
-    public static Set<T> ToSet<T>(this IEnumerable<T> coll)
-    {
-      Contract.Requires(coll != null);
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
-
-      return new Set<T>(coll);
-    }
-
-
-
-    // equivalent to Linq IEnumerable<Out>.Select
-    public static IEnumerable<Out> ApplyToAll<In, Out>(this IEnumerable<In> input, Func<In, Out> map)
-    {
-      Contract.Requires(input != null);
-      Contract.Requires(map != null);
-      Contract.Ensures(Contract.Result<IEnumerable<Out>>() != null);
-
-      foreach (var i in input)
-      {
-        yield return map(i);
-      }
-    }
-
-    public static int GetStructuralHashCode<T>(this IEnumerable<T> input)
-    {
-      Contract.Requires(input != null);
-
-      return HashHelpers.CombineHashCodes(input.ApplyToAll(x => x.GetHashCode()));
-    }
-
-    /// <summary>
-    /// Splits a sequence of values based on a predicate (One: true, Two: false)
-    /// </summary>
-    /// <returns>a pair of IEnumerable whose first elements verify the predicate and second elements don't</returns>
-    public static Pair<IEnumerable<T>, IEnumerable<T>> Split<T>(this IEnumerable<T> input, Predicate<T> predicate)
-    {
-      Contract.Requires(input != null);
-      Contract.Requires(predicate != null);
-
-      // TOCHECK: predicate is called only once per element
-      var inputWithBool = input.Select(x => Pair.For(x, predicate(x)));
-      return Pair.For(inputWithBool.Where(Pair.Two).Select(Pair.One), inputWithBool.Where(Pair.NotTwo).Select(Pair.One));
-    }
-  }
-
-  public static class ICollectionExtensions
-  {
-    private class CastCollection<TSource, TResult> : ICollection<TResult>
-    {
-      private readonly ICollection<TSource> source;
-
-      public CastCollection(ICollection<TSource> source)
-      {
-        this.source = source;
-      }
-
-      int ICollection<TResult>.Count { get { return source.Count; } }
-      bool ICollection<TResult>.IsReadOnly { get { return source.IsReadOnly; } }
-      void ICollection<TResult>.Add(TResult item) { this.source.Add((TSource)(object)item); }
-      void ICollection<TResult>.Clear() { this.source.Clear(); }
-      bool ICollection<TResult>.Contains(TResult item) { return this.source.Contains((TSource)(object)item); }
-      void ICollection<TResult>.CopyTo(TResult[] array, int arrayIndex) { this.source.Cast<TResult>().ToArray().CopyTo(array, arrayIndex); }
-      IEnumerator IEnumerable.GetEnumerator() { return this.source.GetEnumerator(); }
-      IEnumerator<TResult> IEnumerable<TResult>.GetEnumerator() { return this.source.Cast<TResult>().GetEnumerator(); }
-      bool ICollection<TResult>.Remove(TResult item) { return this.source.Remove((TSource)(object)item); }
-    }
-
-    public static ICollection<TResult> CollectionCast<TSource, TResult>(this ICollection<TSource> source)
-    {
-      var typedSource = source as ICollection<TResult>;
-      if (typedSource != null)
-        return typedSource;
-      if (source == null) throw new ArgumentNullException("source");
-      return new CastCollection<TSource, TResult>(source);
-    }    
-  }
-
-  [ContractVerification(true)]
-  public static class DictionaryExtensions
-  {
-    public static bool AddToValues<TKey, TValue>(this Dictionary<TKey, List<TValue>> dictionary, TKey key, TValue value)
-    {
-      Contract.Requires(dictionary != null);
-      Contract.Requires(key != null);
-
-      List<TValue> values;
-      if (!dictionary.TryGetValue(key, out values) || values == null)
-      {
-        values = new List<TValue>() { value };
-        dictionary[key] = values;
-
-        return false;
-      }
-      else
-      {
-        // works with side effects
-        values.Add(value);
-
-        return true;
-      }
-    }
-  }
-
-  public static class SortedListExtensions
-  {
-    /// <summary>
-    /// Finds the last element whose key is not greater than <paramref name="key"/>
-    /// </summary>
-    /// <returns>false if all elements are greater than <paramref name="key"/></returns>
-    public static bool TryUpperBound<TKey, TValue>(this SortedList<TKey, TValue> sortedList, TKey key, out TKey upperBoundKey, out TValue upperBoundValue)
-    {
-      int low = 0;
-      int high = sortedList.Count - 1;
-      while (low <= high)
-      {
-        int med = low + ((high - low) >> 1);
-        var medKey = sortedList.Keys[med];
-        int cmp = sortedList.Comparer.Compare(medKey, key);
-        if (cmp == 0)
+        [Pure]
+        public static Set<T> ToSet<T>(this IEnumerable<T> coll)
         {
-          upperBoundKey = medKey;
-          upperBoundValue = sortedList.Values[med];
-          return true;
+            Contract.Requires(coll != null);
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            return new Set<T>(coll);
         }
-        if (cmp < 0)
-          low = med + 1;
-        else
-          high = med - 1;
-      }
-      if (high >= 0)
-      {
-        upperBoundKey = sortedList.Keys[high];
-        upperBoundValue = sortedList.Values[high];
-        return true;
-      }
-      upperBoundKey = default(TKey);
-      upperBoundValue = default(TValue);
-      return false;
+
+
+
+        // equivalent to Linq IEnumerable<Out>.Select
+        public static IEnumerable<Out> ApplyToAll<In, Out>(this IEnumerable<In> input, Func<In, Out> map)
+        {
+            Contract.Requires(input != null);
+            Contract.Requires(map != null);
+            Contract.Ensures(Contract.Result<IEnumerable<Out>>() != null);
+
+            foreach (var i in input)
+            {
+                yield return map(i);
+            }
+        }
+
+        public static int GetStructuralHashCode<T>(this IEnumerable<T> input)
+        {
+            Contract.Requires(input != null);
+
+            return HashHelpers.CombineHashCodes(input.ApplyToAll(x => x.GetHashCode()));
+        }
+
+        /// <summary>
+        /// Splits a sequence of values based on a predicate (One: true, Two: false)
+        /// </summary>
+        /// <returns>a pair of IEnumerable whose first elements verify the predicate and second elements don't</returns>
+        public static Pair<IEnumerable<T>, IEnumerable<T>> Split<T>(this IEnumerable<T> input, Predicate<T> predicate)
+        {
+            Contract.Requires(input != null);
+            Contract.Requires(predicate != null);
+
+            // TOCHECK: predicate is called only once per element
+            var inputWithBool = input.Select(x => Pair.For(x, predicate(x)));
+            return Pair.For(inputWithBool.Where(Pair.Two).Select(Pair.One), inputWithBool.Where(Pair.NotTwo).Select(Pair.One));
+        }
     }
 
-    public static bool TryUpperBound<TKey, TValue>(this SortedList<TKey, TValue> sortedList, TKey key, out TKey upperBoundKey)
+    public static class ICollectionExtensions
     {
-      TValue upperBoundValue;
-      return sortedList.TryUpperBound(key, out upperBoundKey, out upperBoundValue);
+        private class CastCollection<TSource, TResult> : ICollection<TResult>
+        {
+            private readonly ICollection<TSource> source;
+
+            public CastCollection(ICollection<TSource> source)
+            {
+                this.source = source;
+            }
+
+            int ICollection<TResult>.Count { get { return source.Count; } }
+            bool ICollection<TResult>.IsReadOnly { get { return source.IsReadOnly; } }
+            void ICollection<TResult>.Add(TResult item) { source.Add((TSource)(object)item); }
+            void ICollection<TResult>.Clear() { source.Clear(); }
+            bool ICollection<TResult>.Contains(TResult item) { return source.Contains((TSource)(object)item); }
+            void ICollection<TResult>.CopyTo(TResult[] array, int arrayIndex) { source.Cast<TResult>().ToArray().CopyTo(array, arrayIndex); }
+            IEnumerator IEnumerable.GetEnumerator() { return source.GetEnumerator(); }
+            IEnumerator<TResult> IEnumerable<TResult>.GetEnumerator() { return source.Cast<TResult>().GetEnumerator(); }
+            bool ICollection<TResult>.Remove(TResult item) { return source.Remove((TSource)(object)item); }
+        }
+
+        public static ICollection<TResult> CollectionCast<TSource, TResult>(this ICollection<TSource> source)
+        {
+            var typedSource = source as ICollection<TResult>;
+            if (typedSource != null)
+                return typedSource;
+            if (source == null) throw new ArgumentNullException("source");
+            return new CastCollection<TSource, TResult>(source);
+        }
     }
 
-    public static bool TryUpperBound<TKey, TValue>(this SortedList<TKey, TValue> sortedList, TKey key, out TValue upperBoundValue)
+    [ContractVerification(true)]
+    public static class DictionaryExtensions
     {
-      TKey upperBoundKey;
-      return sortedList.TryUpperBound(key, out upperBoundKey, out upperBoundValue);
-    }
-  }
+        public static bool AddToValues<TKey, TValue>(this Dictionary<TKey, List<TValue>> dictionary, TKey key, TValue value)
+        {
+            Contract.Requires(dictionary != null);
+            Contract.Requires(key != null);
 
-  public static class KeyValuePair
-  {
-    public static KeyValuePair<TKey, TValue> For<TKey, TValue>(TKey key, TValue value)
+            List<TValue> values;
+            if (!dictionary.TryGetValue(key, out values) || values == null)
+            {
+                values = new List<TValue>() { value };
+                dictionary[key] = values;
+
+                return false;
+            }
+            else
+            {
+                // works with side effects
+                values.Add(value);
+
+                return true;
+            }
+        }
+    }
+
+    public static class SortedListExtensions
     {
-      return new KeyValuePair<TKey, TValue>(key, value);
-    }
-  }
+        /// <summary>
+        /// Finds the last element whose key is not greater than <paramref name="key"/>
+        /// </summary>
+        /// <returns>false if all elements are greater than <paramref name="key"/></returns>
+        public static bool TryUpperBound<TKey, TValue>(this SortedList<TKey, TValue> sortedList, TKey key, out TKey upperBoundKey, out TValue upperBoundValue)
+        {
+            int low = 0;
+            int high = sortedList.Count - 1;
+            while (low <= high)
+            {
+                int med = low + ((high - low) >> 1);
+                var medKey = sortedList.Keys[med];
+                int cmp = sortedList.Comparer.Compare(medKey, key);
+                if (cmp == 0)
+                {
+                    upperBoundKey = medKey;
+                    upperBoundValue = sortedList.Values[med];
+                    return true;
+                }
+                if (cmp < 0)
+                    low = med + 1;
+                else
+                    high = med - 1;
+            }
+            if (high >= 0)
+            {
+                upperBoundKey = sortedList.Keys[high];
+                upperBoundValue = sortedList.Values[high];
+                return true;
+            }
+            upperBoundKey = default(TKey);
+            upperBoundValue = default(TValue);
+            return false;
+        }
 
-  [ContractVerification(true)]
-  public static class StringExtensions
-  {
-    [Pure]
-    public static string PrefixWithCurrentTime(this string str, string prefix = "")
+        public static bool TryUpperBound<TKey, TValue>(this SortedList<TKey, TValue> sortedList, TKey key, out TKey upperBoundKey)
+        {
+            TValue upperBoundValue;
+            return sortedList.TryUpperBound(key, out upperBoundKey, out upperBoundValue);
+        }
+
+        public static bool TryUpperBound<TKey, TValue>(this SortedList<TKey, TValue> sortedList, TKey key, out TValue upperBoundValue)
+        {
+            TKey upperBoundKey;
+            return sortedList.TryUpperBound(key, out upperBoundKey, out upperBoundValue);
+        }
+    }
+
+    public static class KeyValuePair
     {
-      var currTime = DateTime.Now.TimeOfDay.ToString();
-
-      return string.Format("[{0}] {1}",
-        String.IsNullOrEmpty(prefix) ? currTime : prefix + " -- " + currTime,
-        str);
+        public static KeyValuePair<TKey, TValue> For<TKey, TValue>(TKey key, TValue value)
+        {
+            return new KeyValuePair<TKey, TValue>(key, value);
+        }
     }
-  }
 
-  public static class ContractExtensions
-  {
-    [Pure]
-    /// <summary>Simple identity function checking the extra assumption that obj != null</summary>
-    public static T AssumeNotNull<T>(this T obj, string msgIfFails = "")
-       where T: class
+    [ContractVerification(true)]
+    public static class StringExtensions
     {
-      Contract.Ensures(Contract.Result<T>() != null);
-      Contract.Ensures(Contract.Result<T>() == obj);
+        [Pure]
+        public static string PrefixWithCurrentTime(this string str, string prefix = "")
+        {
+            var currTime = DateTime.Now.TimeOfDay.ToString();
 
-      Contract.Assume(obj != null, msgIfFails);
-      return obj;
+            return string.Format("[{0}] {1}",
+              String.IsNullOrEmpty(prefix) ? currTime : prefix + " -- " + currTime,
+              str);
+        }
     }
-  }
 
-  public class ExitRequestedException : Exception
-  {
-    public readonly int ExitCode;
-
-    public ExitRequestedException(int exitCode)
+    public static class ContractExtensions
     {
-      this.ExitCode = exitCode;
-    }
-  }
+        [Pure]
+        /// <summary>Simple identity function checking the extra assumption that obj != null</summary>
+        public static T AssumeNotNull<T>(this T obj, string msgIfFails = "")
+           where T : class
+        {
+            Contract.Ensures(Contract.Result<T>() != null);
+            Contract.Ensures(Contract.Result<T>() == obj);
 
+            Contract.Assume(obj != null, msgIfFails);
+            return obj;
+        }
+    }
+
+    public class ExitRequestedException : Exception
+    {
+        public readonly int ExitCode;
+
+        public ExitRequestedException(int exitCode)
+        {
+            this.ExitCode = exitCode;
+        }
+    }
 }

--- a/Microsoft.Research/DataStructures/FileSystemAbstractions.cs
+++ b/Microsoft.Research/DataStructures/FileSystemAbstractions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,107 +10,106 @@ using System.Text;
 
 namespace Microsoft.Research.DataStructures
 {
-  public class FileSystemAbstractions
-  {
-    [DllImport("mpr.dll", CharSet = CharSet.Unicode)]
-    [return: MarshalAs(UnmanagedType.U4)]
-    static extern int WNetGetUniversalName(
-        string lpLocalPath,
-        [MarshalAs(UnmanagedType.U4)] int dwInfoLevel,
-        IntPtr lpBuffer,
-        [MarshalAs(UnmanagedType.U4)] ref int lpBufferSize);
-
-    const int UNIVERSAL_NAME_INFO_LEVEL = 0x00000001;
-    const int REMOTE_NAME_INFO_LEVEL = 0x00000002;
-    const int ERROR_MORE_DATA = 234;
-    const int ERROR_NOT_CONNECTED = 2250;
-    const int ERROR_NO_NETWORK = 1222;
-    const int NOERROR = 0;
-
-    public static bool TryGetUniversalName(string localPath, out string result)
+    public class FileSystemAbstractions
     {
-      result = null;
+        [DllImport("mpr.dll", CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.U4)]
+        private static extern int WNetGetUniversalName(
+            string lpLocalPath,
+            [MarshalAs(UnmanagedType.U4)] int dwInfoLevel,
+            IntPtr lpBuffer,
+            [MarshalAs(UnmanagedType.U4)] ref int lpBufferSize);
 
-      if (String.IsNullOrEmpty(localPath))
-      {
-        return false;
-      }
+        private const int UNIVERSAL_NAME_INFO_LEVEL = 0x00000001;
+        private const int REMOTE_NAME_INFO_LEVEL = 0x00000002;
+        private const int ERROR_MORE_DATA = 234;
+        private const int ERROR_NOT_CONNECTED = 2250;
+        private const int ERROR_NO_NETWORK = 1222;
+        private const int NOERROR = 0;
 
-      var buffer = IntPtr.Zero;
-
-      try
-      {
-        // First, call WNetGetUniversalName to get the size.
-        int size = 0;
-
-        // Make the call.
-        // Pass IntPtr.Size because the API doesn't like null, even though
-        // size is zero.  We know that IntPtr.Size will be
-        // aligned correctly.
-        int apiRetVal = WNetGetUniversalName(localPath, UNIVERSAL_NAME_INFO_LEVEL, (IntPtr)IntPtr.Size, ref size);
-
-        // Local Drive
-        if (apiRetVal == ERROR_NOT_CONNECTED || apiRetVal == ERROR_NO_NETWORK)
+        public static bool TryGetUniversalName(string localPath, out string result)
         {
-          return TryGetLocalUniversalName(localPath, out result);
+            result = null;
+
+            if (String.IsNullOrEmpty(localPath))
+            {
+                return false;
+            }
+
+            var buffer = IntPtr.Zero;
+
+            try
+            {
+                // First, call WNetGetUniversalName to get the size.
+                int size = 0;
+
+                // Make the call.
+                // Pass IntPtr.Size because the API doesn't like null, even though
+                // size is zero.  We know that IntPtr.Size will be
+                // aligned correctly.
+                int apiRetVal = WNetGetUniversalName(localPath, UNIVERSAL_NAME_INFO_LEVEL, (IntPtr)IntPtr.Size, ref size);
+
+                // Local Drive
+                if (apiRetVal == ERROR_NOT_CONNECTED || apiRetVal == ERROR_NO_NETWORK)
+                {
+                    return TryGetLocalUniversalName(localPath, out result);
+                }
+
+                if (apiRetVal == 1200 && localPath.StartsWith(@"\\"))
+                {
+                    result = localPath;
+                    return true;
+                }
+
+                size = 1024;
+
+                // Allocate the memory.
+                buffer = Marshal.AllocCoTaskMem(size);
+
+                // Now make the call.
+                apiRetVal = WNetGetUniversalName(localPath, UNIVERSAL_NAME_INFO_LEVEL, buffer, ref size);
+
+                // If it didn't succeed, then throw.
+                if (apiRetVal != NOERROR)
+                    return false;
+
+                // Now get the string.  It's all in the same buffer, but
+                // the pointer is first, so offset the pointer by IntPtr.Size
+                // and pass to PtrToStringAnsi.
+                result = Marshal.PtrToStringAuto(new IntPtr(buffer.ToInt64() + IntPtr.Size), size);
+                result = result.Substring(0, result.IndexOf('\0'));
+            }
+            finally
+            {
+                // Release the buffer.
+                Marshal.FreeCoTaskMem(buffer);
+            }
+
+            return true;
         }
 
-        if (apiRetVal == 1200 && localPath.StartsWith(@"\\"))
+        static private bool TryGetLocalUniversalName(string localpath, out string result)
         {
-          result = localPath;
-          return true;
+            localpath = localpath.ToLower();
+            result = null;
+            var shares = new ManagementClass("Win32_Share").GetInstances();
+
+            //System.Diagnostics.Debugger.Break();
+
+            foreach (var share in shares)
+            {
+                var path = share["Path"].ToString().ToLower();
+                if (!String.IsNullOrEmpty(path) && localpath.StartsWith(path))
+                {
+                    var name = share["Name"].ToString();
+                    var caption = share["Caption"].ToString();
+                    var rest = localpath.Substring(path.Length);
+                    result = String.Format(@"\\{0}\{1}\{2}", Environment.MachineName, name, rest);
+
+                    return true;
+                }
+            }
+            return result != null;
         }
-
-        size = 1024;
-
-        // Allocate the memory.
-        buffer = Marshal.AllocCoTaskMem(size);
-
-        // Now make the call.
-        apiRetVal = WNetGetUniversalName(localPath, UNIVERSAL_NAME_INFO_LEVEL, buffer, ref size);
-
-        // If it didn't succeed, then throw.
-        if (apiRetVal != NOERROR)
-          return false;
-
-        // Now get the string.  It's all in the same buffer, but
-        // the pointer is first, so offset the pointer by IntPtr.Size
-        // and pass to PtrToStringAnsi.
-        result = Marshal.PtrToStringAuto(new IntPtr(buffer.ToInt64() + IntPtr.Size), size);
-        result = result.Substring(0, result.IndexOf('\0'));
-      }
-      finally
-      {
-        // Release the buffer.
-        Marshal.FreeCoTaskMem(buffer);
-      }
-
-      return true;
     }
-
-    static private bool TryGetLocalUniversalName(string localpath, out string result)
-    {
-      localpath = localpath.ToLower();
-      result = null;
-      var shares = new ManagementClass("Win32_Share").GetInstances();
-
-      //System.Diagnostics.Debugger.Break();
-
-      foreach (var share in shares)
-      {
-        var path = share["Path"].ToString().ToLower();
-        if (!String.IsNullOrEmpty(path) && localpath.StartsWith(path))
-        {
-          var name = share["Name"].ToString();
-          var caption = share["Caption"].ToString();
-          var rest = localpath.Substring(path.Length);
-          result = String.Format(@"\\{0}\{1}\{2}", Environment.MachineName, name, rest);
-
-          return true;
-        }
-      }
-      return result != null;
-    }
-
-  }
 }

--- a/Microsoft.Research/DataStructures/Functional.cs
+++ b/Microsoft.Research/DataStructures/Functional.cs
@@ -1,1991 +1,2059 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+namespace Microsoft.Research.DataStructures
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
 
-namespace Microsoft.Research.DataStructures {
-
-  using System;
-  using System.Collections.Generic;
-  using System.Diagnostics.Contracts;
-  using System.IO;
-  using System.Linq;
-  using System.Text;
-
-  public static class Pair
-  {
-    public static Pair<L, R> For<L, R>(L l, R r) { return new Pair<L, R>(l, r); }
-
-    public static L One<L, R>(Pair<L, R> p) { return p.One; }
-    public static R Two<L, R>(Pair<L, R> p) { return p.Two; }
-    public static bool NotTwo<L>(Pair<L, bool> p) { return !p.Two; }
-  }
-
-  /// <summary>
-  /// Pair value
-  /// </summary>
-  /// <typeparam name="L">first component type</typeparam>
-  /// <typeparam name="R">second component type</typeparam>
-  [Serializable]
-  public struct Pair<L, R> : IEquatable<Pair<L,R>> {
-    /// <summary>
-    /// First component of pair
-    /// </summary>
-    public readonly L One;
-
-    /// <summary>
-    /// Second component of pair
-    /// </summary>
-    public readonly R Two;
-
-    /// <summary>
-    /// These flags are used to avoid boxing in GetHashCode and ToString
-    /// </summary>
-    private static readonly bool LIsReferenceType = (object)default(L) == null; // Thread-safe if L is thread-safe
-    private static readonly bool RIsReferenceType = (object)default(R) == null; // Thread-safe if R is thread-safe
-
-    /// <summary>
-    /// Pair constructor
-    /// </summary>
-    /// <param name="first">first component</param>
-    /// <param name="second">second component</param>
-    public Pair(L first, R second) {
-      this.One = first;
-      this.Two = second;
-    }
-
-    public override int GetHashCode()
+    public static class Pair
     {
-      var hc1 = (LIsReferenceType && One == null) ? 0 : One.GetHashCode();
-      var hc2 = (RIsReferenceType && Two == null) ? 0 : Two.GetHashCode();
+        public static Pair<L, R> For<L, R>(L l, R r) { return new Pair<L, R>(l, r); }
 
-      return hc1 + hc2;
-    }
-
-    public override string ToString() {
-      string oneStr = (LIsReferenceType && One == null) ? "<null>" : One.ToString();
-      string twoStr = (RIsReferenceType && Two == null) ? "<null>" : Two.ToString();
-      return String.Format("({0},{1})", oneStr, twoStr);
-    }
-
-    #region IEquatable<Pair<L,R>> Members
-
-    //^ [StateIndependent]
-    public bool Equals(Pair<L, R> other) {
-      bool result = (this.One is IEquatable<L>) ? (((IEquatable<L>)this.One).Equals(other.One)) : Object.Equals(this.One, other.One);
-      if (!result) return result;
-
-      return (this.Two is IEquatable<R>) ? (((IEquatable<R>)this.Two).Equals(other.Two)) : Object.Equals(this.Two, other.Two);
-    }
-
-    #endregion
-  }
-
-  /// <summary>
-  /// Pair value whose components are non-null
-  /// </summary>
-  /// <typeparam name="L">first component type</typeparam>
-  /// <typeparam name="R">second component type</typeparam>
-  public struct PairNonNull<L, R> 
-    : IEquatable<Pair<L, R>>
-    where L : class
-    where R : class
-  {
-    #region object invariant
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(One != null);
-      Contract.Invariant(Two != null);
-    }
-
-    #endregion
-
-    /// <summary>
-    /// First component of pair
-    /// </summary>
-    private L one;
-    public L One
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<L>() != null);
-
-        return this.one;
-      }
+        public static L One<L, R>(Pair<L, R> p) { return p.One; }
+        public static R Two<L, R>(Pair<L, R> p) { return p.Two; }
+        public static bool NotTwo<L>(Pair<L, bool> p) { return !p.Two; }
     }
 
     /// <summary>
-    /// Second component of pair
+    /// Pair value
     /// </summary>
-    private R two;
-    public R Two
+    /// <typeparam name="L">first component type</typeparam>
+    /// <typeparam name="R">second component type</typeparam>
+    [Serializable]
+    public struct Pair<L, R> : IEquatable<Pair<L, R>>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<R>() != null);
+        /// <summary>
+        /// First component of pair
+        /// </summary>
+        public readonly L One;
 
-        return this.two;
-      }
-    }
+        /// <summary>
+        /// Second component of pair
+        /// </summary>
+        public readonly R Two;
 
-    /// <summary>
-    /// Pair constructor
-    /// </summary>
-    /// <param name="first">first component - should be != null</param>
-    /// <param name="second">second component - shoule be != null</param>
-    public PairNonNull(L first, R second)
-    {
-      Contract.Requires(first != null);
-      Contract.Requires(second != null);
+        /// <summary>
+        /// These flags are used to avoid boxing in GetHashCode and ToString
+        /// </summary>
+        private static readonly bool LIsReferenceType = (object)default(L) == null; // Thread-safe if L is thread-safe
+        private static readonly bool RIsReferenceType = (object)default(R) == null; // Thread-safe if R is thread-safe
 
-      this.one = first;
-      this.two = second;
-    }
-
-    public override int GetHashCode()
-    {
-      var hc1 = One.GetHashCode();
-      var hc2 = Two.GetHashCode();
-
-      return hc1 + hc2;
-    }
-
-    public override string ToString()
-    {
-      string oneStr = One.ToString();
-      string twoStr = Two.ToString();
-      return String.Format("({0},{1})", oneStr, twoStr);
-    }
-
-    #region IEquatable<Pair<L,R>> Members
-
-    public bool Equals(Pair<L, R> other)
-    {
-      bool result = (this.One is IEquatable<L>) ? (((IEquatable<L>)this.One).Equals(other.One)) : Object.Equals(this.One, other.One);
-      if (!result) return result;
-
-      return (this.Two is IEquatable<R>) ? (((IEquatable<R>)this.Two).Equals(other.Two)) : Object.Equals(this.Two, other.Two);
-    }
-
-    #endregion
-  }
-
-  public static class STuple
-  {
-    public static STuple<A, B, C> For<A, B, C>(A first, B second, C third) { return new STuple<A, B, C>(first, second, third); }
-    public static STuple<A, B, C, D> For<A, B, C, D>(A first, B second, C third, D fourth) { return new STuple<A, B, C, D>(first, second, third, fourth); }
-  }
-
-  [Serializable]
-  public struct STuple<A, B, C> : IEquatable<STuple<A, B, C>>
-  {
-    /// <summary>
-    /// First component
-    /// </summary>
-    public readonly A One;
-
-    /// <summary>
-    /// Second component
-    /// </summary>
-    public readonly B Two;
-
-    /// <summary>
-    /// Third component
-    /// </summary>
-    public readonly C Three;
-
-
-    public STuple(A first, B second, C third)
-    {
-      this.One = first;
-      this.Two = second;
-      this.Three = third;
-    }
-
-    public override string ToString()
-    {
-      string oneStr = One == null ? "<null>" : One.ToString();
-      string twoStr = Two == null ? "<null>" : Two.ToString();
-      string threeStr = Three == null ? "<null>" : Three.ToString();
-      return String.Format("({0},{1},{2})", oneStr, twoStr, threeStr);
-    }
-
-    #region IEquatable<Tuple<A,B,C>> Members
-
-    //^ [StateIndependent]
-    public bool Equals(STuple<A,B,C> other)
-    {
-      bool result = (this.One is IEquatable<A>) ? (((IEquatable<A>)this.One).Equals(other.One)) : Object.Equals(this.One, other.One);
-      if (!result) return result;
-      result = (this.Two is IEquatable<B>) ? (((IEquatable<B>)this.Two).Equals(other.Two)) : Object.Equals(this.Two, other.Two);
-      if (!result) return result;
-      result = (this.Three is IEquatable<C>) ? (((IEquatable<C>)this.Three).Equals(other.Three)) : Object.Equals(this.Three, other.Three);
-      return result;
-    }
-
-    #endregion
-  }
-
-  public struct STuple<A, B, C, D> : IEquatable<STuple<A, B, C, D>>
-  {
-    /// <summary>
-    /// First component
-    /// </summary>
-    public readonly A One;
-
-    /// <summary>
-    /// Second component
-    /// </summary>
-    public readonly B Two;
-
-    /// <summary>
-    /// Third component
-    /// </summary>
-    public readonly C Three;
-
-    /// <summary>
-    /// Fourth component
-    /// </summary>
-    public readonly D Four;
-
-    public STuple(A first, B second, C third, D fourth)
-    {
-      this.One = first;
-      this.Two = second;
-      this.Three = third;
-      this.Four = fourth;
-    }
-
-    public override string ToString()
-    {
-      string oneStr = One == null ? "<null>" : One.ToString();
-      string twoStr = Two == null ? "<null>" : Two.ToString();
-      string threeStr = Three == null ? "<null>" : Three.ToString();
-      string fourStr = Four == null ? "<null>" : Four.ToString();
-      return String.Format("({0},{1},{2},{3})", oneStr, twoStr, threeStr, fourStr);
-    }
-
-    #region IEquatable<Tuple<A,B,C>> Members
-
-    //^ [StateIndependent]
-    public bool Equals(STuple<A, B, C, D> other)
-    {
-      bool result = (this.One is IEquatable<A>) ? (((IEquatable<A>)this.One).Equals(other.One)) : Object.Equals(this.One, other.One);
-      if (!result) return result;
-      result = (this.Two is IEquatable<B>) ? (((IEquatable<B>)this.Two).Equals(other.Two)) : Object.Equals(this.Two, other.Two);
-      if (!result) return result;
-      result = (this.Three is IEquatable<C>) ? (((IEquatable<C>)this.Three).Equals(other.Three)) : Object.Equals(this.Three, other.Three);
-
-      if (!result) return result;
-      result = (this.Four is IEquatable<C>) ? (((IEquatable<C>)this.Four).Equals(other.Four)) : Object.Equals(this.Four, other.Four);
- 
-      return result;
-    }
-
-    #endregion
-  }
-
-  [ContractVerification(true)]
-  public static class FList
-  {
-    /// <summary>
-    /// Returns a new list representing the appended lists
-    /// </summary>
-    [Pure]
-    public static FList<T>/*?*/ Append<T>(this FList<T>/*?*/ l1, FList<T>/*?*/ l2)
-    {
-      Contract.Ensures((l1 == null || l2 == null) || Contract.Result<FList<T>>() != null);
-      Contract.Ensures(l1 != null || Contract.Result<FList<T>>() == l2);
-      Contract.Ensures(l2 != null || Contract.Result<FList<T>>() == l1);
-
-      if (l1 == null) return l2;
-
-      if (l2 == null) return l1;
-
-      return l1.Tail.Append(l2).Cons(l1.Head);
-    }
-
-    /// <summary>
-    /// Gives the length of the list
-    /// </summary>
-    [Pure]
-    [ContractVerification(false)]
-    public static int Length<T>(this FList<T>/*?*/ l)
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      Contract.Ensures(Contract.Result<int>() >= 1 || l == null);
-      Contract.Ensures(Contract.Result<int>() <= 0 || l != null);
-      Contract.Ensures(Contract.Result<int>() <= 1 || l.Tail != null);
-
-      return FList<T>.Length(l);
-    }
-
-    /// <summary>
-    /// Construct a new list by consing the element to the head of tail list
-    /// </summary>
-    [Pure]
-    public static FList<T> Cons<T>(this FList<T>/*?*/ rest, T elem)
-    {
-      Contract.Ensures(Contract.Result<FList<T>>() != null);
-
-      return FList<T>.Cons(elem, rest);
-    }
-
-    [Pure]
-    public static FList<T> ConsIfNotAlreadyThere<T>(this FList<T> list, T what, Comparer<T> comparer = null)
-    {
-      Contract.Ensures(Contract.Result<FList<T>>() != null);
-
-      if(list == null || what == null)
-      {
-        return list.Cons(what);
-      }
-
-      if (comparer != null)
-      {
-        for (var curr = list; curr != FList<T>.Empty; curr = curr.Tail)
+        /// <summary>
+        /// Pair constructor
+        /// </summary>
+        /// <param name="first">first component</param>
+        /// <param name="second">second component</param>
+        public Pair(L first, R second)
         {
-          var head = curr.Head;
-          if (comparer.Compare(head, what) == 0)
-          {
-            return list;
-          }
+            this.One = first;
+            this.Two = second;
         }
-      }
-      else
-      {
-        for (var curr = list; curr != FList<T>.Empty; curr = curr.Tail)
+
+        public override int GetHashCode()
         {
-          var head = curr.Head;
-          if (what.Equals(head))
-          {
-            return list;
-          }
+            var hc1 = (LIsReferenceType && One == null) ? 0 : One.GetHashCode();
+            var hc2 = (RIsReferenceType && Two == null) ? 0 : Two.GetHashCode();
+
+            return hc1 + hc2;
         }
 
-      }
-      return list.Cons(what);
-    }
-
-
-
-    /// <summary>
-    /// Constructs a new list that represents the reversed original list
-    /// </summary>
-    [Pure]
-    public static FList<T>/*?*/ Reverse<T>(this FList<T>/*?*/ list)
-    {
-      Contract.Ensures(list == null || Contract.Result<FList<T>>() != null);
-
-      return FList<T>.Reverse(list);
-    }
-
-    /// <summary>
-    /// Constructs a new list that represents the reversed original list with the applied conversion
-    /// </summary>
-    [Pure]
-    public static FList<R>/*?*/ Reverse<T,R>(this FList<T>/*?*/ list, Func<T,R> converter)
-    {
-      Contract.Ensures(list == null || Contract.Result<FList<R>>() != null);
-
-      return FList<T>.Reverse(list, converter);
-    }
-
-    /// <summary>
-    /// Return a list that only contains elements satisfying predicate in the same order 
-    /// </summary>
-    /// <param name="predicate">Predicate to be satisfied to be in result</param>
-    [Pure]
-    public static FList<T> Filter<T>(this FList<T> list, Predicate<T> predicate)
-    {
-      Contract.Requires(predicate != null);
-
-      if (list == null) return null;
-      var tail = Filter(list.Tail, predicate);
-      if (!predicate(list.Head)) return tail;
-      if (tail == list.Tail) return list;
-      return tail.Cons(list.Head);
-    }
-
-    /// <summary>
-    /// Applies action to each element in list
-    /// </summary>
-    /// <param name="list">List iterated over</param>
-    /// <param name="action">Action called on each element</param>
-    public static void Apply<T>(this FList<T>/*?*/ list, Action<T> action)
-    {
-      FList<T>.Apply(list, action);
-    }
-
-    [Pure]
-    public static IEnumerable<T> GetEnumerable<T>(this FList<T>/*?*/ list)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<T>>() != null);
-
-      return FList<T>.PrivateGetEnumerable(list);
-    }
-
-    [Pure]
-    public static bool IsEmpty<T>(this FList<T> list)
-    {
-      Contract.Ensures(Contract.Result<bool>() == (list == null));
-      return list == null;
-    }
-
-    [Pure]
-    public static T Last<T>(this FList<T> list)
-    {
-      Contract.Requires(!list.IsEmpty());
-      if (list.Tail == null)
-      {
-        return list.Head;
-      }
-      return Last(list.Tail);
-    }
-
-    [Pure]
-    // Needed when looking at access paths
-    public static T ButLast<T>(this FList<T> list)
-    {
-      Contract.Requires(!list.IsEmpty());
-      Contract.Requires(list.Tail != null);
-      return ButLastInternal(list.Tail, list.Head);
-    }
-
-    [Pure]
-    private static T ButLastInternal<T>(this FList<T> list, T butLast)
-    {
-      Contract.Requires(list != null);
-
-      if (list.Tail == null)
-        return butLast;
-      return ButLastInternal(list.Tail, list.Head);
-    }
-
-    [Pure]
-    public static FList<T> Coerce<S, T>(this FList<S> list) where S : T
-    {
-      return list.Map(orig => (T)orig);
-    }
-
-    [Pure]
-    public static bool Contains<T>(this FList<T> list, T value) where T : IEquatable<T>
-    {
-      for (; list != null; list = list.Tail)
-      {
-        if (list.Head.Equals(value)) return true;
-      }
-      return false;
-    }
-
-    [Pure]
-    public static FList<T> Singleton<T>(T elem)
-    {
-      Contract.Ensures(Contract.Result<FList<T>>() != null);
-
-      return Cons(elem, null);
-    }
-
-    [Pure]
-    public static FList<T> Cons<T>(T elem, FList<T> tail)
-    {
-      Contract.Ensures(Contract.Result<FList<T>>() != null);
-
-      return tail.Cons(elem);
-    }
-
-    [Pure]
-    public static FList<C> Product<A, B, C>(FList<A> alist, FList<B> blist, Func<A, B, C> mapper, FList<C> accumulator = null)
-    {
-      Contract.Requires(mapper != null);
-
-      var alist2 = alist;
-      while (alist2 != null)
-      {
-        var blist2 = blist;
-        while (blist2 != null)
+        public override string ToString()
         {
-          accumulator = accumulator.Cons(mapper(alist2.Head, blist2.Head));
-          blist2 = blist2.Tail;
+            string oneStr = (LIsReferenceType && One == null) ? "<null>" : One.ToString();
+            string twoStr = (RIsReferenceType && Two == null) ? "<null>" : Two.ToString();
+            return String.Format("({0},{1})", oneStr, twoStr);
         }
-        alist2 = alist2.Tail;
-      }
-      return accumulator;
-    }
 
-    [Pure]
-    public static FList<B> Product<A, B>(this FList<FList<A>> lists, Func<FList<A>, B> combine, FList<B> accumulator = null)
-    {
-      if (lists == null) return accumulator;
-      var first = lists.Head;
-      if (lists.Tail == null) { return first.Map(e => combine(Singleton(e)), accumulator); }
-      while (first != null)
-      {
-        var subProducts = Product(lists.Tail, l => l);
-        Contract.Assume(first != null, "for some reason first gets havoced after product");
-        accumulator = subProducts.Map(rest => combine(rest.Cons(first.Head)), accumulator);
-        first = first.Tail;
-      }
-      return accumulator;
-    }
+        #region IEquatable<Pair<L,R>> Members
 
-    [Pure]
-    public static FList<B> Map<A, B>(this IEnumerable<A> enumerable, Func<A, B> mapper)
-    {
-      Contract.Requires(enumerable != null);
-      Contract.Requires(mapper != null);
-
-      FList<B> result = null;
-      foreach (var a in enumerable)
-      {
-        result = result.Cons(mapper(a));
-      }
-      return result.Reverse();
-    }
-
-    /// <summary>
-    /// Transforms a T list into an S list using the converter
-    /// </summary>
-    [Pure]
-    public static FList<S>/*?*/ Map<T, S>(this FList<T>/*?*/ list, Converter<T, S> converter, FList<S> accumulator = null)
-    {
-      Contract.Requires(converter != null);
-
-      if (list == null) return accumulator;
-      FList<S>/*?*/ tail = list.Tail.Map(converter, accumulator);
-      return tail.Cons(converter(list.Head));
-    }
-
-    /// <summary>
-    /// Transforms a T list into an S list using the converter
-    /// </summary>
-    [Pure]
-    public static FList<S>/*?*/ Map<T, S>(this FList<T>/*?*/ list, Converter<T, S> converter, int maxLength, FList<S> accumulator = null)
-    {
-      Contract.Requires(converter != null);
-
-      if (list == null) return accumulator;
-      if (maxLength <= 0) return accumulator;
-      FList<S>/*?*/ tail = list.Tail.Map(converter, maxLength -1, accumulator);
-      return tail.Cons(converter(list.Head));
-    }
-
-    [Pure]
-    public static T[] ToArray<T>(this FList<T> list)
-    {
-      Contract.Ensures(Contract.Result<T[]>() != null);
-
-      var result = new T[list.Length()];
-      var i = 0;
-      while (list != null)
-      {
-        Contract.Assume(i < result.Length, "need to relate list length with iteration");
-        result[i++] = list.Head;
-        list = list.Tail;
-      }
-      return result;
-    }
-  }
-
-  /// <summary>
-  /// Functional lists. null represents the empty list.
-  /// </summary>
-  [Serializable]
-  public class FList<T> 
-  {
-
-    #region Privates
-    private T elem;
-
-    private FList<T>/*?*/ tail;
-
-    private int count;
-    #endregion
-
-    public static FList<T> Cons(T elem, FList<T> tail)
-    {
-      Contract.Ensures(Contract.Result<FList<T>>() != null);
-
-      return new FList<T>(elem, tail);
-    }
-
-    FList(T elem, FList<T>/*?*/ tail)
-    {
-      this.elem = elem;
-      this.tail = tail;
-      this.count = Length(tail) + 1;
-    }
-
-    /// <summary>
-    /// The head element of the list
-    /// </summary>
-    public T Head { get { return this.elem; } }
-
-    /// <summary>
-    /// The tail of the list
-    /// </summary>
-    public FList<T>/*?*/ Tail {
-      get { return this.tail; }
-    }
-
-    /// <summary>
-    /// Reusable Empty list representation
-    /// </summary>
-    public const FList<T>/*?*/ Empty = null;
-
-    /// <summary>
-    /// Constructs a new list that represents the reversed original list
-    /// </summary>
-    public static FList<T>/*?*/ Reverse(FList<T>/*?*/ list) {
-      Contract.Ensures(Contract.Result<FList<T>>() != null || list == null);
-
-      if (list == null || list.Tail == null) return list;
-
-      FList<T>/*?*/ tail = null;
-
-      while (list != null) {
-        tail = tail.Cons(list.elem);
-        list = list.tail;
-      }
-      return tail;
-    }
-
-    /// <summary>
-    /// Constructs a new list that represents the reversed original list
-    /// </summary>
-    public static FList<R>/*?*/ Reverse<R>(FList<T>/*?*/ list, Func<T,R> converter)
-    {
-      Contract.Ensures(Contract.Result<FList<R>>() != null || list == null);
-
-      if (list == null) return null;
-
-      FList<R>/*?*/ result = null;
-
-      while (list != null)
-      {
-        result = result.Cons(converter(list.elem));
-        list = list.tail;
-      }
-      return result;
-    }
-
-
-    internal static IEnumerable<T> PrivateGetEnumerable(FList<T>/*?*/ list)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<T>>() != null);
-
-      FList<T>/*?*/ current = list;
-      while (current != null)
-      {
-        T next = current.Head;
-        current = current.Tail;
-        yield return next;
-      }
-      yield break;
-    }
-
-
-
-    /// <summary>
-    /// Query the list for the presence of an element
-    /// </summary>
-    public static bool Contains(FList<T>/*?*/ l, T/*!*/ o) {
-      if (l == null) return false;
-
-      if (o is IEquatable<T>) { if (((IEquatable<T>)o).Equals(l.elem)) return true; }
-      else if (o.Equals(l.elem)) return true;
-
-      return Contains(l.tail, o);
-    }
-
-
-    /// <summary>
-    /// Applies action to each element in list
-    /// </summary>
-    /// <param name="list">List iterated over</param>
-    /// <param name="action">Action called on each element</param>
-    public static void Apply(FList<T>/*?*/ list, Action<T> action) {
-      while (list != null) {
-        action(list.Head);
-        list = list.Tail;
-      }
-    }
-
-
-    /// <summary>
-    /// Given two sorted lists, compute their intersection
-    /// </summary>
-    /// <param name="l1">sorted list</param>
-    /// <param name="l2">sorted list</param>
-    /// <returns>sorted intersection</returns>
-    public static FList<T>/*?*/ Intersect(FList<T>/*?*/ l1, FList<T>/*?*/ l2) {
-      if (l1 == null || l2 == null) return null;
-
-      int comp = System.Collections.Comparer.Default.Compare(l1.Head, l2.Head);
-      if (comp < 0) {
-        return Intersect(l1.Tail, l2);
-      }
-      if (comp > 0) {
-        return Intersect(l1, l2.Tail);
-      }
-      // equal
-      return Intersect(l1.Tail, l2.Tail).Cons(l1.Head);
-    }
-
-    /// <summary>
-    /// Returns a new list that contains the elements of the argument list in increasing order
-    /// </summary>
-    public static FList<T>/*?*/ Sort(FList<T>/*?*/ l) {
-      return Sort(l, null);
-    }
-
-    private static FList<T>/*?*/ Sort(FList<T>/*?*/ l, FList<T>/*?*/ tail) {
-      // quicksort
-      if (l == null) return tail;
-
-      T pivot = l.Head;
-
-      FList<T>/*?*/ less;
-      FList<T>/*?*/ more;
-      Partition(l.Tail, pivot, out less, out more);
-
-      return Sort(less, Sort(more, tail).Cons(pivot));
-    }
-
-    private static void Partition(FList<T>/*?*/ l, T pivot, out FList<T>/*?*/ less, out FList<T>/*?*/ more) {
-      less = null;
-      more = null;
-      if (l == null) {
-        return;
-      }
-      foreach (T value in l.GetEnumerable()) {
-        if (System.Collections.Comparer.Default.Compare(value, pivot) <= 0) {
-          less = less.Cons(value);
-        }
-        else {
-          more = more.Cons(value);
-        }
-      }
-    }
-    /// <summary>
-    /// Gives the length of the list
-    /// </summary>
-    [Pure]
-    public static int Length(FList<T>/*?*/ l)
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-
-      if (l == null) { return 0; }
-      else return l.count;
-    }
-
-    /// <summary>
-    /// Generates a string representing the list
-    /// </summary>
-    /// <returns></returns>
-    //^ [Confined]
-    public override string ToString() {
-      var sb = new StringBuilder();
-
-      this.BuildString(sb);
-      return sb.ToString();
-    }
-
-    /// <summary>
-    /// Adds a string representation of the list to the StringBuilder
-    /// </summary>
-    public void BuildString(StringBuilder sb) {
-      string elemStr = this.elem == null ? "<null>" : this.elem.ToString();
-      if (this.tail != null) {
-        sb.AppendFormat("{0},", elemStr);
-        this.tail.BuildString(sb);
-      }
-      else {
-        sb.Append(elemStr);
-      }
-    }
-
-
-  }
-
-  public enum VisitStatus { ContinueVisit, StopVisit }
-
-  public delegate VisitStatus VisitMapPair<Key,Value>(Key key, Value value);
-
-  public partial interface IFunctionalMap<Key,Val> : IEquatable<IFunctionalMap<Key,Val>> {
-
-    Val/*?*/ this[Key/*!*/ key] { get; }
-    [Pure]
-    IFunctionalMap<Key,Val> Add(Key/*!*/ key, Val val);
-    [Pure]
-    IFunctionalMap<Key,Val> Remove(Key/*!*/ key);
-    [Pure]
-    bool Contains(Key/*!*/ key);
-    /// <summary>
-    /// For non-empty domains, returns one of the keys
-    /// </summary>
-    Key AnyKey { get; }
-    IEnumerable<Key> Keys { get; }
-    void Visit(VisitMapPair<Key/*!*/,Val> visitor);
-    int Count { get; }
-
-    /// <summary>
-    /// Returns an emtpy map
-    /// </summary>
-    IFunctionalMap<Key, Val> EmptyMap { get; }
-
-    void Dump(System.IO.TextWriter tw);
-  }
-
-  #region IFunctionalMap<Key,Val> contract binding
-  [ContractClass(typeof(IFunctionalMapContract<,>))]
-  public partial interface IFunctionalMap<Key,Val>
-  {
-
-  }
-
-  [ContractClassFor(typeof(IFunctionalMap<,>))]
-  abstract class IFunctionalMapContract<Key,Val>: IFunctionalMap<Key,Val>
-  {
-    #region IFunctionalMap<Key,Val> Members
-
-    public Val this[Key key]
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public IFunctionalMap<Key, Val> Add(Key key, Val val)
-    {
-      Contract.Ensures(Contract.Result<IFunctionalMap<Key,Val>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IFunctionalMap<Key, Val> Remove(Key key)
-    {
-      Contract.Ensures(Contract.Result<IFunctionalMap<Key, Val>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public bool Contains(Key key)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Key AnyKey
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public IEnumerable<Key> Keys
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<Key>>() != null);
-        throw new NotImplementedException();
-      }
-    }
-
-    public void Visit(VisitMapPair<Key, Val> visitor)
-    {
-      throw new NotImplementedException();
-    }
-
-    public int Count
-    {
-      get { 
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        throw new NotImplementedException(); 
-      }
-    }
-
-    public IFunctionalMap<Key, Val> EmptyMap
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IFunctionalMap<Key, Val>>() != null);
-
-        throw new NotImplementedException();
-      }
-    }
-
-    public void Dump(TextWriter tw)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IEquatable<IFunctionalMap<Key,Val>> Members
-
-    public bool Equals(IFunctionalMap<Key, Val> other)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-  }
-  #endregion
-
-  [ContractClass(typeof(IFunctionalIntMapContracts<>))]
-  public interface IFunctionalIntMap<B> {
-    /*
-     * Ideally, the key type in this API would be 
-     * an interface IHasUniqueId with a single property
-     * that return an int. However, in our use of this
-     * API, we need to plug in objects that cannot be
-     * unified under a common interface because we don't 
-     * own some of the classes. So, awkwardly, we ask
-     * the client to pass in BOTH a key object and its
-     * integer under which it will be stored.
-     */
-    [Pure]
-    B Lookup(int keyNumber);
-    B this[int keyNumber] { get; }
-    // For a non-empty map, returns any value
-    B Any { get; }
-    [Pure]
-    bool Contains(int keyNumber);
-    [Pure]
-    IFunctionalIntMap<B> Add(int keyNumber, B val);
-    IEnumerable<B> Values { get; }
-    IEnumerable<int> Keys { get; }
-    void Visit(Action<B> action);
-    void Visit(Action<int, B> action);
-    [Pure]
-    IFunctionalIntMap<B> Remove(int keyNumber);
-    int Count { get; }
-
-    void Dump(System.IO.TextWriter tw);
-  }
-
-  [ContractClassFor(typeof(IFunctionalIntMap<>))]
-  abstract class IFunctionalIntMapContracts<B> 
-    : IFunctionalIntMap<B>
-  {
-    public IFunctionalIntMap<B> Add(int keyNumber, B val)
-    {
-      Contract.Ensures(Contract.Result<IFunctionalIntMap<B>>() != null);
-
-      return null;
-    }
-
-    #region No Contracts
-    public B Lookup(int keyNumber)
-    {
-      throw new NotImplementedException();
-    }
-
-    public B this[int keyNumber]
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public B Any
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool Contains(int keyNumber)
-    {
-      throw new NotImplementedException();
-    }
-
-
-
-    public IEnumerable<B> Values
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public IEnumerable<int> Keys
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public void Visit(Action<B> action)
-    {
-      throw new NotImplementedException();
-    }
-
-    public void Visit(Action<int, B> action)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IFunctionalIntMap<B> Remove(int keyNumber)
-    {
-      throw new NotImplementedException();
-    }
-
-    public int Count
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public void Dump(TextWriter tw)
-    {
-      throw new NotImplementedException();
-    }
-    #endregion
-  }
-
-  public class FunctionalIntMap<B>
-  {
-    // Adapted from Okasaki and Gill, "Fast mergeable integer maps", ML Workshop, 1998.
-
-    public static IFunctionalIntMap<B> EmptyMap
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IFunctionalIntMap<B>>() != null); // F: addded
-        return Empty.E;
-      }
-    }
-
-    private abstract class PatriciaTree : IFunctionalIntMap<B>
-    {
-      public abstract B Lookup (int keyNumber);
-
-      public B this[int keyNumber] { get { return this.Lookup(keyNumber); } }
-
-      public abstract B Any { get; }
-
-      public abstract IFunctionalIntMap<B> Add (int keyNumber, B val);
-
-      public abstract int Count { get; }
-
-      public abstract bool Contains(int keyNumber);
-
-      internal abstract void AddValues (List<B> list);
-
-      internal abstract void AddKeys(List<int> list);
-
-      public abstract IFunctionalIntMap<B> Remove (int keyNumber);
-
-      internal abstract void AppendToBuffer (System.Text.StringBuilder buffer);
-
-      protected abstract int KeyNumber { get; }
-
-      internal abstract void Dump (System.IO.TextWriter tw, string prefix);
-
-      public void Dump (System.IO.TextWriter tw) { this.Dump(tw, ""); }
-
-      public IEnumerable<B> Values 
-      {
-        // If gathering a list is too expensive, we can change this one day
-        // That's why I made the return type IEnumerable rather than ICollection. RD
-        get 
-        { 
-          List<B> list = new List<B>(this.Count);
-          this.AddValues(list);
-          return list;
-        } 
-      }
-
-      public IEnumerable<int> Keys
-      {
-        // If gathering a list is too expensive, we can change this one day
-        // That's why I made the return type IEnumerable rather than ICollection. RD
-        get
+        //^ [StateIndependent]
+        public bool Equals(Pair<L, R> other)
         {
-          List<int> list = new List<int>(this.Count);
-          this.AddKeys(list);
-          return list;
+            bool result = (this.One is IEquatable<L>) ? (((IEquatable<L>)this.One).Equals(other.One)) : Object.Equals(this.One, other.One);
+            if (!result) return result;
+
+            return (this.Two is IEquatable<R>) ? (((IEquatable<R>)this.Two).Equals(other.Two)) : Object.Equals(this.Two, other.Two);
         }
-      }
 
-      public abstract void Visit(Action<B> action);
-      public abstract void Visit(Action<int, B> action);
-
-      //^ [Confined]
-      public override string ToString ()
-      {
-        System.Text.StringBuilder buffer = new System.Text.StringBuilder();
-        buffer.Append("[ ");
-        this.AppendToBuffer(buffer);
-        buffer.Append("]");
-        return buffer.ToString();
-      }
-
-      protected static int LowestBit (int x) { return x & -x; }
-      protected static int BranchingBit (int p0, int p1) { return LowestBit(p0 ^ p1); }
-      protected static int MaskBits (int k, int m) { return k & (m-1); }
-      protected static bool ZeroBit (int k, int m) { return (k & m) == 0; }
-      protected static bool MatchPrefix (int k, int p, int m) { return MaskBits(k,m) == p; }
-
-
-      protected static PatriciaTree Join (PatriciaTree t0, PatriciaTree t1)
-      {
-        int p0 = t0.KeyNumber, p1 = t1.KeyNumber;
-        int m = BranchingBit(p0, p1);
-        return ZeroBit(p0, m) ?
-          new Branch(MaskBits(p0,m), m, t0, t1) :
-          new Branch(MaskBits(p0,m), m, t1, t0);
-      }
+        #endregion
     }
 
-
-
-    private class Empty : PatriciaTree
+    /// <summary>
+    /// Pair value whose components are non-null
+    /// </summary>
+    /// <typeparam name="L">first component type</typeparam>
+    /// <typeparam name="R">second component type</typeparam>
+    public struct PairNonNull<L, R>
+      : IEquatable<Pair<L, R>>
+      where L : class
+      where R : class
     {
-      public static readonly Empty E = new Empty(); // Thread-safe
+        #region object invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(One != null);
+            Contract.Invariant(Two != null);
+        }
 
-      protected override int KeyNumber { get { throw new System.NotImplementedException(); } }
+        #endregion
 
-      public override B Lookup(int key) { return default(B); }
+        /// <summary>
+        /// First component of pair
+        /// </summary>
+        private L one;
+        public L One
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<L>() != null);
 
-      public override B Any
-      {
-        get { return default(B); }
-      }
-
-      public override IFunctionalIntMap<B> Add(int keyNumber, B val) 
-      {  
-        return new Leaf(keyNumber, val); 
-      }
-
-      public override IFunctionalIntMap<B> Remove (int keyNumber) { return this; }
-
-      public override int Count { get { return 0; } }
-
-      public override bool Contains(int keyNumber) {
-        return false;
-      }
-
-      internal override void AddValues (List<B> list) { }
-
-      internal override void AddKeys(List<int> list) { }
-
-      public override void Visit(Action<B> action) { 
-        // do nothing
-      }
-
-      public override void Visit(Action<int, B> action)
-      {
-        // do nothing
-      }
-
-      internal override void AppendToBuffer(System.Text.StringBuilder buffer) { }
-
-      internal override void Dump (System.IO.TextWriter tw, string prefix) { tw.WriteLine(prefix + "<Empty/>"); }
-    }
-
-
-
-    private class Leaf : PatriciaTree
-    {
-      public readonly int UniqueId;
-      public readonly B Value;
-
-      public Leaf (int k, B val) { this.UniqueId = k; this.Value = val; }
-
-      protected override int KeyNumber { get { return this.UniqueId; } }
-
-      public override B Lookup(int key) 
-      { 
-        return key == this.UniqueId ? this.Value : default(B); 
-      }
-
-      public override B Any
-      {
-        get { return this.Value; }
-      }
-
-      public override IFunctionalIntMap<B> Add(int keyNumber, B val) 
-      { 
-        int thisUniqueId = this.UniqueId;
-        return (keyNumber == thisUniqueId) ? 
-          new Leaf(keyNumber, val) : 
-          Join(new Leaf(keyNumber, val), this); 
-      }
-
-      public override IFunctionalIntMap<B> Remove (int keyNumber) 
-      { 
-        return keyNumber == this.UniqueId ? Empty.E : (IFunctionalIntMap<B>)this; 
-      }
-
-      public override int Count { get { return 1; } }
-
-      public override bool Contains(int keyNumber) {
-        return this.UniqueId == keyNumber;
-      }
-
-      internal override void AddValues (List<B> list) { list.Add(this.Value); }
-
-      internal override void AddKeys(List<int> list) { list.Add(this.UniqueId); }
-
-      public override void Visit(Action<B> action)
-      {
-        action(Value);
-      }
-      public override void Visit(Action<int, B> action)
-      {
-        action(this.KeyNumber, this.Value);
-      }
-
-      internal override void AppendToBuffer (System.Text.StringBuilder buffer) 
-      { 
-        buffer.AppendFormat("{0}->{1} ", this.KeyNumber, this.Value);
-      }
-
-      internal override void Dump (System.IO.TextWriter tw, string prefix) 
-      { 
-        tw.WriteLine(prefix + "<Leaf KeyInt={0} Value='{1}'/>", UniqueId, Value); 
-      }
-    }
-
-
-
-    private class Branch : PatriciaTree
-    {
-      public readonly int Prefix;
-      public readonly int Mask;
-      public readonly PatriciaTree Left, Right;
-      private readonly int count;
-
-      [ContractInvariantMethod]
-      [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.Left != null);
-        Contract.Invariant(this.Right != null);
-      }
-
-      public Branch (int prefix, int mask, PatriciaTree left, PatriciaTree right) 
-      {
-        Contract.Requires(left != null);
-        Contract.Requires(right != null);
-
-        this.Prefix = prefix;
-        this.Mask = mask; 
-        this.Left = left; 
-        this.Right = right; 
-        this.count = left.Count + right.Count;
-      }
-
-      protected override int KeyNumber { get { return this.Prefix; } }
-
-      public override B Lookup (int key) 
-      {
-        Branch current = this;
-        do {
-          if (ZeroBit(key, current.Mask)) {
-            Branch next = current.Left as Branch;
-            if (next == null) {
-              return current.Left.Lookup(key);
+                return one;
             }
-            current = next;
-          }
-          else {
-            Branch next = current.Right as Branch;
-            if (next == null) {
-              return current.Right.Lookup(key);
+        }
+
+        /// <summary>
+        /// Second component of pair
+        /// </summary>
+        private R two;
+        public R Two
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<R>() != null);
+
+                return two;
             }
-            current = next;
-          }
-        } while (true);
-      }
+        }
 
-      public override B Any
-      {
-        get { return Left.Any; }
-      }
-
-      public override IFunctionalIntMap<B> Add(int keyNumber, B val) 
-      { 
-        if (MatchPrefix(keyNumber, this.Prefix, this.Mask))
+        /// <summary>
+        /// Pair constructor
+        /// </summary>
+        /// <param name="first">first component - should be != null</param>
+        /// <param name="second">second component - shoule be != null</param>
+        public PairNonNull(L first, R second)
         {
-          if (ZeroBit(keyNumber, this.Mask))
-          {
-            return new Branch(this.Prefix, this.Mask, 
-              (PatriciaTree) this.Left.Add(keyNumber, val), this.Right);
-          }
-          else
-          {
-            return new Branch(this.Prefix, this.Mask, this.Left, 
-              (PatriciaTree) this.Right.Add(keyNumber, val));
-          }
-        }
-        else
-          return Join(new Leaf(keyNumber, val), this);
-      }
+            Contract.Requires(first != null);
+            Contract.Requires(second != null);
 
-      public override IFunctionalIntMap<B> Remove (int keyNumber)
-      {
-        if (ZeroBit(keyNumber, this.Mask))
+            one = first;
+            two = second;
+        }
+
+        public override int GetHashCode()
         {
-          PatriciaTree newLeft = (PatriciaTree)this.Left.Remove(keyNumber);
-          if (newLeft is Empty)
-            return this.Right;
-          return Join(newLeft, this.Right);
+            var hc1 = One.GetHashCode();
+            var hc2 = Two.GetHashCode();
+
+            return hc1 + hc2;
         }
-        else
+
+        public override string ToString()
         {
-          PatriciaTree newRight = (PatriciaTree)this.Right.Remove(keyNumber);
-          if (newRight is Empty)
-            return this.Left;
-          return Join(this.Left, newRight);
+            string oneStr = One.ToString();
+            string twoStr = Two.ToString();
+            return String.Format("({0},{1})", oneStr, twoStr);
         }
-      }
 
-      public override int Count { get { return this.count; } }
+        #region IEquatable<Pair<L,R>> Members
 
-      public override bool Contains(int keyNumber) {
-        if (MatchPrefix(keyNumber, this.Prefix, this.Mask)) {
-          if (ZeroBit(keyNumber, this.Mask)) {
-            return this.Left.Contains(keyNumber);
-          }
-          else {
-            return this.Right.Contains(keyNumber);
-          }
+        public bool Equals(Pair<L, R> other)
+        {
+            bool result = (this.One is IEquatable<L>) ? (((IEquatable<L>)this.One).Equals(other.One)) : Object.Equals(this.One, other.One);
+            if (!result) return result;
+
+            return (this.Two is IEquatable<R>) ? (((IEquatable<R>)this.Two).Equals(other.Two)) : Object.Equals(this.Two, other.Two);
         }
-        else
-          return false;
-      }
 
-
-      internal override void AddValues (List<B> list) 
-      { 
-        this.Left.AddValues(list);
-        this.Right.AddValues(list);
-      }
-
-      internal override void AddKeys(List<int> list)
-      {
-        this.Left.AddKeys(list);
-        this.Right.AddKeys(list);
-      }
-
-      public override void Visit(Action<B> action) {
-        Left.Visit(action);
-        Right.Visit(action);
-      }
-
-      public override void Visit(Action<int, B> action)
-      {
-        Left.Visit(action);
-        Right.Visit(action);
-      }
-
-      internal override void AppendToBuffer(System.Text.StringBuilder buffer) 
-      { 
-        this.Left.AppendToBuffer(buffer);
-        this.Right.AppendToBuffer(buffer);
-      }
-
-      internal override void Dump (System.IO.TextWriter tw, string prefix) 
-      { 
-        tw.WriteLine(prefix + "<Branch Prefix={0} Mask={1}>", Prefix, Mask); 
-        this.Left.Dump(tw, prefix + "  ");
-        this.Right.Dump(tw, prefix + "  ");
-        tw.WriteLine(prefix + "</Branch>");
-      }
+        #endregion
     }
 
+    public static class STuple
+    {
+        public static STuple<A, B, C> For<A, B, C>(A first, B second, C third) { return new STuple<A, B, C>(first, second, third); }
+        public static STuple<A, B, C, D> For<A, B, C, D>(A first, B second, C third, D fourth) { return new STuple<A, B, C, D>(first, second, third, fourth); }
+    }
 
-  }
+    [Serializable]
+    public struct STuple<A, B, C> : IEquatable<STuple<A, B, C>>
+    {
+        /// <summary>
+        /// First component
+        /// </summary>
+        public readonly A One;
+
+        /// <summary>
+        /// Second component
+        /// </summary>
+        public readonly B Two;
+
+        /// <summary>
+        /// Third component
+        /// </summary>
+        public readonly C Three;
 
 
-  public class FunctionalMap<A,B> : IFunctionalMap<A,B> where A:IEquatable<A> {
+        public STuple(A first, B second, C third)
+        {
+            this.One = first;
+            this.Two = second;
+            this.Three = third;
+        }
+
+        public override string ToString()
+        {
+            string oneStr = One == null ? "<null>" : One.ToString();
+            string twoStr = Two == null ? "<null>" : Two.ToString();
+            string threeStr = Three == null ? "<null>" : Three.ToString();
+            return String.Format("({0},{1},{2})", oneStr, twoStr, threeStr);
+        }
+
+        #region IEquatable<Tuple<A,B,C>> Members
+
+        //^ [StateIndependent]
+        public bool Equals(STuple<A, B, C> other)
+        {
+            bool result = (this.One is IEquatable<A>) ? (((IEquatable<A>)this.One).Equals(other.One)) : Object.Equals(this.One, other.One);
+            if (!result) return result;
+            result = (this.Two is IEquatable<B>) ? (((IEquatable<B>)this.Two).Equals(other.Two)) : Object.Equals(this.Two, other.Two);
+            if (!result) return result;
+            result = (this.Three is IEquatable<C>) ? (((IEquatable<C>)this.Three).Equals(other.Three)) : Object.Equals(this.Three, other.Three);
+            return result;
+        }
+
+        #endregion
+    }
+
+    public struct STuple<A, B, C, D> : IEquatable<STuple<A, B, C, D>>
+    {
+        /// <summary>
+        /// First component
+        /// </summary>
+        public readonly A One;
+
+        /// <summary>
+        /// Second component
+        /// </summary>
+        public readonly B Two;
+
+        /// <summary>
+        /// Third component
+        /// </summary>
+        public readonly C Three;
+
+        /// <summary>
+        /// Fourth component
+        /// </summary>
+        public readonly D Four;
+
+        public STuple(A first, B second, C third, D fourth)
+        {
+            this.One = first;
+            this.Two = second;
+            this.Three = third;
+            this.Four = fourth;
+        }
+
+        public override string ToString()
+        {
+            string oneStr = One == null ? "<null>" : One.ToString();
+            string twoStr = Two == null ? "<null>" : Two.ToString();
+            string threeStr = Three == null ? "<null>" : Three.ToString();
+            string fourStr = Four == null ? "<null>" : Four.ToString();
+            return String.Format("({0},{1},{2},{3})", oneStr, twoStr, threeStr, fourStr);
+        }
+
+        #region IEquatable<Tuple<A,B,C>> Members
+
+        //^ [StateIndependent]
+        public bool Equals(STuple<A, B, C, D> other)
+        {
+            bool result = (this.One is IEquatable<A>) ? (((IEquatable<A>)this.One).Equals(other.One)) : Object.Equals(this.One, other.One);
+            if (!result) return result;
+            result = (this.Two is IEquatable<B>) ? (((IEquatable<B>)this.Two).Equals(other.Two)) : Object.Equals(this.Two, other.Two);
+            if (!result) return result;
+            result = (this.Three is IEquatable<C>) ? (((IEquatable<C>)this.Three).Equals(other.Three)) : Object.Equals(this.Three, other.Three);
+
+            if (!result) return result;
+            result = (this.Four is IEquatable<C>) ? (((IEquatable<C>)this.Four).Equals(other.Four)) : Object.Equals(this.Four, other.Four);
+
+            return result;
+        }
+
+        #endregion
+    }
+
+    [ContractVerification(true)]
+    public static class FList
+    {
+        /// <summary>
+        /// Returns a new list representing the appended lists
+        /// </summary>
+        [Pure]
+        public static FList<T>/*?*/ Append<T>(this FList<T>/*?*/ l1, FList<T>/*?*/ l2)
+        {
+            Contract.Ensures((l1 == null || l2 == null) || Contract.Result<FList<T>>() != null);
+            Contract.Ensures(l1 != null || Contract.Result<FList<T>>() == l2);
+            Contract.Ensures(l2 != null || Contract.Result<FList<T>>() == l1);
+
+            if (l1 == null) return l2;
+
+            if (l2 == null) return l1;
+
+            return l1.Tail.Append(l2).Cons(l1.Head);
+        }
+
+        /// <summary>
+        /// Gives the length of the list
+        /// </summary>
+        [Pure]
+        [ContractVerification(false)]
+        public static int Length<T>(this FList<T>/*?*/ l)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            Contract.Ensures(Contract.Result<int>() >= 1 || l == null);
+            Contract.Ensures(Contract.Result<int>() <= 0 || l != null);
+            Contract.Ensures(Contract.Result<int>() <= 1 || l.Tail != null);
+
+            return FList<T>.Length(l);
+        }
+
+        /// <summary>
+        /// Construct a new list by consing the element to the head of tail list
+        /// </summary>
+        [Pure]
+        public static FList<T> Cons<T>(this FList<T>/*?*/ rest, T elem)
+        {
+            Contract.Ensures(Contract.Result<FList<T>>() != null);
+
+            return FList<T>.Cons(elem, rest);
+        }
+
+        [Pure]
+        public static FList<T> ConsIfNotAlreadyThere<T>(this FList<T> list, T what, Comparer<T> comparer = null)
+        {
+            Contract.Ensures(Contract.Result<FList<T>>() != null);
+
+            if (list == null || what == null)
+            {
+                return list.Cons(what);
+            }
+
+            if (comparer != null)
+            {
+                for (var curr = list; curr != FList<T>.Empty; curr = curr.Tail)
+                {
+                    var head = curr.Head;
+                    if (comparer.Compare(head, what) == 0)
+                    {
+                        return list;
+                    }
+                }
+            }
+            else
+            {
+                for (var curr = list; curr != FList<T>.Empty; curr = curr.Tail)
+                {
+                    var head = curr.Head;
+                    if (what.Equals(head))
+                    {
+                        return list;
+                    }
+                }
+            }
+            return list.Cons(what);
+        }
+
+
+
+        /// <summary>
+        /// Constructs a new list that represents the reversed original list
+        /// </summary>
+        [Pure]
+        public static FList<T>/*?*/ Reverse<T>(this FList<T>/*?*/ list)
+        {
+            Contract.Ensures(list == null || Contract.Result<FList<T>>() != null);
+
+            return FList<T>.Reverse(list);
+        }
+
+        /// <summary>
+        /// Constructs a new list that represents the reversed original list with the applied conversion
+        /// </summary>
+        [Pure]
+        public static FList<R>/*?*/ Reverse<T, R>(this FList<T>/*?*/ list, Func<T, R> converter)
+        {
+            Contract.Ensures(list == null || Contract.Result<FList<R>>() != null);
+
+            return FList<T>.Reverse(list, converter);
+        }
+
+        /// <summary>
+        /// Return a list that only contains elements satisfying predicate in the same order 
+        /// </summary>
+        /// <param name="predicate">Predicate to be satisfied to be in result</param>
+        [Pure]
+        public static FList<T> Filter<T>(this FList<T> list, Predicate<T> predicate)
+        {
+            Contract.Requires(predicate != null);
+
+            if (list == null) return null;
+            var tail = Filter(list.Tail, predicate);
+            if (!predicate(list.Head)) return tail;
+            if (tail == list.Tail) return list;
+            return tail.Cons(list.Head);
+        }
+
+        /// <summary>
+        /// Applies action to each element in list
+        /// </summary>
+        /// <param name="list">List iterated over</param>
+        /// <param name="action">Action called on each element</param>
+        public static void Apply<T>(this FList<T>/*?*/ list, Action<T> action)
+        {
+            FList<T>.Apply(list, action);
+        }
+
+        [Pure]
+        public static IEnumerable<T> GetEnumerable<T>(this FList<T>/*?*/ list)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<T>>() != null);
+
+            return FList<T>.PrivateGetEnumerable(list);
+        }
+
+        [Pure]
+        public static bool IsEmpty<T>(this FList<T> list)
+        {
+            Contract.Ensures(Contract.Result<bool>() == (list == null));
+            return list == null;
+        }
+
+        [Pure]
+        public static T Last<T>(this FList<T> list)
+        {
+            Contract.Requires(!list.IsEmpty());
+            if (list.Tail == null)
+            {
+                return list.Head;
+            }
+            return Last(list.Tail);
+        }
+
+        [Pure]
+        // Needed when looking at access paths
+        public static T ButLast<T>(this FList<T> list)
+        {
+            Contract.Requires(!list.IsEmpty());
+            Contract.Requires(list.Tail != null);
+            return ButLastInternal(list.Tail, list.Head);
+        }
+
+        [Pure]
+        private static T ButLastInternal<T>(this FList<T> list, T butLast)
+        {
+            Contract.Requires(list != null);
+
+            if (list.Tail == null)
+                return butLast;
+            return ButLastInternal(list.Tail, list.Head);
+        }
+
+        [Pure]
+        public static FList<T> Coerce<S, T>(this FList<S> list) where S : T
+        {
+            return list.Map(orig => (T)orig);
+        }
+
+        [Pure]
+        public static bool Contains<T>(this FList<T> list, T value) where T : IEquatable<T>
+        {
+            for (; list != null; list = list.Tail)
+            {
+                if (list.Head.Equals(value)) return true;
+            }
+            return false;
+        }
+
+        [Pure]
+        public static FList<T> Singleton<T>(T elem)
+        {
+            Contract.Ensures(Contract.Result<FList<T>>() != null);
+
+            return Cons(elem, null);
+        }
+
+        [Pure]
+        public static FList<T> Cons<T>(T elem, FList<T> tail)
+        {
+            Contract.Ensures(Contract.Result<FList<T>>() != null);
+
+            return tail.Cons(elem);
+        }
+
+        [Pure]
+        public static FList<C> Product<A, B, C>(FList<A> alist, FList<B> blist, Func<A, B, C> mapper, FList<C> accumulator = null)
+        {
+            Contract.Requires(mapper != null);
+
+            var alist2 = alist;
+            while (alist2 != null)
+            {
+                var blist2 = blist;
+                while (blist2 != null)
+                {
+                    accumulator = accumulator.Cons(mapper(alist2.Head, blist2.Head));
+                    blist2 = blist2.Tail;
+                }
+                alist2 = alist2.Tail;
+            }
+            return accumulator;
+        }
+
+        [Pure]
+        public static FList<B> Product<A, B>(this FList<FList<A>> lists, Func<FList<A>, B> combine, FList<B> accumulator = null)
+        {
+            if (lists == null) return accumulator;
+            var first = lists.Head;
+            if (lists.Tail == null) { return first.Map(e => combine(Singleton(e)), accumulator); }
+            while (first != null)
+            {
+                var subProducts = Product(lists.Tail, l => l);
+                Contract.Assume(first != null, "for some reason first gets havoced after product");
+                accumulator = subProducts.Map(rest => combine(rest.Cons(first.Head)), accumulator);
+                first = first.Tail;
+            }
+            return accumulator;
+        }
+
+        [Pure]
+        public static FList<B> Map<A, B>(this IEnumerable<A> enumerable, Func<A, B> mapper)
+        {
+            Contract.Requires(enumerable != null);
+            Contract.Requires(mapper != null);
+
+            FList<B> result = null;
+            foreach (var a in enumerable)
+            {
+                result = result.Cons(mapper(a));
+            }
+            return result.Reverse();
+        }
+
+        /// <summary>
+        /// Transforms a T list into an S list using the converter
+        /// </summary>
+        [Pure]
+        public static FList<S>/*?*/ Map<T, S>(this FList<T>/*?*/ list, Converter<T, S> converter, FList<S> accumulator = null)
+        {
+            Contract.Requires(converter != null);
+
+            if (list == null) return accumulator;
+            FList<S>/*?*/ tail = list.Tail.Map(converter, accumulator);
+            return tail.Cons(converter(list.Head));
+        }
+
+        /// <summary>
+        /// Transforms a T list into an S list using the converter
+        /// </summary>
+        [Pure]
+        public static FList<S>/*?*/ Map<T, S>(this FList<T>/*?*/ list, Converter<T, S> converter, int maxLength, FList<S> accumulator = null)
+        {
+            Contract.Requires(converter != null);
+
+            if (list == null) return accumulator;
+            if (maxLength <= 0) return accumulator;
+            FList<S>/*?*/ tail = list.Tail.Map(converter, maxLength - 1, accumulator);
+            return tail.Cons(converter(list.Head));
+        }
+
+        [Pure]
+        public static T[] ToArray<T>(this FList<T> list)
+        {
+            Contract.Ensures(Contract.Result<T[]>() != null);
+
+            var result = new T[list.Length()];
+            var i = 0;
+            while (list != null)
+            {
+                Contract.Assume(i < result.Length, "need to relate list length with iteration");
+                result[i++] = list.Head;
+                list = list.Tail;
+            }
+            return result;
+        }
+    }
+
     /// <summary>
-    /// Because we have no unique integers for the keys, we use HashCode and keep 
-    /// conflicts in a list.
+    /// Functional lists. null represents the empty list.
     /// </summary>
-    readonly IFunctionalIntMap<FList<Pair<A/*!*/, B>>/*?*/> fimap;
-    readonly int count;
-    readonly FList<A> keys;
+    [Serializable]
+    public class FList<T>
+    {
+        #region Privates
+        private T elem;
 
-    private FunctionalMap(IFunctionalIntMap<FList<Pair<A/*!*/,B>>/*?*/> map, int count, FList<A> keys) {
-      this.fimap = map;
-      this.count = count;
-      this.keys = keys;
-    }
+        private FList<T>/*?*/ tail;
 
-    public static readonly FunctionalMap<A,B> Empty = new FunctionalMap<A,B>(FunctionalIntMap<FList<Pair<A/*!*/,B>>/*?*/>.EmptyMap, 0, null); // Thread-safe
+        private int count;
+        #endregion
 
-    public IFunctionalMap<A, B> EmptyMap { get { return Empty; } }
+        public static FList<T> Cons(T elem, FList<T> tail)
+        {
+            Contract.Ensures(Contract.Result<FList<T>>() != null);
 
-    #region IFunctionalMap Members
-
-    public B/*?*/ this[A/*!*/ key] {
-      get {
-        FList<Pair<A/*!*/,B>>/*?*/ candidates = this.fimap[key.GetHashCode()];
-        while (candidates != null) {
-          A headkey = candidates.Head.One;
-          if (key.Equals(headkey)) {
-            return candidates.Head.Two;
-          }
-          candidates = candidates.Tail;
+            return new FList<T>(elem, tail);
         }
-        return default(B);
-      }
-    }
 
-    public A AnyKey
-    {
-      get
-      {
-        return this.keys.Head;
-      }
-    }
-
-    public bool Contains(A/*!*/ key) {
-      FList<Pair<A/*!*/, B>>/*?*/ candidates = this.fimap[key.GetHashCode()];
-      while (candidates != null) {
-        A headkey = candidates.Head.One;
-        if (key.Equals(headkey)) {
-          return true;
+        private FList(T elem, FList<T>/*?*/ tail)
+        {
+            this.elem = elem;
+            this.tail = tail;
+            count = Length(tail) + 1;
         }
-        candidates = candidates.Tail;
-      }
-      return false;
+
+        /// <summary>
+        /// The head element of the list
+        /// </summary>
+        public T Head { get { return elem; } }
+
+        /// <summary>
+        /// The tail of the list
+        /// </summary>
+        public FList<T>/*?*/ Tail
+        {
+            get { return tail; }
+        }
+
+        /// <summary>
+        /// Reusable Empty list representation
+        /// </summary>
+        public const FList<T>/*?*/ Empty = null;
+
+        /// <summary>
+        /// Constructs a new list that represents the reversed original list
+        /// </summary>
+        public static FList<T>/*?*/ Reverse(FList<T>/*?*/ list)
+        {
+            Contract.Ensures(Contract.Result<FList<T>>() != null || list == null);
+
+            if (list == null || list.Tail == null) return list;
+
+            FList<T>/*?*/ tail = null;
+
+            while (list != null)
+            {
+                tail = tail.Cons(list.elem);
+                list = list.tail;
+            }
+            return tail;
+        }
+
+        /// <summary>
+        /// Constructs a new list that represents the reversed original list
+        /// </summary>
+        public static FList<R>/*?*/ Reverse<R>(FList<T>/*?*/ list, Func<T, R> converter)
+        {
+            Contract.Ensures(Contract.Result<FList<R>>() != null || list == null);
+
+            if (list == null) return null;
+
+            FList<R>/*?*/ result = null;
+
+            while (list != null)
+            {
+                result = result.Cons(converter(list.elem));
+                list = list.tail;
+            }
+            return result;
+        }
+
+
+        internal static IEnumerable<T> PrivateGetEnumerable(FList<T>/*?*/ list)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<T>>() != null);
+
+            FList<T>/*?*/ current = list;
+            while (current != null)
+            {
+                T next = current.Head;
+                current = current.Tail;
+                yield return next;
+            }
+            yield break;
+        }
+
+
+
+        /// <summary>
+        /// Query the list for the presence of an element
+        /// </summary>
+        public static bool Contains(FList<T>/*?*/ l, T/*!*/ o)
+        {
+            if (l == null) return false;
+
+            if (o is IEquatable<T>) { if (((IEquatable<T>)o).Equals(l.elem)) return true; }
+            else if (o.Equals(l.elem)) return true;
+
+            return Contains(l.tail, o);
+        }
+
+
+        /// <summary>
+        /// Applies action to each element in list
+        /// </summary>
+        /// <param name="list">List iterated over</param>
+        /// <param name="action">Action called on each element</param>
+        public static void Apply(FList<T>/*?*/ list, Action<T> action)
+        {
+            while (list != null)
+            {
+                action(list.Head);
+                list = list.Tail;
+            }
+        }
+
+
+        /// <summary>
+        /// Given two sorted lists, compute their intersection
+        /// </summary>
+        /// <param name="l1">sorted list</param>
+        /// <param name="l2">sorted list</param>
+        /// <returns>sorted intersection</returns>
+        public static FList<T>/*?*/ Intersect(FList<T>/*?*/ l1, FList<T>/*?*/ l2)
+        {
+            if (l1 == null || l2 == null) return null;
+
+            int comp = System.Collections.Comparer.Default.Compare(l1.Head, l2.Head);
+            if (comp < 0)
+            {
+                return Intersect(l1.Tail, l2);
+            }
+            if (comp > 0)
+            {
+                return Intersect(l1, l2.Tail);
+            }
+            // equal
+            return Intersect(l1.Tail, l2.Tail).Cons(l1.Head);
+        }
+
+        /// <summary>
+        /// Returns a new list that contains the elements of the argument list in increasing order
+        /// </summary>
+        public static FList<T>/*?*/ Sort(FList<T>/*?*/ l)
+        {
+            return Sort(l, null);
+        }
+
+        private static FList<T>/*?*/ Sort(FList<T>/*?*/ l, FList<T>/*?*/ tail)
+        {
+            // quicksort
+            if (l == null) return tail;
+
+            T pivot = l.Head;
+
+            FList<T>/*?*/ less;
+            FList<T>/*?*/ more;
+            Partition(l.Tail, pivot, out less, out more);
+
+            return Sort(less, Sort(more, tail).Cons(pivot));
+        }
+
+        private static void Partition(FList<T>/*?*/ l, T pivot, out FList<T>/*?*/ less, out FList<T>/*?*/ more)
+        {
+            less = null;
+            more = null;
+            if (l == null)
+            {
+                return;
+            }
+            foreach (T value in l.GetEnumerable())
+            {
+                if (System.Collections.Comparer.Default.Compare(value, pivot) <= 0)
+                {
+                    less = less.Cons(value);
+                }
+                else
+                {
+                    more = more.Cons(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Gives the length of the list
+        /// </summary>
+        [Pure]
+        public static int Length(FList<T>/*?*/ l)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+
+            if (l == null) { return 0; }
+            else return l.count;
+        }
+
+        /// <summary>
+        /// Generates a string representing the list
+        /// </summary>
+        /// <returns></returns>
+        //^ [Confined]
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            this.BuildString(sb);
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Adds a string representation of the list to the StringBuilder
+        /// </summary>
+        public void BuildString(StringBuilder sb)
+        {
+            string elemStr = elem == null ? "<null>" : elem.ToString();
+            if (tail != null)
+            {
+                sb.AppendFormat("{0},", elemStr);
+                tail.BuildString(sb);
+            }
+            else
+            {
+                sb.Append(elemStr);
+            }
+        }
     }
 
-    private FList<Pair<A/*!*/, B>>/*?*/ Remove(FList<Pair<A/*!*/, B>>/*?*/ from, A/*!*/ key) {
-      if (from == null) return null;
-      if (key.Equals(from.Head.One)) { return from.Tail; }
-      FList<Pair<A/*!*/, B>>/*?*/ newTail = Remove(from.Tail, key);
-      if (newTail == from.Tail) return from; // optimization
-      return newTail.Cons(from.Head);
-    }
+    public enum VisitStatus { ContinueVisit, StopVisit }
 
-    public IFunctionalMap<A,B> Add(A/*!*/ key, B val) {
-      int keyNum = key.GetHashCode();
-      FList<Pair<A/*!*/, B>>/*?*/ oldPairs = this.fimap[keyNum];
-      var newPairs = Remove(oldPairs, key).Cons(new Pair<A/*!*/, B>(key, val));
-      int addition = newPairs.Length() - oldPairs.Length();
-      FList<A> keys = (addition == 0) ? this.keys : this.keys.Cons(key);
-      return new FunctionalMap<A,B>(this.fimap.Add(keyNum, newPairs), this.count + addition, keys);
-    }
+    public delegate VisitStatus VisitMapPair<Key, Value>(Key key, Value value);
 
-    public IFunctionalMap<A,B> Remove(A/*!*/ key) {
-      int keyNum = key.GetHashCode();
-      FList<Pair<A/*!*/, B>>/*?*/ oldPairs = this.fimap[keyNum];
-      if (oldPairs == null) return this; // no change
-
-      FList<Pair<A/*!*/, B>>/*?*/ newPairs = Remove(oldPairs, key);
-      if (newPairs == oldPairs) return this; // no change
-
-      // Optimize: remove element if newPairs == null
-      FList<A> keys = RemoveKey(key, this.keys);
-      if (newPairs == null) {
-        return new FunctionalMap<A, B>(this.fimap.Remove(keyNum), this.count - 1, keys);
-      }
-      return new FunctionalMap<A,B>(this.fimap.Add(keyNum, newPairs), this.count - 1, keys);
-    }
-
-    private static FList<A> RemoveKey(A key, FList<A> keys)
+    public partial interface IFunctionalMap<Key, Val> : IEquatable<IFunctionalMap<Key, Val>>
     {
-      if (keys == null) { throw new InvalidOperationException(); }
-      if (key.Equals(keys.Head)) {
-        return keys.Tail;
-      }
-      return RemoveKey(key, keys.Tail).Cons(keys.Head);
+        Val/*?*/ this[Key/*!*/ key] { get; }
+        [Pure]
+        IFunctionalMap<Key, Val> Add(Key/*!*/ key, Val val);
+        [Pure]
+        IFunctionalMap<Key, Val> Remove(Key/*!*/ key);
+        [Pure]
+        bool Contains(Key/*!*/ key);
+        /// <summary>
+        /// For non-empty domains, returns one of the keys
+        /// </summary>
+        Key AnyKey { get; }
+        IEnumerable<Key> Keys { get; }
+        void Visit(VisitMapPair<Key/*!*/, Val> visitor);
+        int Count { get; }
+
+        /// <summary>
+        /// Returns an emtpy map
+        /// </summary>
+        IFunctionalMap<Key, Val> EmptyMap { get; }
+
+        void Dump(System.IO.TextWriter tw);
     }
 
-    public IEnumerable<A> Keys
+    #region IFunctionalMap<Key,Val> contract binding
+    [ContractClass(typeof(IFunctionalMapContract<,>))]
+    public partial interface IFunctionalMap<Key, Val>
     {
-      get {
-        return this.keys.GetEnumerable();
+    }
+
+    [ContractClassFor(typeof(IFunctionalMap<,>))]
+    internal abstract class IFunctionalMapContract<Key, Val> : IFunctionalMap<Key, Val>
+    {
+        #region IFunctionalMap<Key,Val> Members
+
+        public Val this[Key key]
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IFunctionalMap<Key, Val> Add(Key key, Val val)
+        {
+            Contract.Ensures(Contract.Result<IFunctionalMap<Key, Val>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IFunctionalMap<Key, Val> Remove(Key key)
+        {
+            Contract.Ensures(Contract.Result<IFunctionalMap<Key, Val>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public bool Contains(Key key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Key AnyKey
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IEnumerable<Key> Keys
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<Key>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public void Visit(VisitMapPair<Key, Val> visitor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                throw new NotImplementedException();
+            }
+        }
+
+        public IFunctionalMap<Key, Val> EmptyMap
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IFunctionalMap<Key, Val>>() != null);
+
+                throw new NotImplementedException();
+            }
+        }
+
+        public void Dump(TextWriter tw)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IEquatable<IFunctionalMap<Key,Val>> Members
+
+        public bool Equals(IFunctionalMap<Key, Val> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+    #endregion
+
+    [ContractClass(typeof(IFunctionalIntMapContracts<>))]
+    public interface IFunctionalIntMap<B>
+    {
+        /*
+         * Ideally, the key type in this API would be 
+         * an interface IHasUniqueId with a single property
+         * that return an int. However, in our use of this
+         * API, we need to plug in objects that cannot be
+         * unified under a common interface because we don't 
+         * own some of the classes. So, awkwardly, we ask
+         * the client to pass in BOTH a key object and its
+         * integer under which it will be stored.
+         */
+        [Pure]
+        B Lookup(int keyNumber);
+        B this[int keyNumber] { get; }
+        // For a non-empty map, returns any value
+        B Any { get; }
+        [Pure]
+        bool Contains(int keyNumber);
+        [Pure]
+        IFunctionalIntMap<B> Add(int keyNumber, B val);
+        IEnumerable<B> Values { get; }
+        IEnumerable<int> Keys { get; }
+        void Visit(Action<B> action);
+        void Visit(Action<int, B> action);
+        [Pure]
+        IFunctionalIntMap<B> Remove(int keyNumber);
+        int Count { get; }
+
+        void Dump(System.IO.TextWriter tw);
+    }
+
+    [ContractClassFor(typeof(IFunctionalIntMap<>))]
+    internal abstract class IFunctionalIntMapContracts<B>
+      : IFunctionalIntMap<B>
+    {
+        public IFunctionalIntMap<B> Add(int keyNumber, B val)
+        {
+            Contract.Ensures(Contract.Result<IFunctionalIntMap<B>>() != null);
+
+            return null;
+        }
+
+        #region No Contracts
+        public B Lookup(int keyNumber)
+        {
+            throw new NotImplementedException();
+        }
+
+        public B this[int keyNumber]
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public B Any
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool Contains(int keyNumber)
+        {
+            throw new NotImplementedException();
+        }
+
+
+
+        public IEnumerable<B> Values
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IEnumerable<int> Keys
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public void Visit(Action<B> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Visit(Action<int, B> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IFunctionalIntMap<B> Remove(int keyNumber)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int Count
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public void Dump(TextWriter tw)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+    }
+
+    public class FunctionalIntMap<B>
+    {
+        // Adapted from Okasaki and Gill, "Fast mergeable integer maps", ML Workshop, 1998.
+
+        public static IFunctionalIntMap<B> EmptyMap
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IFunctionalIntMap<B>>() != null); // F: addded
+                return Empty.E;
+            }
+        }
+
+        private abstract class PatriciaTree : IFunctionalIntMap<B>
+        {
+            public abstract B Lookup(int keyNumber);
+
+            public B this[int keyNumber] { get { return this.Lookup(keyNumber); } }
+
+            public abstract B Any { get; }
+
+            public abstract IFunctionalIntMap<B> Add(int keyNumber, B val);
+
+            public abstract int Count { get; }
+
+            public abstract bool Contains(int keyNumber);
+
+            internal abstract void AddValues(List<B> list);
+
+            internal abstract void AddKeys(List<int> list);
+
+            public abstract IFunctionalIntMap<B> Remove(int keyNumber);
+
+            internal abstract void AppendToBuffer(System.Text.StringBuilder buffer);
+
+            protected abstract int KeyNumber { get; }
+
+            internal abstract void Dump(System.IO.TextWriter tw, string prefix);
+
+            public void Dump(System.IO.TextWriter tw) { this.Dump(tw, ""); }
+
+            public IEnumerable<B> Values
+            {
+                // If gathering a list is too expensive, we can change this one day
+                // That's why I made the return type IEnumerable rather than ICollection. RD
+                get
+                {
+                    List<B> list = new List<B>(this.Count);
+                    this.AddValues(list);
+                    return list;
+                }
+            }
+
+            public IEnumerable<int> Keys
+            {
+                // If gathering a list is too expensive, we can change this one day
+                // That's why I made the return type IEnumerable rather than ICollection. RD
+                get
+                {
+                    List<int> list = new List<int>(this.Count);
+                    this.AddKeys(list);
+                    return list;
+                }
+            }
+
+            public abstract void Visit(Action<B> action);
+            public abstract void Visit(Action<int, B> action);
+
+            //^ [Confined]
+            public override string ToString()
+            {
+                System.Text.StringBuilder buffer = new System.Text.StringBuilder();
+                buffer.Append("[ ");
+                this.AppendToBuffer(buffer);
+                buffer.Append("]");
+                return buffer.ToString();
+            }
+
+            protected static int LowestBit(int x) { return x & -x; }
+            protected static int BranchingBit(int p0, int p1) { return LowestBit(p0 ^ p1); }
+            protected static int MaskBits(int k, int m) { return k & (m - 1); }
+            protected static bool ZeroBit(int k, int m) { return (k & m) == 0; }
+            protected static bool MatchPrefix(int k, int p, int m) { return MaskBits(k, m) == p; }
+
+
+            protected static PatriciaTree Join(PatriciaTree t0, PatriciaTree t1)
+            {
+                int p0 = t0.KeyNumber, p1 = t1.KeyNumber;
+                int m = BranchingBit(p0, p1);
+                return ZeroBit(p0, m) ?
+                  new Branch(MaskBits(p0, m), m, t0, t1) :
+                  new Branch(MaskBits(p0, m), m, t1, t0);
+            }
+        }
+
+
+
+        private class Empty : PatriciaTree
+        {
+            public static readonly Empty E = new Empty(); // Thread-safe
+
+            protected override int KeyNumber { get { throw new System.NotImplementedException(); } }
+
+            public override B Lookup(int key) { return default(B); }
+
+            public override B Any
+            {
+                get { return default(B); }
+            }
+
+            public override IFunctionalIntMap<B> Add(int keyNumber, B val)
+            {
+                return new Leaf(keyNumber, val);
+            }
+
+            public override IFunctionalIntMap<B> Remove(int keyNumber) { return this; }
+
+            public override int Count { get { return 0; } }
+
+            public override bool Contains(int keyNumber)
+            {
+                return false;
+            }
+
+            internal override void AddValues(List<B> list) { }
+
+            internal override void AddKeys(List<int> list) { }
+
+            public override void Visit(Action<B> action)
+            {
+                // do nothing
+            }
+
+            public override void Visit(Action<int, B> action)
+            {
+                // do nothing
+            }
+
+            internal override void AppendToBuffer(System.Text.StringBuilder buffer) { }
+
+            internal override void Dump(System.IO.TextWriter tw, string prefix) { tw.WriteLine(prefix + "<Empty/>"); }
+        }
+
+
+
+        private class Leaf : PatriciaTree
+        {
+            public readonly int UniqueId;
+            public readonly B Value;
+
+            public Leaf(int k, B val) { this.UniqueId = k; this.Value = val; }
+
+            protected override int KeyNumber { get { return this.UniqueId; } }
+
+            public override B Lookup(int key)
+            {
+                return key == this.UniqueId ? this.Value : default(B);
+            }
+
+            public override B Any
+            {
+                get { return this.Value; }
+            }
+
+            public override IFunctionalIntMap<B> Add(int keyNumber, B val)
+            {
+                int thisUniqueId = this.UniqueId;
+                return (keyNumber == thisUniqueId) ?
+                  new Leaf(keyNumber, val) :
+                  Join(new Leaf(keyNumber, val), this);
+            }
+
+            public override IFunctionalIntMap<B> Remove(int keyNumber)
+            {
+                return keyNumber == this.UniqueId ? Empty.E : (IFunctionalIntMap<B>)this;
+            }
+
+            public override int Count { get { return 1; } }
+
+            public override bool Contains(int keyNumber)
+            {
+                return this.UniqueId == keyNumber;
+            }
+
+            internal override void AddValues(List<B> list) { list.Add(this.Value); }
+
+            internal override void AddKeys(List<int> list) { list.Add(this.UniqueId); }
+
+            public override void Visit(Action<B> action)
+            {
+                action(Value);
+            }
+            public override void Visit(Action<int, B> action)
+            {
+                action(this.KeyNumber, this.Value);
+            }
+
+            internal override void AppendToBuffer(System.Text.StringBuilder buffer)
+            {
+                buffer.AppendFormat("{0}->{1} ", this.KeyNumber, this.Value);
+            }
+
+            internal override void Dump(System.IO.TextWriter tw, string prefix)
+            {
+                tw.WriteLine(prefix + "<Leaf KeyInt={0} Value='{1}'/>", UniqueId, Value);
+            }
+        }
+
+
+
+        private class Branch : PatriciaTree
+        {
+            public readonly int Prefix;
+            public readonly int Mask;
+            public readonly PatriciaTree Left, Right;
+            private readonly int count;
+
+            [ContractInvariantMethod]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.Left != null);
+                Contract.Invariant(this.Right != null);
+            }
+
+            public Branch(int prefix, int mask, PatriciaTree left, PatriciaTree right)
+            {
+                Contract.Requires(left != null);
+                Contract.Requires(right != null);
+
+                this.Prefix = prefix;
+                this.Mask = mask;
+                this.Left = left;
+                this.Right = right;
+                count = left.Count + right.Count;
+            }
+
+            protected override int KeyNumber { get { return this.Prefix; } }
+
+            public override B Lookup(int key)
+            {
+                Branch current = this;
+                do
+                {
+                    if (ZeroBit(key, current.Mask))
+                    {
+                        Branch next = current.Left as Branch;
+                        if (next == null)
+                        {
+                            return current.Left.Lookup(key);
+                        }
+                        current = next;
+                    }
+                    else
+                    {
+                        Branch next = current.Right as Branch;
+                        if (next == null)
+                        {
+                            return current.Right.Lookup(key);
+                        }
+                        current = next;
+                    }
+                } while (true);
+            }
+
+            public override B Any
+            {
+                get { return Left.Any; }
+            }
+
+            public override IFunctionalIntMap<B> Add(int keyNumber, B val)
+            {
+                if (MatchPrefix(keyNumber, this.Prefix, this.Mask))
+                {
+                    if (ZeroBit(keyNumber, this.Mask))
+                    {
+                        return new Branch(this.Prefix, this.Mask,
+                          (PatriciaTree)this.Left.Add(keyNumber, val), this.Right);
+                    }
+                    else
+                    {
+                        return new Branch(this.Prefix, this.Mask, this.Left,
+                          (PatriciaTree)this.Right.Add(keyNumber, val));
+                    }
+                }
+                else
+                    return Join(new Leaf(keyNumber, val), this);
+            }
+
+            public override IFunctionalIntMap<B> Remove(int keyNumber)
+            {
+                if (ZeroBit(keyNumber, this.Mask))
+                {
+                    PatriciaTree newLeft = (PatriciaTree)this.Left.Remove(keyNumber);
+                    if (newLeft is Empty)
+                        return this.Right;
+                    return Join(newLeft, this.Right);
+                }
+                else
+                {
+                    PatriciaTree newRight = (PatriciaTree)this.Right.Remove(keyNumber);
+                    if (newRight is Empty)
+                        return this.Left;
+                    return Join(this.Left, newRight);
+                }
+            }
+
+            public override int Count { get { return count; } }
+
+            public override bool Contains(int keyNumber)
+            {
+                if (MatchPrefix(keyNumber, this.Prefix, this.Mask))
+                {
+                    if (ZeroBit(keyNumber, this.Mask))
+                    {
+                        return this.Left.Contains(keyNumber);
+                    }
+                    else
+                    {
+                        return this.Right.Contains(keyNumber);
+                    }
+                }
+                else
+                    return false;
+            }
+
+
+            internal override void AddValues(List<B> list)
+            {
+                this.Left.AddValues(list);
+                this.Right.AddValues(list);
+            }
+
+            internal override void AddKeys(List<int> list)
+            {
+                this.Left.AddKeys(list);
+                this.Right.AddKeys(list);
+            }
+
+            public override void Visit(Action<B> action)
+            {
+                Left.Visit(action);
+                Right.Visit(action);
+            }
+
+            public override void Visit(Action<int, B> action)
+            {
+                Left.Visit(action);
+                Right.Visit(action);
+            }
+
+            internal override void AppendToBuffer(System.Text.StringBuilder buffer)
+            {
+                this.Left.AppendToBuffer(buffer);
+                this.Right.AppendToBuffer(buffer);
+            }
+
+            internal override void Dump(System.IO.TextWriter tw, string prefix)
+            {
+                tw.WriteLine(prefix + "<Branch Prefix={0} Mask={1}>", Prefix, Mask);
+                this.Left.Dump(tw, prefix + "  ");
+                this.Right.Dump(tw, prefix + "  ");
+                tw.WriteLine(prefix + "</Branch>");
+            }
+        }
+    }
+
+
+    public class FunctionalMap<A, B> : IFunctionalMap<A, B> where A : IEquatable<A>
+    {
+        /// <summary>
+        /// Because we have no unique integers for the keys, we use HashCode and keep 
+        /// conflicts in a list.
+        /// </summary>
+        private readonly IFunctionalIntMap<FList<Pair<A/*!*/, B>>/*?*/> fimap;
+        private readonly int count;
+        private readonly FList<A> keys;
+
+        private FunctionalMap(IFunctionalIntMap<FList<Pair<A/*!*/, B>>/*?*/> map, int count, FList<A> keys)
+        {
+            fimap = map;
+            this.count = count;
+            this.keys = keys;
+        }
+
+        public static readonly FunctionalMap<A, B> Empty = new FunctionalMap<A, B>(FunctionalIntMap<FList<Pair<A/*!*/, B>>/*?*/>.EmptyMap, 0, null); // Thread-safe
+
+        public IFunctionalMap<A, B> EmptyMap { get { return Empty; } }
+
+        #region IFunctionalMap Members
+
+        public B/*?*/ this[A/*!*/ key]
+        {
+            get
+            {
+                FList<Pair<A/*!*/, B>>/*?*/ candidates = fimap[key.GetHashCode()];
+                while (candidates != null)
+                {
+                    A headkey = candidates.Head.One;
+                    if (key.Equals(headkey))
+                    {
+                        return candidates.Head.Two;
+                    }
+                    candidates = candidates.Tail;
+                }
+                return default(B);
+            }
+        }
+
+        public A AnyKey
+        {
+            get
+            {
+                return keys.Head;
+            }
+        }
+
+        public bool Contains(A/*!*/ key)
+        {
+            FList<Pair<A/*!*/, B>>/*?*/ candidates = fimap[key.GetHashCode()];
+            while (candidates != null)
+            {
+                A headkey = candidates.Head.One;
+                if (key.Equals(headkey))
+                {
+                    return true;
+                }
+                candidates = candidates.Tail;
+            }
+            return false;
+        }
+
+        private FList<Pair<A/*!*/, B>>/*?*/ Remove(FList<Pair<A/*!*/, B>>/*?*/ from, A/*!*/ key)
+        {
+            if (from == null) return null;
+            if (key.Equals(from.Head.One)) { return from.Tail; }
+            FList<Pair<A/*!*/, B>>/*?*/ newTail = Remove(from.Tail, key);
+            if (newTail == from.Tail) return from; // optimization
+            return newTail.Cons(from.Head);
+        }
+
+        public IFunctionalMap<A, B> Add(A/*!*/ key, B val)
+        {
+            int keyNum = key.GetHashCode();
+            FList<Pair<A/*!*/, B>>/*?*/ oldPairs = fimap[keyNum];
+            var newPairs = Remove(oldPairs, key).Cons(new Pair<A/*!*/, B>(key, val));
+            int addition = newPairs.Length() - oldPairs.Length();
+            FList<A> keys = (addition == 0) ? this.keys : this.keys.Cons(key);
+            return new FunctionalMap<A, B>(fimap.Add(keyNum, newPairs), count + addition, keys);
+        }
+
+        public IFunctionalMap<A, B> Remove(A/*!*/ key)
+        {
+            int keyNum = key.GetHashCode();
+            FList<Pair<A/*!*/, B>>/*?*/ oldPairs = fimap[keyNum];
+            if (oldPairs == null) return this; // no change
+
+            FList<Pair<A/*!*/, B>>/*?*/ newPairs = Remove(oldPairs, key);
+            if (newPairs == oldPairs) return this; // no change
+
+            // Optimize: remove element if newPairs == null
+            FList<A> keys = RemoveKey(key, this.keys);
+            if (newPairs == null)
+            {
+                return new FunctionalMap<A, B>(fimap.Remove(keyNum), count - 1, keys);
+            }
+            return new FunctionalMap<A, B>(fimap.Add(keyNum, newPairs), count - 1, keys);
+        }
+
+        private static FList<A> RemoveKey(A key, FList<A> keys)
+        {
+            if (keys == null) { throw new InvalidOperationException(); }
+            if (key.Equals(keys.Head))
+            {
+                return keys.Tail;
+            }
+            return RemoveKey(key, keys.Tail).Cons(keys.Head);
+        }
+
+        public IEnumerable<A> Keys
+        {
+            get
+            {
+                return keys.GetEnumerable();
 #if false
-        List<A> result = new List<A>();
-        this.fimap.Visit(delegate(FList<Pair<A/*!*/, B>>/*?*/ list) { while (list != null) { result.Add(list.Head.One); list = list.Tail; } });
-        return result;
+                List<A> result = new List<A>();
+                fimap.Visit(delegate (FList<Pair<A/*!*/, B>>/*?*/ list) { while (list != null) { result.Add(list.Head.One); list = list.Tail; } });
+                return result;
 #endif
-      }
+            }
+        }
+
+        public void Visit(VisitMapPair<A/*!*/, B> visitor)
+        {
+            fimap.Visit(delegate (FList<Pair<A/*!*/, B>>/*?*/ list) { while (list != null) { visitor(list.Head.One, list.Head.Two); list = list.Tail; } });
+        }
+
+        public int Count
+        {
+            get
+            {
+                return count;
+            }
+        }
+
+        public void Dump(TextWriter tw)
+        {
+            fimap.Dump(tw);
+        }
+
+        #endregion
+
+        #region IEquatable Members
+        //^ [StateIndependent]
+        public bool Equals(IFunctionalMap<A, B> other) { return this == other; }
+        #endregion
     }
 
-    public void Visit(VisitMapPair<A/*!*/,B> visitor) {
-      this.fimap.Visit(delegate(FList<Pair<A/*!*/, B>>/*?*/ list) { while (list != null) { visitor(list.Head.One, list.Head.Two); list = list.Tail; } });
-    }
-
-    public int Count {
-      get {
-        return this.count;
-      }
-    }
-
-    public void Dump(TextWriter tw) {
-      this.fimap.Dump(tw);
-    }
-
-    #endregion
-
-    #region IEquatable Members
-    //^ [StateIndependent]
-    public bool Equals(IFunctionalMap<A, B> other) { return this == other; }
-    #endregion
-  }
-
-  public class FunctionalIntKeyMap<A, B> : IFunctionalMap<A, B> { 
-    #region Privates
-    private readonly IFunctionalIntMap<Pair<A/*!*/, B>> fimap;
-    private readonly Converter<A/*!*/, int> KeyNumber;
-    // private readonly FList<A> keys;
-
-    private FunctionalIntKeyMap(IFunctionalIntMap<Pair<A/*!*/,B>> fimap, Converter<A/*!*/,int> keynumber/*, FList<A> keys*/) {
-      this.fimap = fimap;
-      this.KeyNumber = keynumber;
-//      this.keys = keys;
-    }
-    #endregion
-
-    public B/*?*/ this[A/*!*/ key] {
-      get {
-        return fimap[KeyNumber(key)].Two;
-      }
-    }
-
-    public A AnyKey { get { return this.Keys.First(); } }
-
-    public IFunctionalMap<A, B> Add(A/*!*/ key, B val) {
-      //int oldCount = this.fimap.Count;
-      IFunctionalIntMap<Pair<A,B>> newMap = this.fimap.Add(KeyNumber(key), new Pair<A/*!*/,B>(key,val));
-      //FList<A> keys = this.keys;
-      //if (newMap.Count != oldCount)
-      //{
-        //keys = keys.Cons(key);
-      //}
-      return new FunctionalIntKeyMap<A,B>(newMap, this.KeyNumber);
-    }
-
-    public IFunctionalMap<A, B> Remove(A/*!*/ key) {
-      //int oldCount = this.fimap.Count;
-      IFunctionalIntMap<Pair<A, B>> newMap = this.fimap.Remove(KeyNumber(key));
-      //FList<A> keys = this.keys;
-      //if (newMap.Count != oldCount) {
-      //  // remove key
-      //  keys = RemoveKey(KeyNumber(key), keys);
-      //}
-      return new FunctionalIntKeyMap<A, B>(newMap, this.KeyNumber);
-    }
-
-    private FList<A> RemoveKey(int keynumber, FList<A> keys)
+    public class FunctionalIntKeyMap<A, B> : IFunctionalMap<A, B>
     {
-      if (keys == null) { throw new InvalidOperationException(); }
-      if (KeyNumber(keys.Head) == keynumber) {
-        return keys.Tail;
-      }
-      return RemoveKey(keynumber, keys.Tail).Cons(keys.Head);
-    }
+        #region Privates
+        private readonly IFunctionalIntMap<Pair<A/*!*/, B>> fimap;
+        private readonly Converter<A/*!*/, int> KeyNumber;
+        // private readonly FList<A> keys;
 
-    private IEnumerable<A> keyCache;
-    public IEnumerable<A> Keys {
-      get
-      {
+        private FunctionalIntKeyMap(IFunctionalIntMap<Pair<A/*!*/, B>> fimap, Converter<A/*!*/, int> keynumber/*, FList<A> keys*/)
+        {
+            this.fimap = fimap;
+            KeyNumber = keynumber;
+            //      this.keys = keys;
+        }
+        #endregion
+
+        public B/*?*/ this[A/*!*/ key]
+        {
+            get
+            {
+                return fimap[KeyNumber(key)].Two;
+            }
+        }
+
+        public A AnyKey { get { return this.Keys.First(); } }
+
+        public IFunctionalMap<A, B> Add(A/*!*/ key, B val)
+        {
+            //int oldCount = this.fimap.Count;
+            IFunctionalIntMap<Pair<A, B>> newMap = fimap.Add(KeyNumber(key), new Pair<A/*!*/, B>(key, val));
+            //FList<A> keys = this.keys;
+            //if (newMap.Count != oldCount)
+            //{
+            //keys = keys.Cons(key);
+            //}
+            return new FunctionalIntKeyMap<A, B>(newMap, KeyNumber);
+        }
+
+        public IFunctionalMap<A, B> Remove(A/*!*/ key)
+        {
+            //int oldCount = this.fimap.Count;
+            IFunctionalIntMap<Pair<A, B>> newMap = fimap.Remove(KeyNumber(key));
+            //FList<A> keys = this.keys;
+            //if (newMap.Count != oldCount) {
+            //  // remove key
+            //  keys = RemoveKey(KeyNumber(key), keys);
+            //}
+            return new FunctionalIntKeyMap<A, B>(newMap, KeyNumber);
+        }
+
+        private FList<A> RemoveKey(int keynumber, FList<A> keys)
+        {
+            if (keys == null) { throw new InvalidOperationException(); }
+            if (KeyNumber(keys.Head) == keynumber)
+            {
+                return keys.Tail;
+            }
+            return RemoveKey(keynumber, keys.Tail).Cons(keys.Head);
+        }
+
+        private IEnumerable<A> keyCache;
+        public IEnumerable<A> Keys
+        {
+            get
+            {
 #if false
-        return this.keys.GetEnumerable();
+                return this.keys.GetEnumerable();
 #else
-        if (keyCache == null)
-        {
-          List<A> l = new List<A>();
-          fimap.Visit(delegate(Pair<A/*!*/, B> data) { l.Add(data.One); });
-          this.keyCache = l;
-        }
-        return this.keyCache;
+                if (keyCache == null)
+                {
+                    List<A> l = new List<A>();
+                    fimap.Visit(delegate (Pair<A/*!*/, B> data) { l.Add(data.One); });
+                    keyCache = l;
+                }
+                return keyCache;
 #endif
-      }
-    }
-
-    public void Visit(VisitMapPair<A/*!*/, B> visitor) {
-      fimap.Visit(delegate (Pair<A/*!*/,B> data) { visitor(data.One, data.Two); } );
-    }
-
-    public int Count {
-      get { return fimap.Count; }
-    }
-
-    public bool Contains(A/*!*/ key) {
-      return this.fimap.Contains(this.KeyNumber(key));
-    }
-
-    public void Dump(TextWriter tw) {
-      fimap.Dump(tw);
-    }
-
-    public static IFunctionalMap<A, B> Empty(Converter<A/*!*/, int> keyNumber) {
-      Contract.Ensures(Contract.Result<IFunctionalMap<A, B>>() != null);
-
-      return new FunctionalIntKeyMap<A, B>(FunctionalIntMap<Pair<A/*!*/, B>>.EmptyMap, keyNumber);
-    }
-
-    public IFunctionalMap<A, B> EmptyMap { get { return Empty(this.KeyNumber); } }
-
-    #region IEquatable Members
-    //^ [StateIndependent]
-    public bool Equals(IFunctionalMap<A, B> other) { return this == other; }
-    #endregion
-}
-
-  public class DoubleFunctionalMap<A, B, C> where A:IEquatable<A> where B:IEquatable<B> {
-
-    private IFunctionalMap<A, IFunctionalMap<B, C>> map;
-
-    public C/*?*/ this[A/*!*/ key1, B/*!*/ key2] {
-      get {
-        IFunctionalMap<B, C>/*?*/ t = this.map[key1];
-
-        if (t == null) {
-          return default(C);
+            }
         }
 
-        return t[key2];
-      }
-    }
-
-    public DoubleFunctionalMap<A, B, C> Add(A/*!*/ key1, B/*!*/ key2, C value) {
-      IFunctionalMap<B, C>/*?*/ t = this.map[key1];
-
-      if (t == null) {
-        t = FunctionalMap<B, C>.Empty;
-      }
-
-      return new DoubleFunctionalMap<A, B, C>(this.map.Add(key1, t.Add(key2, value)));
-    }
-
-
-    public DoubleFunctionalMap<A, B, C> RemoveAll(A/*!*/ key1) {
-      return new DoubleFunctionalMap<A, B, C>(this.map.Remove(key1));
-    }
-
-    public DoubleFunctionalMap<A, B, C> Remove(A/*!*/ key1, B/*!*/ key2) {
-      IFunctionalMap<B, C>/*?*/ t = this.map[key1];
-
-      if (t == null) { return this; }
-
-      var t2 = t.Remove(key2);
-      if (t == t2) return this; // no-op
-
-      return new DoubleFunctionalMap<A, B, C>(this.map.Add(key1, t2));
-    }
-
-    private DoubleFunctionalMap(IFunctionalMap<A, IFunctionalMap<B, C>> map) {
-      this.map = map;
-    }
-
-    public static DoubleFunctionalMap<A, B, C> Empty(Converter<A/*!*/, int> keynumber) {
-      return new DoubleFunctionalMap<A, B, C>(FunctionalIntKeyMap<A, IFunctionalMap<B, C>>.Empty(keynumber));
-    }
-
-    public bool Contains(A key1, B key2)
-    {
-      var map1 = this.map[key1];
-      if (map1 == null) return false;
-      return map1.Contains(key2);
-    }
-
-    public bool ContainsKey1(A/*!*/ key1) {
-      return this.map[key1] != null;
-    }
-
-    public int Keys1Count
-    {
-      get
-      {
-        return this.map.Count;
-      }
-    }
-
-    public IEnumerable<A> Keys1 {
-      get { return this.map.Keys; }
-    }
-
-    public int Keys2Count(A/*!*/ key1) {
-      if (key1 == null) return 0;
-      IFunctionalMap<B, C>/*?*/ map2 = this.map[key1];
-
-      if (map2 == null) { return 0; }
-      return map2.Count;
-    }
-
-    private B[] EmptyCache = new B[0];
-
-    public IEnumerable<B> Keys2(A/*!*/ key1) {
-      if (key1 == null) { return EmptyCache; }
-      IFunctionalMap<B, C>/*?*/ map2 = this.map[key1];
-
-      if (map2 == null) { return EmptyCache; }
-      return map2.Keys;
-    }
-
-  }
-
-
-  [ContractClass(typeof(IFunctionalSetContracts<>))]
-  public interface IFunctionalSet<T> where T : IEquatable<T>
-  {
-    IFunctionalSet<T> Add(T/*!*/ elem);
-    IFunctionalSet<T> Remove(T/*!*/ elem);
-    bool Contains(T/*!*/ elem);
-
-    /// <summary>
-    /// For non-empty sets, returns one of the elements
-    /// </summary>
-    T Any { get; }
-    
-    /// <summary>
-    /// Returns true, if every element in this is contained in that.
-    /// </summary>
-    bool Contained(IFunctionalSet<T> that);
-
-    /// <summary>
-    /// Returns the intersection of this and that.
-    /// </summary>
-    IFunctionalSet<T> Intersect(IFunctionalSet<T> that);
-
-    IFunctionalSet<T> Union(IFunctionalSet<T> that);
-
-    void Visit(Action<T/*!*/> visitor);
-    int Count { get; }
-    IEnumerable<T> Elements { get; }
-
-    void Dump(System.IO.TextWriter tw);
-  }
-
-  [ContractClassFor(typeof(IFunctionalSet<>))]
-  abstract class IFunctionalSetContracts<T> : IFunctionalSet<T>
-    where T : IEquatable<T>
-  {
-    #region IFunctionalSet<T> Members
-
-    public IFunctionalSet<T> Add(T elem)
-    {
-      Contract.Ensures(Contract.Result<IFunctionalSet<T>>() != null);
-
-      //Contract.Requires(elem != null);
-      return null;
-    }
-
-    public IFunctionalSet<T> Remove(T elem)
-    {
-      //Contract.Requires(elem != null);
-      return null;
-    }
-
-    public bool Contains(T elem)
-    {
-      //Contract.Requires(elem != null);
-      return false;
-    }
-
-    public T Any
-    {
-      get
-      {
-        return default(T);
-      }
-    }
-
-    public bool Contained(IFunctionalSet<T> that)
-    {
-      return false;
-    }
-
-    public IFunctionalSet<T> Intersect(IFunctionalSet<T> that)
-    {
-      Contract.Ensures(Contract.Result<IFunctionalSet<T>>() != null);
-
-      return null;
-    }
-
-    public IFunctionalSet<T> Union(IFunctionalSet<T> that)
-    {
-      return null;
-    }
-
-    public void Visit(Action<T> visitor)
-    {
-      Contract.Requires(visitor != null);
-    }
-
-    public int Count
-    {
-      get 
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-
-        return 0;
-      }
-    }
-
-    public IEnumerable<T> Elements
-    {
-      get 
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<T>>() != null);
-
-        return null;
-      }
-    }
-
-    public void Dump(TextWriter tw)
-    {
-
-    }
-
-    #endregion
-  }
-
-  public class FunctionalSet<T> : IFunctionalSet<T> where T : IEquatable<T>
-  {
-    // representation is a function intkeymap
-    IFunctionalMap<T,Unit> rep;
-
-    /// <summary>
-    /// Optimized set using functional maps based on the element numbering provided.
-    /// </summary>
-    public static IFunctionalSet<T> Empty(Converter<T/*!*/, int> elementNumber) {
-      Contract.Ensures(Contract.Result<IFunctionalSet<T>>() != null);
-      
-      return new FunctionalSet<T>(FunctionalIntKeyMap<T,Unit>.Empty(elementNumber)); }
-
-    public static IFunctionalSet<T> Empty() {
-      Contract.Ensures(Contract.Result<IFunctionalSet<T>>() != null);
-      
-      return new FunctionalSet<T>(FunctionalMap<T, Unit>.Empty);
-    }
-
-    private FunctionalSet(IFunctionalMap<T,Unit> underlying)
-    {
-      this.rep = underlying;
-    }
-
-
-
-    #region IFunctionalSet<T> Members
-
-    public IFunctionalSet<T> Add(T/*!*/ elem)
-    {
-      return new FunctionalSet<T>(rep.Add(elem, Unit.Value));
-    }
-
-    public IFunctionalSet<T> Remove(T/*!*/ elem)
-    {
-      return new FunctionalSet<T>(rep.Remove(elem));
-    }
-
-    public bool Contains(T/*!*/ elem)
-    {
-      return rep.Contains(elem);
-    }
-
-    public T Any { get { return this.rep.AnyKey; } }
-
-    public void Visit(Action<T/*!*/> visitor)
-    {
-      rep.Visit(delegate(T/*!*/ elem, Unit dummy) { visitor(elem); return VisitStatus.ContinueVisit; });
-    }
-
-    public int Count
-    {
-      get { return rep.Count; }
-    }
-
-    public void Dump(TextWriter tw)
-    {
-      var str = new StringBuilder();
-
-      str.Append("{");
-      var first = true;
-      foreach (T elem in this.rep.Keys)
-      {
-        if (!first)
+        public void Visit(VisitMapPair<A/*!*/, B> visitor)
         {
-          str.Append(", ");
+            fimap.Visit(delegate (Pair<A/*!*/, B> data) { visitor(data.One, data.Two); });
         }
-        else
+
+        public int Count
         {
-          first = false;
+            get { return fimap.Count; }
         }
-        str.AppendFormat("{0}", elem.ToString());
-      }
-      str.Append("}");
 
-      tw.WriteLine(str.ToString());
+        public bool Contains(A/*!*/ key)
+        {
+            return fimap.Contains(KeyNumber(key));
+        }
+
+        public void Dump(TextWriter tw)
+        {
+            fimap.Dump(tw);
+        }
+
+        public static IFunctionalMap<A, B> Empty(Converter<A/*!*/, int> keyNumber)
+        {
+            Contract.Ensures(Contract.Result<IFunctionalMap<A, B>>() != null);
+
+            return new FunctionalIntKeyMap<A, B>(FunctionalIntMap<Pair<A/*!*/, B>>.EmptyMap, keyNumber);
+        }
+
+        public IFunctionalMap<A, B> EmptyMap { get { return Empty(KeyNumber); } }
+
+        #region IEquatable Members
+        //^ [StateIndependent]
+        public bool Equals(IFunctionalMap<A, B> other) { return this == other; }
+        #endregion
     }
 
-
-    public IFunctionalSet<T> Intersect(IFunctionalSet<T> that)
+    public class DoubleFunctionalMap<A, B, C> where A : IEquatable<A> where B : IEquatable<B>
     {
-      if (this == that) { return this; }
-      IFunctionalSet<T> smaller;
-      IFunctionalSet<T> larger;
+        private IFunctionalMap<A, IFunctionalMap<B, C>> map;
 
-      if (this.Count == 0) { return this; }
-      if (this.Count < that.Count) {
-        smaller = this;
-        larger = that;
-      }
-      else {
-        if (that.Count == 0) { return that; }
-        smaller = that;
-        larger = this;
-      }
-      IFunctionalSet<T> result = smaller;
-      smaller.Visit(delegate(T/*!*/ elem)
-      {
-        if (!larger.Contains(elem)) { result = result.Remove(elem); }
-      });
+        public C/*?*/ this[A/*!*/ key1, B/*!*/ key2]
+        {
+            get
+            {
+                IFunctionalMap<B, C>/*?*/ t = map[key1];
 
-      return result;
+                if (t == null)
+                {
+                    return default(C);
+                }
+
+                return t[key2];
+            }
+        }
+
+        public DoubleFunctionalMap<A, B, C> Add(A/*!*/ key1, B/*!*/ key2, C value)
+        {
+            IFunctionalMap<B, C>/*?*/ t = map[key1];
+
+            if (t == null)
+            {
+                t = FunctionalMap<B, C>.Empty;
+            }
+
+            return new DoubleFunctionalMap<A, B, C>(map.Add(key1, t.Add(key2, value)));
+        }
+
+
+        public DoubleFunctionalMap<A, B, C> RemoveAll(A/*!*/ key1)
+        {
+            return new DoubleFunctionalMap<A, B, C>(map.Remove(key1));
+        }
+
+        public DoubleFunctionalMap<A, B, C> Remove(A/*!*/ key1, B/*!*/ key2)
+        {
+            IFunctionalMap<B, C>/*?*/ t = map[key1];
+
+            if (t == null) { return this; }
+
+            var t2 = t.Remove(key2);
+            if (t == t2) return this; // no-op
+
+            return new DoubleFunctionalMap<A, B, C>(map.Add(key1, t2));
+        }
+
+        private DoubleFunctionalMap(IFunctionalMap<A, IFunctionalMap<B, C>> map)
+        {
+            this.map = map;
+        }
+
+        public static DoubleFunctionalMap<A, B, C> Empty(Converter<A/*!*/, int> keynumber)
+        {
+            return new DoubleFunctionalMap<A, B, C>(FunctionalIntKeyMap<A, IFunctionalMap<B, C>>.Empty(keynumber));
+        }
+
+        public bool Contains(A key1, B key2)
+        {
+            var map1 = map[key1];
+            if (map1 == null) return false;
+            return map1.Contains(key2);
+        }
+
+        public bool ContainsKey1(A/*!*/ key1)
+        {
+            return map[key1] != null;
+        }
+
+        public int Keys1Count
+        {
+            get
+            {
+                return map.Count;
+            }
+        }
+
+        public IEnumerable<A> Keys1
+        {
+            get { return map.Keys; }
+        }
+
+        public int Keys2Count(A/*!*/ key1)
+        {
+            if (key1 == null) return 0;
+            IFunctionalMap<B, C>/*?*/ map2 = map[key1];
+
+            if (map2 == null) { return 0; }
+            return map2.Count;
+        }
+
+        private B[] EmptyCache = new B[0];
+
+        public IEnumerable<B> Keys2(A/*!*/ key1)
+        {
+            if (key1 == null) { return EmptyCache; }
+            IFunctionalMap<B, C>/*?*/ map2 = map[key1];
+
+            if (map2 == null) { return EmptyCache; }
+            return map2.Keys;
+        }
     }
 
-    public IFunctionalSet<T> Union(IFunctionalSet<T> that)
+
+    [ContractClass(typeof(IFunctionalSetContracts<>))]
+    public interface IFunctionalSet<T> where T : IEquatable<T>
     {
-      if (this == that) { return this; }
-      IFunctionalSet<T> smaller;
-      IFunctionalSet<T> larger;
+        IFunctionalSet<T> Add(T/*!*/ elem);
+        IFunctionalSet<T> Remove(T/*!*/ elem);
+        bool Contains(T/*!*/ elem);
 
-      if (this.Count == 0) { return that; }
-      if (this.Count < that.Count) {
-        smaller = this;
-        larger = that;
-      }
-      else {
-        if (that.Count == 0) { return this; }
-        smaller = that;
-        larger = this;
-      }
-      IFunctionalSet<T> result = larger;
-      smaller.Visit(delegate(T/*!*/ elem)
-      {
-        result = result.Add(elem);
-      });
+        /// <summary>
+        /// For non-empty sets, returns one of the elements
+        /// </summary>
+        T Any { get; }
 
-      return result;
+        /// <summary>
+        /// Returns true, if every element in this is contained in that.
+        /// </summary>
+        bool Contained(IFunctionalSet<T> that);
+
+        /// <summary>
+        /// Returns the intersection of this and that.
+        /// </summary>
+        IFunctionalSet<T> Intersect(IFunctionalSet<T> that);
+
+        IFunctionalSet<T> Union(IFunctionalSet<T> that);
+
+        void Visit(Action<T/*!*/> visitor);
+        int Count { get; }
+        IEnumerable<T> Elements { get; }
+
+        void Dump(System.IO.TextWriter tw);
     }
 
-
-    public bool Contained(IFunctionalSet<T> that)
+    [ContractClassFor(typeof(IFunctionalSet<>))]
+    internal abstract class IFunctionalSetContracts<T> : IFunctionalSet<T>
+      where T : IEquatable<T>
     {
-      if (this.Count > that.Count) return false;
+        #region IFunctionalSet<T> Members
 
-      bool result = true;
-      this.rep.Visit(delegate(T/*!*/ elem, Unit dummy) { if (!that.Contains(elem)) { result = false; return VisitStatus.StopVisit; } else return VisitStatus.ContinueVisit; });
-      return result;
+        public IFunctionalSet<T> Add(T elem)
+        {
+            Contract.Ensures(Contract.Result<IFunctionalSet<T>>() != null);
+
+            //Contract.Requires(elem != null);
+            return null;
+        }
+
+        public IFunctionalSet<T> Remove(T elem)
+        {
+            //Contract.Requires(elem != null);
+            return null;
+        }
+
+        public bool Contains(T elem)
+        {
+            //Contract.Requires(elem != null);
+            return false;
+        }
+
+        public T Any
+        {
+            get
+            {
+                return default(T);
+            }
+        }
+
+        public bool Contained(IFunctionalSet<T> that)
+        {
+            return false;
+        }
+
+        public IFunctionalSet<T> Intersect(IFunctionalSet<T> that)
+        {
+            Contract.Ensures(Contract.Result<IFunctionalSet<T>>() != null);
+
+            return null;
+        }
+
+        public IFunctionalSet<T> Union(IFunctionalSet<T> that)
+        {
+            return null;
+        }
+
+        public void Visit(Action<T> visitor)
+        {
+            Contract.Requires(visitor != null);
+        }
+
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+
+                return 0;
+            }
+        }
+
+        public IEnumerable<T> Elements
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<T>>() != null);
+
+                return null;
+            }
+        }
+
+        public void Dump(TextWriter tw)
+        {
+        }
+
+        #endregion
     }
-    #endregion
 
-
-    public IEnumerable<T> Elements
+    public class FunctionalSet<T> : IFunctionalSet<T> where T : IEquatable<T>
     {
-      get
-      {
-        return rep.Keys;
-      }
+        // representation is a function intkeymap
+        private IFunctionalMap<T, Unit> rep;
+
+        /// <summary>
+        /// Optimized set using functional maps based on the element numbering provided.
+        /// </summary>
+        public static IFunctionalSet<T> Empty(Converter<T/*!*/, int> elementNumber)
+        {
+            Contract.Ensures(Contract.Result<IFunctionalSet<T>>() != null);
+
+            return new FunctionalSet<T>(FunctionalIntKeyMap<T, Unit>.Empty(elementNumber));
+        }
+
+        public static IFunctionalSet<T> Empty()
+        {
+            Contract.Ensures(Contract.Result<IFunctionalSet<T>>() != null);
+
+            return new FunctionalSet<T>(FunctionalMap<T, Unit>.Empty);
+        }
+
+        private FunctionalSet(IFunctionalMap<T, Unit> underlying)
+        {
+            rep = underlying;
+        }
+
+
+
+        #region IFunctionalSet<T> Members
+
+        public IFunctionalSet<T> Add(T/*!*/ elem)
+        {
+            return new FunctionalSet<T>(rep.Add(elem, Unit.Value));
+        }
+
+        public IFunctionalSet<T> Remove(T/*!*/ elem)
+        {
+            return new FunctionalSet<T>(rep.Remove(elem));
+        }
+
+        public bool Contains(T/*!*/ elem)
+        {
+            return rep.Contains(elem);
+        }
+
+        public T Any { get { return rep.AnyKey; } }
+
+        public void Visit(Action<T/*!*/> visitor)
+        {
+            rep.Visit(delegate (T/*!*/ elem, Unit dummy) { visitor(elem); return VisitStatus.ContinueVisit; });
+        }
+
+        public int Count
+        {
+            get { return rep.Count; }
+        }
+
+        public void Dump(TextWriter tw)
+        {
+            var str = new StringBuilder();
+
+            str.Append("{");
+            var first = true;
+            foreach (T elem in rep.Keys)
+            {
+                if (!first)
+                {
+                    str.Append(", ");
+                }
+                else
+                {
+                    first = false;
+                }
+                str.AppendFormat("{0}", elem.ToString());
+            }
+            str.Append("}");
+
+            tw.WriteLine(str.ToString());
+        }
+
+
+        public IFunctionalSet<T> Intersect(IFunctionalSet<T> that)
+        {
+            if (this == that) { return this; }
+            IFunctionalSet<T> smaller;
+            IFunctionalSet<T> larger;
+
+            if (this.Count == 0) { return this; }
+            if (this.Count < that.Count)
+            {
+                smaller = this;
+                larger = that;
+            }
+            else
+            {
+                if (that.Count == 0) { return that; }
+                smaller = that;
+                larger = this;
+            }
+            IFunctionalSet<T> result = smaller;
+            smaller.Visit(delegate (T/*!*/ elem)
+            {
+                if (!larger.Contains(elem)) { result = result.Remove(elem); }
+            });
+
+            return result;
+        }
+
+        public IFunctionalSet<T> Union(IFunctionalSet<T> that)
+        {
+            if (this == that) { return this; }
+            IFunctionalSet<T> smaller;
+            IFunctionalSet<T> larger;
+
+            if (this.Count == 0) { return that; }
+            if (this.Count < that.Count)
+            {
+                smaller = this;
+                larger = that;
+            }
+            else
+            {
+                if (that.Count == 0) { return this; }
+                smaller = that;
+                larger = this;
+            }
+            IFunctionalSet<T> result = larger;
+            smaller.Visit(delegate (T/*!*/ elem)
+            {
+                result = result.Add(elem);
+            });
+
+            return result;
+        }
+
+
+        public bool Contained(IFunctionalSet<T> that)
+        {
+            if (this.Count > that.Count) return false;
+
+            bool result = true;
+            rep.Visit(delegate (T/*!*/ elem, Unit dummy) { if (!that.Contains(elem)) { result = false; return VisitStatus.StopVisit; } else return VisitStatus.ContinueVisit; });
+            return result;
+        }
+        #endregion
+
+
+        public IEnumerable<T> Elements
+        {
+            get
+            {
+                return rep.Keys;
+            }
+        }
     }
-
-  }
-
 }

--- a/Microsoft.Research/DataStructures/HashHelpers.cs
+++ b/Microsoft.Research/DataStructures/HashHelpers.cs
@@ -1,24 +1,13 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
 
-namespace Microsoft.Research.DataStructures {
-
+namespace Microsoft.Research.DataStructures
+{
     public static class HashHelpers
     {
         // Table of prime numbers to use as hash table sizes. 
@@ -69,32 +58,32 @@ namespace Microsoft.Research.DataStructures {
 
         public static int CombineHashCodes(int h1, int h2)
         {
-          return ((h1 << 5) + h1) ^ h2; // taken from Syste.Tuple.CombineHashCodes
+            return ((h1 << 5) + h1) ^ h2; // taken from Syste.Tuple.CombineHashCodes
         }
 
         public static int CombineHashCodes(params int[] h)
         {
-          return CombineHashCodes((IEnumerable<int>)h);
+            return CombineHashCodes((IEnumerable<int>)h);
         }
 
         public static int CombineHashCodes(IEnumerable<int> h)
         {
-          return h == null ? 0 : h.Aggregate(0, CombineHashCodes);
+            return h == null ? 0 : h.Aggregate(0, CombineHashCodes);
         }
 
         public static int GetStructuralHashCode<T1, T2>(T1 x1, T2 x2)
         {
-          return CombineHashCodes(x1.GetHashCode(), x2.GetHashCode());
+            return CombineHashCodes(x1.GetHashCode(), x2.GetHashCode());
         }
 
         public static int GetStructuralHashCode<T1, T2, T3>(T1 x1, T2 x2, T3 x3)
         {
-          return CombineHashCodes(x1.GetHashCode(), x2.GetHashCode(), x3.GetHashCode());
+            return CombineHashCodes(x1.GetHashCode(), x2.GetHashCode(), x3.GetHashCode());
         }
 
         public static int GetStructuralHashCode<T1, T2, T3, T4>(T1 x1, T2 x2, T3 x3, T4 x4)
         {
-          return CombineHashCodes(x1.GetHashCode(), x2.GetHashCode(), x3.GetHashCode(), x4.GetHashCode());
+            return CombineHashCodes(x1.GetHashCode(), x2.GetHashCode(), x3.GetHashCode(), x4.GetHashCode());
         }
     }
 }

--- a/Microsoft.Research/DataStructures/HashSetPriorityQueue.cs
+++ b/Microsoft.Research/DataStructures/HashSetPriorityQueue.cs
@@ -1,145 +1,134 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Research.DataStructures
 {
-  /// <summary>
-  /// A heap-based priority queue with a Remove operation ruled by a customizable dictionary
-  /// </summary>
-  public class HashSetPriorityQueue<T>
-  {
-    protected static readonly T[] emptyArray = new T[0];
-
-    protected T[] heap = emptyArray;
-    protected int count = 0;
-    protected readonly IDictionary<T, int> indexInHeap;
-    protected readonly IComparer<T> priorityComparer;
-    
-    private HashSetPriorityQueue(IComparer<T> priorityComparer, IDictionary<T, int> indexInHeap)
+    /// <summary>
+    /// A heap-based priority queue with a Remove operation ruled by a customizable dictionary
+    /// </summary>
+    public class HashSetPriorityQueue<T>
     {
-      this.priorityComparer = priorityComparer;
-      this.indexInHeap = indexInHeap;
-    }
+        protected static readonly T[] emptyArray = new T[0];
 
-    public HashSetPriorityQueue(IComparer<T> priorityComparer, IEqualityComparer<T> hashComparer)
-      : this(priorityComparer, new Dictionary<T, int>(hashComparer))
-    { }
+        protected T[] heap = emptyArray;
+        protected int count = 0;
+        protected readonly IDictionary<T, int> indexInHeap;
+        protected readonly IComparer<T> priorityComparer;
 
-    public HashSetPriorityQueue()
-      : this(Comparer<T>.Default, new Dictionary<T, int>())
-    { }
-
-    public static HashSetPriorityQueue<T> Create<TDic>(IComparer<T> priorityComparer)
-      where TDic : IDictionary<T, int>, new()
-    {
-      return new HashSetPriorityQueue<T>(priorityComparer, new TDic());
-    }
-
-    public static HashSetPriorityQueue<T> Create<TDic>()
-      where TDic : IDictionary<T, int>, new()
-    {
-      return Create<TDic>(Comparer<T>.Default);
-    }
-
-    public int Count { get { return this.count; } }
-
-    public bool Add(T item)
-    {
-      if (this.indexInHeap.ContainsKey(item))
-        return false;
-
-      this.EnsureCapacity(this.count + 2);
-      var index = ++this.count;
-
-      while (index > 1)
-      {
-        var parent = this.heap[index >> 1];
-        if (!this.GreaterThan(item, parent))
-          break;
-        this.heap[index] = parent;
-        this.indexInHeap[parent] = index;
-        index >>= 1;
-      }
-      this.heap[index] = item;
-      this.indexInHeap[item] = index;
-
-      return true;
-    }
-
-    public T Top
-    {
-      get
-      {
-        if (this.count == 0)
-          throw new InvalidOperationException("SortedHashSet is empty");
-        return this.heap[1];
-      }
-    }
-
-    public bool Remove(T item)
-    {
-      int index;
-      if (!this.indexInHeap.TryGetValue(item, out index))
-        return false;
-      this.indexInHeap.Remove(item);
-      var last = this.heap[this.count];
-      this.heap[this.count] = default(T);
-      if (index == this.count--)
-        return true;
-      var indexLeft = index << 1;
-      while (indexLeft <= this.count)
-      {
-        var indexRight = indexLeft + 1;
-        var indexLargest = indexRight;
-        if (this.GreaterThan(this.heap[indexLeft], last))
+        private HashSetPriorityQueue(IComparer<T> priorityComparer, IDictionary<T, int> indexInHeap)
         {
-          if (indexRight > this.count || !this.GreaterThan(this.heap[indexRight], this.heap[indexLeft]))
-            indexLargest = indexLeft;
+            this.priorityComparer = priorityComparer;
+            this.indexInHeap = indexInHeap;
         }
-        else if (indexRight > this.count || !this.GreaterThan(this.heap[indexRight], last))
-          break;
-        this.heap[index] = this.heap[indexLargest];
-        this.indexInHeap[this.heap[index]] = index;
-        index = indexLargest;
-        indexLeft = index << 1;
-      }
-      this.heap[index] = last;
-      this.indexInHeap[last] = index;
-      return true;
-    }
 
-    public T Pop()
-    {
-      var top = this.Top;
-      this.Remove(top);
-      return top;
-    }
+        public HashSetPriorityQueue(IComparer<T> priorityComparer, IEqualityComparer<T> hashComparer)
+          : this(priorityComparer, new Dictionary<T, int>(hashComparer))
+        { }
 
-    protected void EnsureCapacity(int min)
-    {
-      if (this.heap.Length >= min)
-        return;
+        public HashSetPriorityQueue()
+          : this(Comparer<T>.Default, new Dictionary<T, int>())
+        { }
 
-      Array.Resize(ref this.heap, Math.Max(min, this.heap.Length * 2));
-    }
+        public static HashSetPriorityQueue<T> Create<TDic>(IComparer<T> priorityComparer)
+          where TDic : IDictionary<T, int>, new()
+        {
+            return new HashSetPriorityQueue<T>(priorityComparer, new TDic());
+        }
 
-    protected bool GreaterThan(T x, T y)
-    {
-      return this.priorityComparer.Compare(x, y) > 0;
+        public static HashSetPriorityQueue<T> Create<TDic>()
+          where TDic : IDictionary<T, int>, new()
+        {
+            return Create<TDic>(Comparer<T>.Default);
+        }
+
+        public int Count { get { return this.count; } }
+
+        public bool Add(T item)
+        {
+            if (this.indexInHeap.ContainsKey(item))
+                return false;
+
+            this.EnsureCapacity(this.count + 2);
+            var index = ++this.count;
+
+            while (index > 1)
+            {
+                var parent = this.heap[index >> 1];
+                if (!this.GreaterThan(item, parent))
+                    break;
+                this.heap[index] = parent;
+                this.indexInHeap[parent] = index;
+                index >>= 1;
+            }
+            this.heap[index] = item;
+            this.indexInHeap[item] = index;
+
+            return true;
+        }
+
+        public T Top
+        {
+            get
+            {
+                if (this.count == 0)
+                    throw new InvalidOperationException("SortedHashSet is empty");
+                return this.heap[1];
+            }
+        }
+
+        public bool Remove(T item)
+        {
+            int index;
+            if (!this.indexInHeap.TryGetValue(item, out index))
+                return false;
+            this.indexInHeap.Remove(item);
+            var last = this.heap[this.count];
+            this.heap[this.count] = default(T);
+            if (index == this.count--)
+                return true;
+            var indexLeft = index << 1;
+            while (indexLeft <= this.count)
+            {
+                var indexRight = indexLeft + 1;
+                var indexLargest = indexRight;
+                if (this.GreaterThan(this.heap[indexLeft], last))
+                {
+                    if (indexRight > this.count || !this.GreaterThan(this.heap[indexRight], this.heap[indexLeft]))
+                        indexLargest = indexLeft;
+                }
+                else if (indexRight > this.count || !this.GreaterThan(this.heap[indexRight], last))
+                    break;
+                this.heap[index] = this.heap[indexLargest];
+                this.indexInHeap[this.heap[index]] = index;
+                index = indexLargest;
+                indexLeft = index << 1;
+            }
+            this.heap[index] = last;
+            this.indexInHeap[last] = index;
+            return true;
+        }
+
+        public T Pop()
+        {
+            var top = this.Top;
+            this.Remove(top);
+            return top;
+        }
+
+        protected void EnsureCapacity(int min)
+        {
+            if (this.heap.Length >= min)
+                return;
+
+            Array.Resize(ref this.heap, Math.Max(min, this.heap.Length * 2));
+        }
+
+        protected bool GreaterThan(T x, T y)
+        {
+            return this.priorityComparer.Compare(x, y) > 0;
+        }
     }
-  }
 }

--- a/Microsoft.Research/DataStructures/LazyEval.cs
+++ b/Microsoft.Research/DataStructures/LazyEval.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,36 +9,36 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.DataStructures
 {
-  public class LazyEval<T>
-  {
-    private readonly Func<T> func;
-    private Optional<T> value;
-
-    public T Value
+    public class LazyEval<T>
     {
-      get
-      {
-        if (!this.value.IsValid)
+        private readonly Func<T> func;
+        private Optional<T> value;
+
+        public T Value
         {
-          this.value = func();
+            get
+            {
+                if (!value.IsValid)
+                {
+                    value = func();
+                }
+
+                return value.Value;
+            }
         }
 
-        return this.value.Value;
-      }
+        public LazyEval(Func<T> func)
+        {
+            Contract.Requires(func != null);
+
+            this.func = func;
+        }
+
+        public LazyEval(LazyEval<T> l)
+        {
+            Contract.Requires(l != null);
+
+            value = l.value;
+        }
     }
-
-    public LazyEval(Func<T> func)
-    {
-      Contract.Requires(func != null);
-
-      this.func = func;
-    }
-
-    public LazyEval(LazyEval<T> l)
-    {
-      Contract.Requires(l != null);
-
-      this.value = l.value;
-    }
-  }
 }

--- a/Microsoft.Research/DataStructures/MemoryObjectSet.cs
+++ b/Microsoft.Research/DataStructures/MemoryObjectSet.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections;
@@ -21,28 +10,28 @@ using System.Linq.Expressions;
 
 namespace Microsoft.Research.DataStructures
 {
-  public class MemoryObjectSet<T> : IObjectSet<T>
-    where T : class
-  {
-    private readonly HashSet<T> data;
-    private readonly IQueryable queryable;
-
-    public MemoryObjectSet() : this(new HashSet<T>()) { }
-
-    public MemoryObjectSet(HashSet<T> data)
+    public class MemoryObjectSet<T> : IObjectSet<T>
+      where T : class
     {
-      this.data = data;
-      this.queryable = data.AsQueryable();
-    }
+        private readonly HashSet<T> data;
+        private readonly IQueryable queryable;
 
-    public void AddObject(T item) { this.data.Add(item); }
-    public void DeleteObject(T item) { this.data.Remove(item); }
-    public void Attach(T item) { this.data.Add(item); throw new NotImplementedException("Need to also add a link from item to the set, right?"); }
-    public void Detach(T item) { this.data.Remove(item); throw new NotImplementedException("Need to also remove the link from item to the set, right?"); }
-    IEnumerator IEnumerable.GetEnumerator() { return this.data.GetEnumerator(); }
-    IEnumerator<T> IEnumerable<T>.GetEnumerator() { return this.data.GetEnumerator(); }
-    Type IQueryable.ElementType { get { return this.queryable.ElementType; } }
-    Expression IQueryable.Expression { get { return this.queryable.Expression; } }
-    IQueryProvider IQueryable.Provider { get { return this.queryable.Provider; } }
-  }
+        public MemoryObjectSet() : this(new HashSet<T>()) { }
+
+        public MemoryObjectSet(HashSet<T> data)
+        {
+            this.data = data;
+            queryable = data.AsQueryable();
+        }
+
+        public void AddObject(T item) { data.Add(item); }
+        public void DeleteObject(T item) { data.Remove(item); }
+        public void Attach(T item) { data.Add(item); throw new NotImplementedException("Need to also add a link from item to the set, right?"); }
+        public void Detach(T item) { data.Remove(item); throw new NotImplementedException("Need to also remove the link from item to the set, right?"); }
+        IEnumerator IEnumerable.GetEnumerator() { return data.GetEnumerator(); }
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { return data.GetEnumerator(); }
+        Type IQueryable.ElementType { get { return queryable.ElementType; } }
+        Expression IQueryable.Expression { get { return queryable.Expression; } }
+        IQueryProvider IQueryable.Provider { get { return queryable.Provider; } }
+    }
 }

--- a/Microsoft.Research/DataStructures/MethodHashAttribute.cs
+++ b/Microsoft.Research/DataStructures/MethodHashAttribute.cs
@@ -1,74 +1,62 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-
-  [Flags]
-  public enum MethodHashAttributeFlags
-  {
-    Default = 0,
-    OnlyFromCache = 1, // means that the result of the analysis can only be read from cache but shouldn't be computed by clousot (e.g. method with empty body)
-    Reuse = 2, // means that we should try to get the latest available result for the id of this method (ignoring its hash)
-    IdIsHash = 4, // means that the method id should also be considered is hash (e.g. method with empty body)
-    IgnoreRegression = 8, // means that we should ignore the regression attribute for this method
-    ReplayOnlyInferredContracts = 16, // means that we read from the cache, outcomes, suggestions, stats, etc. should not be replayed (e.g. APCs coming from other assemblies)
-    FirstInOrder = 32, // means that the methodOrder will put these methods first
-
-    ForDependenceMethod = OnlyFromCache | Reuse | IdIsHash | IgnoreRegression | ReplayOnlyInferredContracts | FirstInOrder,
-  }
-
-  public class MethodHashAttribute : Attribute
-  {
-    private readonly ByteArray methodId;
-    private readonly MethodHashAttributeFlags flags;
-
-    public MethodHashAttribute(ByteArray methodId, MethodHashAttributeFlags flags)
+    [Flags]
+    public enum MethodHashAttributeFlags
     {
-      this.methodId = methodId;
-      this.flags = flags;
+        Default = 0,
+        OnlyFromCache = 1, // means that the result of the analysis can only be read from cache but shouldn't be computed by clousot (e.g. method with empty body)
+        Reuse = 2, // means that we should try to get the latest available result for the id of this method (ignoring its hash)
+        IdIsHash = 4, // means that the method id should also be considered is hash (e.g. method with empty body)
+        IgnoreRegression = 8, // means that we should ignore the regression attribute for this method
+        ReplayOnlyInferredContracts = 16, // means that we read from the cache, outcomes, suggestions, stats, etc. should not be replayed (e.g. APCs coming from other assemblies)
+        FirstInOrder = 32, // means that the methodOrder will put these methods first
+
+        ForDependenceMethod = OnlyFromCache | Reuse | IdIsHash | IgnoreRegression | ReplayOnlyInferredContracts | FirstInOrder,
     }
 
-    public static MethodHashAttribute FromDecoder(IIndexable<object> args)
+    public class MethodHashAttribute : Attribute
     {
-      if (args == null || args.Count != 2)
-        return null;
+        private readonly ByteArray methodId;
+        private readonly MethodHashAttributeFlags flags;
 
-      var hashObj = args[0]; // it can be null, when generated at the Slicer level
-      var flagsObj = args[1];
+        public MethodHashAttribute(ByteArray methodId, MethodHashAttributeFlags flags)
+        {
+            this.methodId = methodId;
+            this.flags = flags;
+        }
 
-      if ((hashObj == null || hashObj is string) && (flagsObj is int))
-      {
-        var flags = (MethodHashAttributeFlags)(int)flagsObj;
-        var methodHash = new ByteArray(hashObj as string);
+        public static MethodHashAttribute FromDecoder(IIndexable<object> args)
+        {
+            if (args == null || args.Count != 2)
+                return null;
 
-        return new MethodHashAttribute(methodHash, flags);
-      }
-      else
-      {
-        return null;
-      }
+            var hashObj = args[0]; // it can be null, when generated at the Slicer level
+            var flagsObj = args[1];
+
+            if ((hashObj == null || hashObj is string) && (flagsObj is int))
+            {
+                var flags = (MethodHashAttributeFlags)(int)flagsObj;
+                var methodHash = new ByteArray(hashObj as string);
+
+                return new MethodHashAttribute(methodHash, flags);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public ByteArray MethodId { get { return methodId; } }
+        public MethodHashAttributeFlags Flags { get { return flags; } }
+
+        // For the code writer
+        public string Arg1 { get { return methodId == null ? "" : methodId.ToString(); } }
+        public int Arg2 { get { return (int)flags; } }
     }
-
-    public ByteArray MethodId { get { return this.methodId; } }
-    public MethodHashAttributeFlags Flags { get { return this.flags; } }
-
-    // For the code writer
-    public string Arg1 { get { return this.methodId == null ? "" : this.methodId.ToString(); } }
-    public int Arg2 { get { return (int)this.flags; } }
-  }
 }

--- a/Microsoft.Research/DataStructures/NonNullList.cs
+++ b/Microsoft.Research/DataStructures/NonNullList.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,273 +8,272 @@ using System.Text;
 using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.DataStructures
-{  
-  [ContractVerification(true)]
-  public class NonNullList<T>
-    : IEnumerable<T>
-    where T : class
-  {
-    #region ObjectInvariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+{
+    [ContractVerification(true)]
+    public class NonNullList<T>
+      : IEnumerable<T>
+      where T : class
     {
-      Contract.Invariant(this.values != null);
-      Contract.Invariant(this.pos >= 0);
-      Contract.Invariant(this.pos <= this.values.Length);
-      Contract.Invariant(Contract.ForAll(0, this.pos, i => this.values[i] != null));
-    }
-
-    #endregion
-
-    #region Private state
-    private T[] values;
-    private int pos;
-    #endregion
-
-    #region Constructor
-    public NonNullList()
-      : this(4)
-    {
-      Contract.Ensures(this.Count == 0);
-    }
-
-    public NonNullList(int size)
-    {
-      Contract.Requires(size >= 0);
-
-      Contract.Ensures(this.Count == 0);
-
-      this.values = new T[size];
-      this.pos = 0;
-    }
-
-    public NonNullList(NonNullList<T> other)
-    {
-      Contract.Requires(other != null);
-
-      Contract.Ensures(this.Count == other.Count);
-
-      // F: Assuming the object invariant for other
-      Contract.Assume(other.values != null);
-      Contract.Assume(other.pos >= 0);
-      Contract.Assume(other.pos <= other.values.Length);
-      Contract.Assume(Contract.ForAll(0, other.pos, i => other.values[i] != null));
-
-      this.values = new T[other.values.Length];
-      this.pos = other.pos;
-
-      for (var i = 0; i < other.pos; i++)
-      {
-        Contract.Assert(other.values[i] != null);
-
-        this.values[i] = other.values[i];
-      }
-
-    }
-
-    private NonNullList(T[] values, int pos)
-    {
-      Contract.Requires(values != null);
-      Contract.Requires(pos >= 0);
-      Contract.Requires(pos <= values.Length);
-      Contract.Requires(Contract.ForAll(0, pos, i => values[i] != null));
-
-      Contract.Ensures(this.Count == pos);
-
-      this.values = values;
-      this.pos = pos;
-    }
-
-    #endregion
-
-    #region Getters
-
-    public bool IsEmpty
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<bool>() == (this.pos == 0));
-
-        return this.pos == 0;
-      }
-    }
-
-    public int Count
-    {
-      get
-      {
-       Contract.Ensures(Contract.Result<int>() >= 0);
-       Contract.Ensures(Contract.Result<int>() == this.pos);
-
-        return this.pos;
-      }
-    }
-
-    public T this[int index]
-    {
-      get
-      {
-        Contract.Requires(index >= 0);
-        Contract.Requires(index < this.Count);
-
-        Contract.Ensures(Contract.Result<T>() != null);
-
-        Contract.Assert(index < this.pos);
-
-        return this.values[index];
-      }
-      set
-      {
-        Contract.Requires(index >= 0);
-        Contract.Requires(index < this.Count);
- 
-        Contract.Requires(value != null);
-
-        Contract.Ensures(this.pos == Contract.OldValue(this.pos));
-
-        this.values[index] = value;
-      }
-    }
-
-    #endregion
-
-    public void Add(T value)
-    {
-      Contract.Requires(value != null);
-
-      Contract.Ensures(this.Count == Contract.OldValue(this.Count) + 1);
-
-      if (this.pos == this.values.Length)
-      {
-        var newArr = new T[this.values.Length * 2 + 1];
-
-        // TODO F: there is an imprecision in the array analysis: If we use this.values.Length instead of this.pos it does not work
-        for (var i = 0; i < this.pos; i++)
+        #region ObjectInvariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          newArr[i] = this.values[i];
+            Contract.Invariant(values != null);
+            Contract.Invariant(pos >= 0);
+            Contract.Invariant(pos <= values.Length);
+            Contract.Invariant(Contract.ForAll(0, pos, i => values[i] != null));
         }
 
-        this.values = newArr;
-      }
+        #endregion
 
-      this.values[pos++] = value;
-    }
+        #region Private state
+        private T[] values;
+        private int pos;
+        #endregion
 
-    public void InsertOrAdd(int index, T value)
-    {
-      Contract.Requires(value != null);
-
-      Contract.Requires(index >= 0);
-      Contract.Requires(index <= this.Count);
-
-      Contract.Ensures(this.Count == Contract.OldValue(this.Count) + 1);
-
-      if (index == this.Count)
-      {
-        this.Add(value);
-        return;
-      }
-
-      if (this.pos == this.values.Length)
-      {
-        var newArr = new T[this.values.Length * 2 + 1];
-        for (var i = 0; i < index; i++)
+        #region Constructor
+        public NonNullList()
+          : this(4)
         {
-          newArr[i] = this.values[i];
+            Contract.Ensures(this.Count == 0);
         }
 
-        newArr[index] = value;
-        this.pos++;
-
-        for (var i = index + 1; i < this.pos; i++)
+        public NonNullList(int size)
         {
-          newArr[i] = this.values[i - 1];
+            Contract.Requires(size >= 0);
+
+            Contract.Ensures(this.Count == 0);
+
+            values = new T[size];
+            pos = 0;
         }
 
-        this.values = newArr;
-      }
-      else
-      {
-        // F: unrolling the first loop helps Clousot to prove the invariant.
-        this.values[pos] = this.values[pos - 1];
-
-        for (var i = pos - 1; i > index; i--)
+        public NonNullList(NonNullList<T> other)
         {
-          Contract.Assert(this.values[i] != null);
-          Contract.Assert(this.values[i - 1] != null);
+            Contract.Requires(other != null);
 
-          this.values[i] = this.values[i - 1];
+            Contract.Ensures(this.Count == other.Count);
+
+            // F: Assuming the object invariant for other
+            Contract.Assume(other.values != null);
+            Contract.Assume(other.pos >= 0);
+            Contract.Assume(other.pos <= other.values.Length);
+            Contract.Assume(Contract.ForAll(0, other.pos, i => other.values[i] != null));
+
+            values = new T[other.values.Length];
+            pos = other.pos;
+
+            for (var i = 0; i < other.pos; i++)
+            {
+                Contract.Assert(other.values[i] != null);
+
+                values[i] = other.values[i];
+            }
         }
 
-        this.values[index] = value;
-        this.pos++;
-      }
+        private NonNullList(T[] values, int pos)
+        {
+            Contract.Requires(values != null);
+            Contract.Requires(pos >= 0);
+            Contract.Requires(pos <= values.Length);
+            Contract.Requires(Contract.ForAll(0, pos, i => values[i] != null));
+
+            Contract.Ensures(this.Count == pos);
+
+            this.values = values;
+            this.pos = pos;
+        }
+
+        #endregion
+
+        #region Getters
+
+        public bool IsEmpty
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<bool>() == (pos == 0));
+
+                return pos == 0;
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                Contract.Ensures(Contract.Result<int>() == pos);
+
+                return pos;
+            }
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                Contract.Requires(index >= 0);
+                Contract.Requires(index < this.Count);
+
+                Contract.Ensures(Contract.Result<T>() != null);
+
+                Contract.Assert(index < pos);
+
+                return values[index];
+            }
+            set
+            {
+                Contract.Requires(index >= 0);
+                Contract.Requires(index < this.Count);
+
+                Contract.Requires(value != null);
+
+                Contract.Ensures(pos == Contract.OldValue(pos));
+
+                values[index] = value;
+            }
+        }
+
+        #endregion
+
+        public void Add(T value)
+        {
+            Contract.Requires(value != null);
+
+            Contract.Ensures(this.Count == Contract.OldValue(this.Count) + 1);
+
+            if (pos == values.Length)
+            {
+                var newArr = new T[values.Length * 2 + 1];
+
+                // TODO F: there is an imprecision in the array analysis: If we use this.values.Length instead of this.pos it does not work
+                for (var i = 0; i < pos; i++)
+                {
+                    newArr[i] = values[i];
+                }
+
+                values = newArr;
+            }
+
+            values[pos++] = value;
+        }
+
+        public void InsertOrAdd(int index, T value)
+        {
+            Contract.Requires(value != null);
+
+            Contract.Requires(index >= 0);
+            Contract.Requires(index <= this.Count);
+
+            Contract.Ensures(this.Count == Contract.OldValue(this.Count) + 1);
+
+            if (index == this.Count)
+            {
+                this.Add(value);
+                return;
+            }
+
+            if (pos == values.Length)
+            {
+                var newArr = new T[values.Length * 2 + 1];
+                for (var i = 0; i < index; i++)
+                {
+                    newArr[i] = values[i];
+                }
+
+                newArr[index] = value;
+                pos++;
+
+                for (var i = index + 1; i < pos; i++)
+                {
+                    newArr[i] = values[i - 1];
+                }
+
+                values = newArr;
+            }
+            else
+            {
+                // F: unrolling the first loop helps Clousot to prove the invariant.
+                values[pos] = values[pos - 1];
+
+                for (var i = pos - 1; i > index; i--)
+                {
+                    Contract.Assert(values[i] != null);
+                    Contract.Assert(values[i - 1] != null);
+
+                    values[i] = values[i - 1];
+                }
+
+                values[index] = value;
+                pos++;
+            }
+        }
+
+        [Pure]
+        public T GetLastElement()
+        {
+            Contract.Requires(!this.IsEmpty);
+
+            Contract.Ensures(Contract.Result<T>() != null);
+
+            return values[pos - 1];
+        }
+
+        public override string ToString()
+        {
+            var result = new StringBuilder();
+
+            for (var i = 0; i < pos; i++)
+            {
+                result.AppendFormat("{0} ", values[i]);
+            }
+
+            return result.ToString();
+        }
+
+        #region Convert
+        [Pure]
+        public NonNullList<U> ConvertAll<U>(Converter<T, U> converter)
+          where U : class
+        {
+            Contract.Requires(converter != null);
+            Contract.Ensures(Contract.Result<NonNullList<U>>() != null);
+            Contract.Ensures(Contract.Result<NonNullList<U>>().Count == this.Count);
+
+            var result = new U[values.Length];
+
+            for (var i = 0; i < pos; i++)
+            {
+                var conv = converter(values[i]);
+                Contract.Assume(conv != null);  // We cannot really prove it as it involves a higher-order contract on converter 
+
+                result[i] = conv;
+            }
+
+            return new NonNullList<U>(result, pos);
+        }
+        #endregion
+
+        #region IEnumerable<T> Members
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (var i = 0; i < pos; i++)
+            {
+                yield return values[i];
+            }
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return values.GetEnumerator();
+        }
+
+        #endregion
     }
-
-    [Pure]
-    public T GetLastElement()
-    {
-      Contract.Requires(!this.IsEmpty);
-
-      Contract.Ensures(Contract.Result<T>() != null);
-
-      return this.values[pos - 1];
-    }
-
-    public override string ToString()
-    {
-      var result = new StringBuilder();
-
-      for (var i = 0; i < this.pos; i++)
-      {
-        result.AppendFormat("{0} ", this.values[i]);
-      }
-
-      return result.ToString();
-    }
-
-    #region Convert
-    [Pure]
-    public NonNullList<U> ConvertAll<U>(Converter<T, U> converter)
-      where U: class
-    {
-      Contract.Requires(converter != null);
-      Contract.Ensures(Contract.Result<NonNullList<U>>() != null);
-      Contract.Ensures(Contract.Result<NonNullList<U>>().Count == this.Count);
-
-      var result = new U[this.values.Length];
-
-      for (var i = 0; i < this.pos; i++)
-      {
-        var conv = converter(this.values[i]);
-        Contract.Assume(conv != null);  // We cannot really prove it as it involves a higher-order contract on converter 
-
-        result[i] = conv;
-      }
-
-      return new NonNullList<U>(result, this.pos);
-    }
-    #endregion
-
-    #region IEnumerable<T> Members
-
-    public IEnumerator<T> GetEnumerator()
-    {
-      for (var i = 0; i < this.pos; i++)
-      {
-        yield return this.values[i];
-      }
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      return this.values.GetEnumerator();
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/DataStructures/ObjectEqualityComparer.cs
+++ b/Microsoft.Research/DataStructures/ObjectEqualityComparer.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;

--- a/Microsoft.Research/DataStructures/OnDemandMap.cs
+++ b/Microsoft.Research/DataStructures/OnDemandMap.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,307 +8,306 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.DataStructures
 {
-  public struct OnDemandMap<Key, Value>
-  {
-    Dictionary<Key, Value> dictionary;
-
-    private Dictionary<Key, Value> Ensure()
+    public struct OnDemandMap<Key, Value>
     {
-      if (dictionary == null)
-      {
-        dictionary = new Dictionary<Key, Value>();
-      }
-      return dictionary;
-    }
+        private Dictionary<Key, Value> dictionary;
 
-    public void Add(Key key, Value value)
-    {
-      var dict = Ensure();
-      dict.Add(key, value);
-    }
-
-    public Value this[Key key]
-    {
-      get
-      {
-        if (dictionary == null)
+        private Dictionary<Key, Value> Ensure()
         {
-          throw new KeyNotFoundException(key.ToString());
+            if (dictionary == null)
+            {
+                dictionary = new Dictionary<Key, Value>();
+            }
+            return dictionary;
         }
-        return dictionary[key];
-      }
-      set
-      {
-        var dict = Ensure();
-        dict[key] = value;
-      }
-    }
 
-    public bool TryGetValue(Key key, out Value value)
-    {
-      if (this.dictionary == null)
-      {
-        value = default(Value); return false;
-      }
-      return this.dictionary.TryGetValue(key, out value);
-    }
-
-    public IEnumerable<Value> Values
-    {
-      get
-      {
-        if (this.dictionary == null) { return new Value[0]; }
-        return this.dictionary.Values;
-      }
-    }
-
-    public bool ContainsKey(Key key)
-    {
-      if (this.dictionary == null) return false;
-      return dictionary.ContainsKey(key);
-    }
-
-    public IEnumerator<KeyValuePair<Key,Value>> GetEnumerator()
-    {
-      if (this.dictionary == null) yield break;
-      foreach (var kv in this.dictionary)
-      {
-        yield return kv;
-      }
-    }
-  }
-
-  public struct OnDemandSet<Key>
-  {
-    Set<Key> set;
-
-    private Set<Key> Ensure()
-    {
-      if (set == null)
-      {
-        set = new Set<Key>();
-      }
-      return set;
-    }
-
-    public void Add(Key key)
-    {
-      var set = Ensure();
-      set.Add(key);
-    }
-
-    public bool Contains(Key key)
-    {
-      if (this.set == null)
-      {
-        return false;
-      }
-      return this.set.Contains(key);
-    }
-
-    public IEnumerable<Key> Elements
-    {
-      get
-      {
-        if (this.set == null) { return new Key[0]; }
-        return this.set;
-      }
-    }
-
-  }
-
-  [ContractVerification(true)]
-  public struct OnDemandCache<Key, Value>
-  {
-    Dictionary<Key, Value> dictionary;
-    WrapQueue<KeyValuePair<Key, Value>> hitQueue;
-
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant((hitQueue == null) == (dictionary == null));
-    }
-
-    public int Capacity { get; set; }
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    private Dictionary<Key, Value> Ensure()
-    {
-      if (dictionary == null)
-      {
-        dictionary = new Dictionary<Key, Value>();
-      }
-      if (Capacity < 10)
-      {
-        Capacity = 1000;
-      }
-      if (this.hitQueue == null || this.hitQueue.Capacity != this.Capacity / 2)
-      {
-        this.hitQueue = new WrapQueue<KeyValuePair<Key, Value>>(this.Capacity / 2);
-      }
-      return dictionary;
-    }
-
-    public void Add(Key key, Value value)
-    {
-      var dict = Ensure();
-      dict.Add(key, value);
-      LimitCapacity(dict);
-    }
-
-    private void LimitCapacity(Dictionary<Key, Value> dict)
-    {
-      Contract.Requires(dict != null);
-      Contract.Requires(this.hitQueue != null);
-
-      if (dict.Count > this.Capacity)
-      {
-        dict.Clear();
-        foreach (var kv in this.hitQueue.Elements())
+        public void Add(Key key, Value value)
         {
-          dict[kv.Key] = kv.Value;
+            var dict = Ensure();
+            dict.Add(key, value);
         }
-      }
+
+        public Value this[Key key]
+        {
+            get
+            {
+                if (dictionary == null)
+                {
+                    throw new KeyNotFoundException(key.ToString());
+                }
+                return dictionary[key];
+            }
+            set
+            {
+                var dict = Ensure();
+                dict[key] = value;
+            }
+        }
+
+        public bool TryGetValue(Key key, out Value value)
+        {
+            if (dictionary == null)
+            {
+                value = default(Value); return false;
+            }
+            return dictionary.TryGetValue(key, out value);
+        }
+
+        public IEnumerable<Value> Values
+        {
+            get
+            {
+                if (dictionary == null) { return new Value[0]; }
+                return dictionary.Values;
+            }
+        }
+
+        public bool ContainsKey(Key key)
+        {
+            if (dictionary == null) return false;
+            return dictionary.ContainsKey(key);
+        }
+
+        public IEnumerator<KeyValuePair<Key, Value>> GetEnumerator()
+        {
+            if (dictionary == null) yield break;
+            foreach (var kv in dictionary)
+            {
+                yield return kv;
+            }
+        }
     }
+
+    public struct OnDemandSet<Key>
+    {
+        private Set<Key> set;
+
+        private Set<Key> Ensure()
+        {
+            if (set == null)
+            {
+                set = new Set<Key>();
+            }
+            return set;
+        }
+
+        public void Add(Key key)
+        {
+            var set = Ensure();
+            set.Add(key);
+        }
+
+        public bool Contains(Key key)
+        {
+            if (set == null)
+            {
+                return false;
+            }
+            return set.Contains(key);
+        }
+
+        public IEnumerable<Key> Elements
+        {
+            get
+            {
+                if (set == null) { return new Key[0]; }
+                return set;
+            }
+        }
+    }
+
+    [ContractVerification(true)]
+    public struct OnDemandCache<Key, Value>
+    {
+        private Dictionary<Key, Value> dictionary;
+        private WrapQueue<KeyValuePair<Key, Value>> hitQueue;
+
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant((hitQueue == null) == (dictionary == null));
+        }
+
+        public int Capacity { get; set; }
+
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        private Dictionary<Key, Value> Ensure()
+        {
+            if (dictionary == null)
+            {
+                dictionary = new Dictionary<Key, Value>();
+            }
+            if (Capacity < 10)
+            {
+                Capacity = 1000;
+            }
+            if (hitQueue == null || hitQueue.Capacity != this.Capacity / 2)
+            {
+                hitQueue = new WrapQueue<KeyValuePair<Key, Value>>(this.Capacity / 2);
+            }
+            return dictionary;
+        }
+
+        public void Add(Key key, Value value)
+        {
+            var dict = Ensure();
+            dict.Add(key, value);
+            LimitCapacity(dict);
+        }
+
+        private void LimitCapacity(Dictionary<Key, Value> dict)
+        {
+            Contract.Requires(dict != null);
+            Contract.Requires(hitQueue != null);
+
+            if (dict.Count > this.Capacity)
+            {
+                dict.Clear();
+                foreach (var kv in hitQueue.Elements())
+                {
+                    dict[kv.Key] = kv.Value;
+                }
+            }
+        }
 
 #if false
-    public Value this[Key key]
-    {
-      get
-      {
-        if (dictionary == null)
+        public Value this[Key key]
         {
-          throw new KeyNotFoundException(key.ToString());
+            get
+            {
+                if (dictionary == null)
+                {
+                    throw new KeyNotFoundException(key.ToString());
+                }
+                return dictionary[key];
+            }
+            set
+            {
+                var dict = Ensure();
+                dict[key] = value;
+            }
         }
-        return dictionary[key];
-      }
-      set
-      {
-        var dict = Ensure();
-        dict[key] = value;
-      }
-    }
 #endif
 
-    public bool TryGetValue(Key key, out Value value)
-    {
-      if (this.dictionary == null)
-      {
-        value = default(Value); return false;
-      }
-      var result = this.dictionary.TryGetValue(key, out value);
-      if (result)
-      {
-        // hit
-        this.hitQueue.Push(new KeyValuePair<Key, Value>(key, value));
-      }
-      return result;
-    }
-
-    public IEnumerable<Value> Values
-    {
-      get
-      {
-        if (this.dictionary == null) { return new Value[0]; }
-        return this.dictionary.Values;
-      }
-    }
-
-    public bool ContainsKey(Key key)
-    {
-      if (this.dictionary == null) return false;
-      return dictionary.ContainsKey(key);
-    }
-
-    public IEnumerator<KeyValuePair<Key, Value>> GetEnumerator()
-    {
-      if (this.dictionary == null) yield break;
-      foreach (var kv in this.dictionary)
-      {
-        yield return kv;
-      }
-    }
-  }
-
-  [ContractVerification(true)]
-  public class WrapQueue<T>
-  {
-    private T[] queue;
-    private int insertAt;
-    private int removeAt;
-
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(queue != null);
-      Contract.Invariant(insertAt >= 0);
-      Contract.Invariant(insertAt <= queue.Length);
-      Contract.Invariant(removeAt >= 0);
-      Contract.Invariant(removeAt <= queue.Length);
-      Contract.Invariant(queue.Length > 0);
-    }
-
-    public WrapQueue(int capacity)
-    {
-      Contract.Requires(capacity > 0);
-
-      this.queue = new T[capacity];
-    }
-
-    public int Capacity { get { return this.queue.Length; } }
-
-    public int Count
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        Contract.Ensures(Contract.Result<int>() <= this.Capacity);
-
-        if (this.insertAt >= this.removeAt) return this.insertAt - this.removeAt;
-        return this.queue.Length - this.removeAt + this.insertAt;
-      }
-    }
-
-    public void Push(T item)
-    {
-      if (this.insertAt >= queue.Length)
-      {
-        this.insertAt = 0;
-      }
-      if (this.Count == this.queue.Length)
-      { // at capacity
-        this.Pop();
-      }
-      queue[this.insertAt++] = item;
-    }
-
-
-    public T Pop()
-    {
-      Contract.Ensures(this.insertAt == Contract.OldValue(this.insertAt));
-      Contract.Ensures(this.queue == Contract.OldValue(this.queue));
-
-      if (this.Count > 0)
-      {
-        if (this.removeAt >= queue.Length)
+        public bool TryGetValue(Key key, out Value value)
         {
-          this.removeAt = 0;
+            if (dictionary == null)
+            {
+                value = default(Value); return false;
+            }
+            var result = dictionary.TryGetValue(key, out value);
+            if (result)
+            {
+                // hit
+                hitQueue.Push(new KeyValuePair<Key, Value>(key, value));
+            }
+            return result;
         }
-        return this.queue[this.removeAt++];
-      }
-      throw new InvalidOperationException("queue empty");
+
+        public IEnumerable<Value> Values
+        {
+            get
+            {
+                if (dictionary == null) { return new Value[0]; }
+                return dictionary.Values;
+            }
+        }
+
+        public bool ContainsKey(Key key)
+        {
+            if (dictionary == null) return false;
+            return dictionary.ContainsKey(key);
+        }
+
+        public IEnumerator<KeyValuePair<Key, Value>> GetEnumerator()
+        {
+            if (dictionary == null) yield break;
+            foreach (var kv in dictionary)
+            {
+                yield return kv;
+            }
+        }
     }
 
-    public IEnumerable<T> Elements()
+    [ContractVerification(true)]
+    public class WrapQueue<T>
     {
-      var limit = this.removeAt > this.insertAt ? this.insertAt + this.Capacity : this.insertAt;
+        private T[] queue;
+        private int insertAt;
+        private int removeAt;
 
-      for (int i = this.removeAt; i < limit; i++)
-      {
-        yield return this.queue[i % this.Capacity];
-      }
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(queue != null);
+            Contract.Invariant(insertAt >= 0);
+            Contract.Invariant(insertAt <= queue.Length);
+            Contract.Invariant(removeAt >= 0);
+            Contract.Invariant(removeAt <= queue.Length);
+            Contract.Invariant(queue.Length > 0);
+        }
+
+        public WrapQueue(int capacity)
+        {
+            Contract.Requires(capacity > 0);
+
+            queue = new T[capacity];
+        }
+
+        public int Capacity { get { return queue.Length; } }
+
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                Contract.Ensures(Contract.Result<int>() <= this.Capacity);
+
+                if (insertAt >= removeAt) return insertAt - removeAt;
+                return queue.Length - removeAt + insertAt;
+            }
+        }
+
+        public void Push(T item)
+        {
+            if (insertAt >= queue.Length)
+            {
+                insertAt = 0;
+            }
+            if (this.Count == queue.Length)
+            { // at capacity
+                this.Pop();
+            }
+            queue[insertAt++] = item;
+        }
+
+
+        public T Pop()
+        {
+            Contract.Ensures(insertAt == Contract.OldValue(insertAt));
+            Contract.Ensures(queue == Contract.OldValue(queue));
+
+            if (this.Count > 0)
+            {
+                if (removeAt >= queue.Length)
+                {
+                    removeAt = 0;
+                }
+                return queue[removeAt++];
+            }
+            throw new InvalidOperationException("queue empty");
+        }
+
+        public IEnumerable<T> Elements()
+        {
+            var limit = removeAt > insertAt ? insertAt + this.Capacity : insertAt;
+
+            for (int i = removeAt; i < limit; i++)
+            {
+                yield return queue[i % this.Capacity];
+            }
+        }
     }
-  }
 }

--- a/Microsoft.Research/DataStructures/OptionParsing.cs
+++ b/Microsoft.Research/DataStructures/OptionParsing.cs
@@ -1,27 +1,6 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-//-----------------------------------------------------------------------------
-//
 // Copyright (c) Microsoft. All rights reserved.
-// This code is licensed under the Microsoft Public License.
-// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
-// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
-// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
-// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
-//
-//-----------------------------------------------------------------------------
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
@@ -29,951 +8,954 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace Microsoft.Research.DataStructures {
-
-  
-  /// <summary>
-  /// Subclass this class and define public fields for options
-  /// </summary>
-  public abstract class OptionParsing
-  {
-    public OptionParsing()
+namespace Microsoft.Research.DataStructures
+{
+    /// <summary>
+    /// Subclass this class and define public fields for options
+    /// </summary>
+    public abstract class OptionParsing
     {
-      this.requiredOptions = GatherRequiredOptions();
-    }
-
-    /// <summary>
-    /// The number of errors discovered during command-line option parsing.
-    /// </summary>
-    protected int errors = 0;
-    private bool helpRequested;
-
-    /// <summary>
-    /// True if and only if a question mark was given as a command-line option.
-    /// </summary>
-    public bool HelpRequested { get { return helpRequested; } }
-
-    /// <summary>
-    /// True if and only if some command-line option caused a parsing error, or specifies an option
-    /// that does not exist.
-    /// </summary>
-    public bool HasErrors { get { return errors > 0; } }
-
-    List<string> errorMessages = new List<string>();
-
-    /// <summary>
-    /// Allows a client to signal that there is an error in the command-line options.
-    /// </summary>
-    public void AddError() { this.errors++; }
-
-    /// <summary>
-    /// Allows a client to signal that there is an error in the command-line options.
-    /// </summary>
-    public void AddError(string format, params object[] args)
-    {
-      this.AddMessage(format, args);
-      this.errors++;
-    }
-
-    /// <summary>
-    /// Allows a client add a message to the output.
-    /// </summary>
-    public void AddMessage(string format, params object[] args)
-    {
-      this.errorMessages.Add(String.Format(format, args));
-    }
-
-    protected IEnumerable<string> Messages { get { return this.errorMessages; } }
-
-    /// <summary>
-    /// Put this on fields if you want a more verbose help description
-    /// </summary>
-    protected class OptionDescription : Attribute
-    {
-      /// <summary>
-      /// The text that is shown when the usage is displayed.
-      /// </summary>
-      readonly public string Description;
-      /// <summary>
-      /// Constructor for creating the information about an option.
-      /// </summary>
-      public OptionDescription(string s) { this.Description = s; }
-      /// <summary>
-      /// Indicates whether the associated option is required or not.
-      /// </summary>
-      public bool Required { get; set; }
-      /// <summary>
-      /// Indicates a short form for the option. Very useful for options
-      /// whose names are reserved keywords.
-      /// </summary>
-      public string ShortForm { get; set; }
-    }
-
-    /// <summary>
-    /// Put this on fields if you want the field to be relevant when hashing an Option object
-    /// </summary>
-    protected class OptionWitness : Attribute { }
-
-    /// <summary>
-    /// If a field has this attribute, then its value is inherited by all the family of analyses
-    /// </summary>
-    public class OptionValueOverridesFamily : Attribute { }
-
-    /// <summary>
-    /// A way to have a single option be a macro for several options.
-    /// </summary>
-    protected class OptionFor : Attribute
-    {
-      /// <summary>
-      /// The field that this option is a macro for.
-      /// </summary>
-      readonly public string options;
-      /// <summary>
-      /// Constructor for specifying which field this is a macro option for.
-      /// </summary>
-      public OptionFor(string options)
-      {
-        this.options = options;
-      }
-    }
-
-    /// <summary>
-    /// Override and return false if options do not start with '-' or '/'
-    /// </summary>
-    protected virtual bool UseDashOptionPrefix { get { return true; } }
-
-    protected virtual bool TreatGeneralArgumentsAsUnknown { get { return false; } }
-
-    protected virtual bool TreatHelpArgumentAsUnknown { get { return false; } }
-
-    /// <summary>
-    /// This field will hold non-option arguments
-    /// </summary>
-    private readonly List<string> generalArguments = new List<string>();
-
-    /// <summary>
-    /// Initialized in constructor
-    /// </summary>
-    private IList<string> requiredOptions;
-
-    /// <summary>
-    /// The non-option arguments provided on the command line.
-    /// </summary>
-    public List<string> GeneralArguments { get { return this.generalArguments; } }
-
-    #region Parsing and Reflection
-
-    /// <summary>
-    /// Called when reflection based resolution does not find option
-    /// </summary>
-    /// <param name="option">option name (no - or /)</param>
-    /// <param name="args">all args being parsed</param>
-    /// <param name="index">current index of arg</param>
-    /// <param name="optionEqualsArgument">null, or the optionArgument when option was option=optionArgument</param>
-    /// <returns>true if option is recognized, false otherwise</returns>
-    protected virtual bool ParseUnknown(string option, string[] args, ref int index, string optionEqualsArgument)
-    {
-      return false;
-    }
-
-    protected virtual bool ParseGeneralArgument(string arg, string[] args, ref int index)
-    {
-      this.generalArguments.Add(arg);
-      return true;
-    }
-
-    // Also add '!' as synonim for '=', as cmd.exe performs fuzzy things with '='
-    private static readonly char[] equalChars = new char[] { ':', '=', '!' };
-    private static readonly char[] quoteChars = new char[] { '\'', '"' };
-
-    /// <summary>
-    /// Main method called by a client to process the command-line options.
-    /// </summary>
-    public void Parse(string[] args, bool parseResponseFile = true)
-    {
-      int index = 0;
-      while (index < args.Length)
-      {
-        string arg = args[index];
-
-        if (arg == "") { index++; continue; }
-
-        if (parseResponseFile && arg[0] == '@')
+        public OptionParsing()
         {
-          var responseFile = arg.Substring(1);
-          while (!ParseResponseFile(responseFile))
-          {
-            index++;
-            if (index < args.Length)
+            requiredOptions = GatherRequiredOptions();
+        }
+
+        /// <summary>
+        /// The number of errors discovered during command-line option parsing.
+        /// </summary>
+        protected int errors = 0;
+        private bool helpRequested;
+
+        /// <summary>
+        /// True if and only if a question mark was given as a command-line option.
+        /// </summary>
+        public bool HelpRequested { get { return helpRequested; } }
+
+        /// <summary>
+        /// True if and only if some command-line option caused a parsing error, or specifies an option
+        /// that does not exist.
+        /// </summary>
+        public bool HasErrors { get { return errors > 0; } }
+
+        private List<string> errorMessages = new List<string>();
+
+        /// <summary>
+        /// Allows a client to signal that there is an error in the command-line options.
+        /// </summary>
+        public void AddError() { this.errors++; }
+
+        /// <summary>
+        /// Allows a client to signal that there is an error in the command-line options.
+        /// </summary>
+        public void AddError(string format, params object[] args)
+        {
+            this.AddMessage(format, args);
+            this.errors++;
+        }
+
+        /// <summary>
+        /// Allows a client add a message to the output.
+        /// </summary>
+        public void AddMessage(string format, params object[] args)
+        {
+            errorMessages.Add(String.Format(format, args));
+        }
+
+        protected IEnumerable<string> Messages { get { return errorMessages; } }
+
+        /// <summary>
+        /// Put this on fields if you want a more verbose help description
+        /// </summary>
+        protected class OptionDescription : Attribute
+        {
+            /// <summary>
+            /// The text that is shown when the usage is displayed.
+            /// </summary>
+            readonly public string Description;
+            /// <summary>
+            /// Constructor for creating the information about an option.
+            /// </summary>
+            public OptionDescription(string s) { this.Description = s; }
+            /// <summary>
+            /// Indicates whether the associated option is required or not.
+            /// </summary>
+            public bool Required { get; set; }
+            /// <summary>
+            /// Indicates a short form for the option. Very useful for options
+            /// whose names are reserved keywords.
+            /// </summary>
+            public string ShortForm { get; set; }
+        }
+
+        /// <summary>
+        /// Put this on fields if you want the field to be relevant when hashing an Option object
+        /// </summary>
+        protected class OptionWitness : Attribute { }
+
+        /// <summary>
+        /// If a field has this attribute, then its value is inherited by all the family of analyses
+        /// </summary>
+        public class OptionValueOverridesFamily : Attribute { }
+
+        /// <summary>
+        /// A way to have a single option be a macro for several options.
+        /// </summary>
+        protected class OptionFor : Attribute
+        {
+            /// <summary>
+            /// The field that this option is a macro for.
+            /// </summary>
+            readonly public string options;
+            /// <summary>
+            /// Constructor for specifying which field this is a macro option for.
+            /// </summary>
+            public OptionFor(string options)
             {
-              responseFile = string.Format("{0} {1}", responseFile, args[index]);
+                this.options = options;
             }
-            else
-            {
-              AddError("Response file '{0}' does not exist.", responseFile);
-              break;
-            }
-          }
-        }
-        else if (!this.UseDashOptionPrefix || arg[0] == '/' || arg[0] == '-')
-        {
-          if (this.UseDashOptionPrefix)
-          {
-            arg = arg.Remove(0, 1);
-          }
-          if (arg == "?" && !this.TreatHelpArgumentAsUnknown)
-          {
-            this.helpRequested = true;
-            index++;
-            continue;
-          }
-
-          string equalArgument = null;
-          int equalIndex = arg.IndexOfAny(equalChars); // use IndexOfAny instead of sequential IndexOf to parse correctly -arg=abc://def
-          if (equalIndex >= 0)
-          {
-            equalArgument = arg.Substring(equalIndex + 1);
-            arg = arg.Substring(0, equalIndex);
-
-            // remove quotes if any
-            if (equalArgument.Length >= 2 && equalArgument[0] == equalArgument[equalArgument.Length - 1] && quoteChars.Contains(equalArgument[0]))
-              equalArgument = equalArgument.Substring(1, equalArgument.Length - 2);
-          }
-
-          bool optionOK = this.FindOptionByReflection(arg, args, ref index, equalArgument);
-          if (!optionOK)
-          {
-            optionOK = this.ParseUnknown(arg, args, ref index, equalArgument);
-            if (!optionOK)
-            {
-              AddError("Unknown option '{0}'", arg);
-            }
-          }
-        }
-        else if (this.TreatGeneralArgumentsAsUnknown)
-        {
-          bool optionOK = this.ParseUnknown(arg, args, ref index, null);
-          if (!optionOK)
-          {
-            AddError("Unknown option '{0}'", arg);
-          }
-        }
-        else
-        {
-          bool optionOK = this.ParseGeneralArgument(arg, args, ref index);
-          if (!optionOK)
-          {
-            AddError("Unknown option '{0}'", arg);
-          }
         }
 
-        index++;
-      }
-      if (!helpRequested) CheckRequiredOptions();
-    }
+        /// <summary>
+        /// Override and return false if options do not start with '-' or '/'
+        /// </summary>
+        protected virtual bool UseDashOptionPrefix { get { return true; } }
 
-    /// <returns>True, if file exists</returns>
-    private bool ParseResponseFile(string responseFile)
-    {
-      if (!File.Exists(responseFile))
-      {
-        return false;
-      }
-      try
-      {
-        var lines = File.ReadAllLines(responseFile);
-        for (int i = 0; i < lines.Length; i++)
+        protected virtual bool TreatGeneralArgumentsAsUnknown { get { return false; } }
+
+        protected virtual bool TreatHelpArgumentAsUnknown { get { return false; } }
+
+        /// <summary>
+        /// This field will hold non-option arguments
+        /// </summary>
+        private readonly List<string> generalArguments = new List<string>();
+
+        /// <summary>
+        /// Initialized in constructor
+        /// </summary>
+        private IList<string> requiredOptions;
+
+        /// <summary>
+        /// The non-option arguments provided on the command line.
+        /// </summary>
+        public List<string> GeneralArguments { get { return generalArguments; } }
+
+        #region Parsing and Reflection
+
+        /// <summary>
+        /// Called when reflection based resolution does not find option
+        /// </summary>
+        /// <param name="option">option name (no - or /)</param>
+        /// <param name="args">all args being parsed</param>
+        /// <param name="index">current index of arg</param>
+        /// <param name="optionEqualsArgument">null, or the optionArgument when option was option=optionArgument</param>
+        /// <returns>true if option is recognized, false otherwise</returns>
+        protected virtual bool ParseUnknown(string option, string[] args, ref int index, string optionEqualsArgument)
         {
-          var line = lines[i];
-          if (line.Length == 0) continue;
-          if (line[0] == '#') {
-            // comment skip
-            continue;
-          }
-          if (ContainsQuote(line))
-          {
-            Parse(SplitLineWithQuotes(responseFile, i, line));
-          }
-          else
-          {
-            // simple splitting
-            Parse(line.Split(' '));
-          }
+            return false;
         }
-      }
-      catch
-      {
-        AddError("Failure reading from response file '{0}'.", responseFile);
-      }
 
-      return true;
-    }
-
-    [Pure]
-    private string[] SplitLineWithQuotes(string responseFileName, int lineNo, string line)
-    {
-      var start = 0;
-      var args = new List<string>();
-      bool inDoubleQuotes = false;
-      int escaping = 0; // number of escape characters in sequence
-      var currentArg = new StringBuilder();
-
-      for (var index = 0; index < line.Length; index++ )
-      {
-        var current = line[index];
-
-        if (current == '\\')
+        protected virtual bool ParseGeneralArgument(string arg, string[] args, ref int index)
         {
-          // escape character
-          escaping++;
-          // swallow the escape character for now
-          // grab everything prior to prior escape character
-          if (index > start)
-          {
-            currentArg.Append(line.Substring(start, index - start));
-          }
-          start = index + 1;
-          continue;
-        }
-        if (escaping > 0)
-        {
-          if (current == '"')
-          {
-            var backslashes = escaping / 2;
-            for (int i = 0; i < backslashes; i++) { currentArg.Append('\\'); }
-            if (escaping % 2 == 1)
-            {
-              // escapes the "
-              currentArg.Append('"');
-              escaping = 0;
-              start = index + 1;
-              continue;
-            }
-          }
-          else
-          {
-            var backslashes = escaping;
-            for (int i = 0; i < backslashes; i++) { currentArg.Append('\\'); }
-          }
-          escaping = 0;
-        }
-        if (inDoubleQuotes)
-        {
-          if (current == '"')
-          {
-            // ending argument
-            FinishArgument(line, start, args, currentArg, index, true);
-            start = index + 1;
-            inDoubleQuotes = false;
-            continue;
-          }
-        }
-        else // not in quotes
-        {
-          if (Char.IsWhiteSpace(current))
-          {
-            // end previous, start new
-            FinishArgument(line, start, args, currentArg, index, false);
-            start = index + 1;
-            continue;
-          }
-          if (current == '"')
-          {
-            // starting double quote
-            if (index != start)
-            {
-              AddError("Response file '{0}' line {1}, char {2} contains '\"' not starting or ending an argument", responseFileName, lineNo, index);
-            }
-            start = index + 1;
-            inDoubleQuotes = true;
-            continue;
-          }
-        }
-      }
-      // add outstanding escape characters
-      while (escaping > 0) { currentArg.Append('\\'); escaping--; }
-      FinishArgument(line, start, args, currentArg, line.Length, inDoubleQuotes);
-      return args.ToArray();
-    }
-
-
-    [Pure]
-    static private void FinishArgument(string line, int start, List<string> args, StringBuilder currentArg, int index, bool includeEmpty)
-    {
-      currentArg.Append(line.Substring(start, index - start));
-      if (includeEmpty || currentArg.Length > 0)
-      {
-        args.Add(currentArg.ToString());
-        currentArg.Length = 0;
-      }
-    }
-
-    [Pure]
-    static private bool ContainsQuote(string line)
-    {
-      var index = line.IndexOf('"');
-      if (index >= 0) return true;
-      index = line.IndexOf('\'');
-      if (index >= 0) return true;
-      return false;
-    }
-
-
-    [Pure]
-    private void CheckRequiredOptions()
-    {
-      foreach (var missed in this.requiredOptions)
-      {
-        AddError("Required option '-{0}' was not given.", missed);
-      }
-    }
-
-    private IList<string> GatherRequiredOptions()
-    {
-      List<string> result = new List<string>();
-
-      foreach (var field in this.GetType().GetFields(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public))
-      {
-        var options = field.GetCustomAttributes(typeof(OptionDescription), false);
-        foreach (OptionDescription attr in options)
-        {
-          if (attr.Required)
-          {
-            result.Add(field.Name.ToLowerInvariant());
-          }
-        }
-      }
-      return result;
-    }
-
-    private bool ParseValue<T>(Converter<string, T> parser, string equalArgument, string[] args, ref int index, ref object result)
-    {
-      if (equalArgument == null)
-      {
-        if (index + 1 < args.Length)
-        {
-          equalArgument = args[++index];
-        }
-      }
-      bool success = false;
-      if (equalArgument != null)
-      {
-        try
-        {
-          result = parser(equalArgument);
-          success = true;
-        }
-        catch
-        {
-        }
-      }
-      return success;
-    }
-
-    private bool ParseValue<T>(Converter<string, T> parser, string argument, ref object result)
-    {
-      bool success = false;
-      if (argument != null)
-      {
-        try
-        {
-          result = parser(argument);
-          success = true;
-        }
-        catch
-        {
-        }
-      }
-      return success;
-    }
-
-    private object ParseValue(Type type, string argument, string option)
-    {
-      object result = null;
-      if (type == typeof(bool))
-      {
-        if (argument != null)
-        {
-          // Allow "+/-" to turn on/off boolean options
-          if (argument.Equals("-")) {
-            result = false;
-          } else if (argument.Equals("+")) {
-            result = true;
-          } else if (!ParseValue<bool>(Boolean.Parse, argument, ref result))
-          {
-            AddError("option -{0} requires a bool argument", option);
-          }
-        }
-        else
-        {
-          result = true;
-        }
-      }
-      else if (type == typeof(string))
-      {
-        if (!ParseValue<string>(Identity, argument, ref result))
-        {
-          AddError("option -{0} requires a string argument", option);
-        }
-      }
-      else if (type == typeof(int))
-      {
-        if (!ParseValue<int>(Int32.Parse, argument, ref result))
-        {
-          AddError("option -{0} requires an int argument", option);
-        }
-      }
-      else if (type == typeof(uint))
-      {
-        if (!ParseValue<uint>(UInt32.Parse, argument, ref result))
-        {
-          AddError("option -{0} requires an unsigned int argument", option);
-        }
-      }
-      else if (type == typeof(long))
-      {
-        if (!ParseValue<long>(Int64.Parse, argument, ref result))
-        {
-          AddError("option -{0} requires a long argument", option);
-        }
-      }
-      else if (type.IsEnum)
-      {
-        if (!ParseValue<object>(ParseEnum(type), argument, ref result))
-        {
-          AddError("option -{0} expects one of", option);
-
-          foreach (System.Reflection.FieldInfo enumConstant in type.GetFields(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public))
-          {
-            if (enumConstant.IsLiteral)
-            {
-              AddMessage("  {0}", enumConstant.Name);
-            }
-          }
-        }
-      }
-      return result;
-    }
-
-    [Pure]
-    private string AdvanceArgumentIfNoExplicitArg(Type type, string explicitArg, string[] args, ref int index)
-    {
-      if (explicitArg != null) return explicitArg;
-      if (type == typeof(bool))
-      {
-        // bool args don't grab the next arg
-        return null;
-      }
-      if (index + 1 < args.Length)
-      {
-        return args[++index];
-      }
-      return null;
-    }
-
-    private bool FindOptionByReflection(string arg, string[] args, ref int index, string explicitArgument)
-    {
-      System.Reflection.FieldInfo fi = this.GetType().GetField(arg, System.Reflection.BindingFlags.IgnoreCase | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
-      if (fi != null)
-      {
-        this.requiredOptions.Remove(arg.ToLowerInvariant());
-        return ProcessOptionWithMatchingField(arg, args, ref index, explicitArgument, ref fi);
-      }
-      else
-      {
-        // derived options
-        fi = this.GetType().GetField(arg, System.Reflection.BindingFlags.IgnoreCase | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.FlattenHierarchy);
-        if (fi != null)
-        {
-          object derived = fi.GetValue(this);
-
-          if (derived is string)
-          {
-            this.Parse(((string)derived).Split(' '));
-            this.requiredOptions.Remove(arg.ToLowerInvariant());
+            generalArguments.Add(arg);
             return true;
-          }
         }
 
-        // Try to see if the arg matches any ShortForm of an option
-        var allFields = this.GetType().GetFields();
-        System.Reflection.FieldInfo matchingField = null;
-        foreach (var f in allFields)
+        // Also add '!' as synonim for '=', as cmd.exe performs fuzzy things with '='
+        private static readonly char[] equalChars = new char[] { ':', '=', '!' };
+        private static readonly char[] quoteChars = new char[] { '\'', '"' };
+
+        /// <summary>
+        /// Main method called by a client to process the command-line options.
+        /// </summary>
+        public void Parse(string[] args, bool parseResponseFile = true)
         {
-          matchingField = f;
-          var options = matchingField.GetCustomAttributes(typeof(OptionDescription), false);
-          foreach (OptionDescription attr in options)
-          {
-            if (attr.ShortForm != null)
+            int index = 0;
+            while (index < args.Length)
             {
-              var lower1 = attr.ShortForm.ToLowerInvariant();
-              var lower2 = arg.ToLowerInvariant();
-              if (lower1.Equals(lower2))
-              {
-                this.requiredOptions.Remove(matchingField.Name.ToLowerInvariant());
-                return ProcessOptionWithMatchingField(arg, args, ref index, explicitArgument, ref matchingField);
-              }
-            }
-          }
-        }
-      }
-      return false;
-    }
+                string arg = args[index];
 
-    private bool ProcessOptionWithMatchingField(string arg, string[] args, ref int index, string explicitArgument, ref System.Reflection.FieldInfo fi)
-    {
-      Type type = fi.FieldType;
-      bool isList = false;
-      if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
-      {
-        isList = true;
-        type = type.GetGenericArguments()[0];
-      }
-      if (isList && explicitArgument == "!!")
-      {
-        // way to set list to empty
-        System.Collections.IList listhandle = (System.Collections.IList)fi.GetValue(this);
-        listhandle.Clear();
-        return true;
-      }
-      string argument = AdvanceArgumentIfNoExplicitArg(type, explicitArgument, args, ref index);
-      if (isList)
-      {
-        if (argument == null) {
-          AddError("option -{0} requires an argument", arg);
-          return true;
-        }
-        string[] listargs = argument.Split(';');
-        for (int i = 0; i < listargs.Length; i++)
-        {
-          if (listargs[i].Length == 0) continue; // skip empty values
-          bool remove = listargs[i][0] == '!';
-          string listarg = remove ? listargs[i].Substring(1) : listargs[i];
-          object value = ParseValue(type, listarg, arg);
-          if (value != null)
-          {
-            if (remove)
-            {
-              this.GetListField(fi).Remove(value);
-            }
-            else
-            {
-              this.GetListField(fi).Add(value);
-            }
-          }
-        }
-      }
-      else
-      {
-        object value = ParseValue(type, argument, arg);
-        if (value != null)
-        {
-          fi.SetValue(this, value);
+                if (arg == "") { index++; continue; }
 
-          string argname;
-          if (value is Int32 && HasOptionForAttribute(fi, out argname))
-          {
-            this.Parse(DerivedOptionFor(argname, (Int32)value).Split(' '));
-          }
-
-        }
-      }
-      return true;
-    }
-
-    [Pure]
-    private bool HasOptionForAttribute(System.Reflection.FieldInfo fi, out string argname)
-    {
-      var options = fi.GetCustomAttributes(typeof(OptionFor), true);
-      if (options != null && options.Length == 1)
-      {
-        argname = ((OptionFor)options[0]).options;
-        return true;
-      }
-
-      argname = null;
-      return false;
-    }
-
-    /// <summary>
-    /// For the given field, returns the derived option that is indexed by
-    /// option in the list of derived options.
-    /// </summary>
-    [Pure]
-    protected string DerivedOptionFor(string fieldWithOptions, int option)
-    {
-      string[] options;
-      if (TryGetOptions(fieldWithOptions, out options))
-      {
-        if (option < 0 || option >= options.Length)
-        {
-          return "";
-        }
-
-        return options[option];
-      }
-
-      return "";
-    }
-
-    /// <summary>
-    /// Returns the options associated with the field, specified as a string.
-    /// If there are none, options is set to null and false is returned.
-    /// </summary>
-    [Pure]
-    protected bool TryGetOptions(string fieldWithOptions, out string[] options)
-    {
-      var fi = this.GetType().GetField(fieldWithOptions,
-        System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy | System.Reflection.BindingFlags.Public);
-
-      if (fi != null)
-      {
-        var obj = fi.GetValue(this);
-
-        if (obj is string[])
-        {
-          options = (string[])obj;
-          return true;
-        }
-      }
-
-      options = null;
-      return false;
-    }
-
-    /// <summary>
-    /// Use this 
-    /// </summary>
-    [Pure]
-    public long GetCheckCode()
-    {
-      var res = 0L;
-      foreach (var f in this.GetType().GetFields())
-      {
-        foreach (var a in f.GetCustomAttributes(true))
-        {
-          if (a is OptionWitness)
-          {
-            res += (f.GetValue(this).GetHashCode()) * f.GetHashCode();
-
-            break;
-          }
-        }
-      }
-
-      return res;
-    }
-
-    [Pure]
-    private string Identity(string s) { return s; }
-
-    private Converter<string, object> ParseEnum(Type enumType)
-    {
-      return delegate(string s) { return Enum.Parse(enumType, s, true); };
-    }
-
-    private System.Collections.IList GetListField(System.Reflection.FieldInfo fi)
-    {
-      object obj = fi.GetValue(this);
-      if (obj != null) { return (System.Collections.IList)obj; }
-      System.Collections.IList result = (System.Collections.IList)fi.FieldType.GetConstructor(new Type[] { }).Invoke(new object[] { });
-      fi.SetValue(this, result);
-      return result;
-    }
-
-    /// <summary>
-    /// Writes all of the options out to the console.
-    /// </summary>
-    [Pure]
-    public void PrintOptions(string indent, TextWriter output)
-    {
-      foreach (System.Reflection.FieldInfo f in this.GetType().GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
-      {
-        System.Type opttype = f.FieldType;
-        bool isList;
-        if (opttype.IsGenericType && opttype.GetGenericTypeDefinition() == typeof(List<>))
-        {
-          opttype = opttype.GetGenericArguments()[0];
-          isList = true;
-        }
-        else
-        {
-          isList = false;
-        }
-        string description = GetOptionAttribute(f);
-        string option = null;
-        if (opttype == typeof(bool))
-        {
-          if (!isList && f.GetValue(this).Equals(true))
-          {
-            option = String.Format("{0} (default=true)", f.Name);
-          }
-          else
-          {
-            option = f.Name;
-          }
-        }
-        else if (opttype == typeof(string))
-        {
-          if (!f.IsLiteral)
-          {
-            object defaultValue = f.GetValue(this);
-            if (!isList && defaultValue != null)
-            {
-              option = String.Format("{0} <string-arg> (default={1})", f.Name, defaultValue);
-            }
-            else
-            {
-              option = String.Format("{0} <string-arg>", f.Name);
-            }
-          }
-        }
-        else if (opttype == typeof(int))
-        {
-          if (!isList)
-          {
-            option = String.Format("{0} <int-arg> (default={1})", f.Name, f.GetValue(this));
-          }
-          else
-          {
-            option = String.Format("{0} <int-arg>", f.Name);
-          }
-        }
-        else if (opttype.IsEnum)
-        {
-          StringBuilder sb = new StringBuilder();
-          sb.Append(f.Name).Append(" (");
-          bool first = true;
-          foreach (System.Reflection.FieldInfo enumConstant in opttype.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
-          {
-            if (enumConstant.IsLiteral)
-            {
-              if (!first)
-              {
-                if (isList)
+                if (parseResponseFile && arg[0] == '@')
                 {
-                  sb.Append(" + ");
+                    var responseFile = arg.Substring(1);
+                    while (!ParseResponseFile(responseFile))
+                    {
+                        index++;
+                        if (index < args.Length)
+                        {
+                            responseFile = string.Format("{0} {1}", responseFile, args[index]);
+                        }
+                        else
+                        {
+                            AddError("Response file '{0}' does not exist.", responseFile);
+                            break;
+                        }
+                    }
+                }
+                else if (!this.UseDashOptionPrefix || arg[0] == '/' || arg[0] == '-')
+                {
+                    if (this.UseDashOptionPrefix)
+                    {
+                        arg = arg.Remove(0, 1);
+                    }
+                    if (arg == "?" && !this.TreatHelpArgumentAsUnknown)
+                    {
+                        helpRequested = true;
+                        index++;
+                        continue;
+                    }
+
+                    string equalArgument = null;
+                    int equalIndex = arg.IndexOfAny(equalChars); // use IndexOfAny instead of sequential IndexOf to parse correctly -arg=abc://def
+                    if (equalIndex >= 0)
+                    {
+                        equalArgument = arg.Substring(equalIndex + 1);
+                        arg = arg.Substring(0, equalIndex);
+
+                        // remove quotes if any
+                        if (equalArgument.Length >= 2 && equalArgument[0] == equalArgument[equalArgument.Length - 1] && quoteChars.Contains(equalArgument[0]))
+                            equalArgument = equalArgument.Substring(1, equalArgument.Length - 2);
+                    }
+
+                    bool optionOK = this.FindOptionByReflection(arg, args, ref index, equalArgument);
+                    if (!optionOK)
+                    {
+                        optionOK = this.ParseUnknown(arg, args, ref index, equalArgument);
+                        if (!optionOK)
+                        {
+                            AddError("Unknown option '{0}'", arg);
+                        }
+                    }
+                }
+                else if (this.TreatGeneralArgumentsAsUnknown)
+                {
+                    bool optionOK = this.ParseUnknown(arg, args, ref index, null);
+                    if (!optionOK)
+                    {
+                        AddError("Unknown option '{0}'", arg);
+                    }
                 }
                 else
                 {
-                  sb.Append(" | ");
+                    bool optionOK = this.ParseGeneralArgument(arg, args, ref index);
+                    if (!optionOK)
+                    {
+                        AddError("Unknown option '{0}'", arg);
+                    }
                 }
-              }
-              else
-              {
-                first = false;
-              }
-              sb.Append(enumConstant.Name);
+
+                index++;
             }
-          }
-          sb.Append(") ");
-          if (!isList)
-          {
-            sb.AppendFormat("(default={0})", f.GetValue(this));
-          }
-          else
-          {
-            sb.Append("(default=");
-            bool first2 = true;
-            foreach (object eval in (System.Collections.IEnumerable)f.GetValue(this))
+            if (!helpRequested) CheckRequiredOptions();
+        }
+
+        /// <returns>True, if file exists</returns>
+        private bool ParseResponseFile(string responseFile)
+        {
+            if (!File.Exists(responseFile))
             {
-              if (!first2)
-              {
-                sb.Append(',');
-              }
-              else
-              {
-                first2 = false;
-              }
-              sb.Append(eval.ToString());
+                return false;
             }
-            sb.Append(')');
-          }
-          option = sb.ToString();
-        }
-        if (option != null)
-        {
-          output.Write("{1}   -{0,-30}", option, indent);
+            try
+            {
+                var lines = File.ReadAllLines(responseFile);
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    var line = lines[i];
+                    if (line.Length == 0) continue;
+                    if (line[0] == '#')
+                    {
+                        // comment skip
+                        continue;
+                    }
+                    if (ContainsQuote(line))
+                    {
+                        Parse(SplitLineWithQuotes(responseFile, i, line));
+                    }
+                    else
+                    {
+                        // simple splitting
+                        Parse(line.Split(' '));
+                    }
+                }
+            }
+            catch
+            {
+                AddError("Failure reading from response file '{0}'.", responseFile);
+            }
 
-          if (description != null)
-          {
-            output.WriteLine(" : {0}", description);
-          }
-          else
-          {
+            return true;
+        }
+
+        [Pure]
+        private string[] SplitLineWithQuotes(string responseFileName, int lineNo, string line)
+        {
+            var start = 0;
+            var args = new List<string>();
+            bool inDoubleQuotes = false;
+            int escaping = 0; // number of escape characters in sequence
+            var currentArg = new StringBuilder();
+
+            for (var index = 0; index < line.Length; index++)
+            {
+                var current = line[index];
+
+                if (current == '\\')
+                {
+                    // escape character
+                    escaping++;
+                    // swallow the escape character for now
+                    // grab everything prior to prior escape character
+                    if (index > start)
+                    {
+                        currentArg.Append(line.Substring(start, index - start));
+                    }
+                    start = index + 1;
+                    continue;
+                }
+                if (escaping > 0)
+                {
+                    if (current == '"')
+                    {
+                        var backslashes = escaping / 2;
+                        for (int i = 0; i < backslashes; i++) { currentArg.Append('\\'); }
+                        if (escaping % 2 == 1)
+                        {
+                            // escapes the "
+                            currentArg.Append('"');
+                            escaping = 0;
+                            start = index + 1;
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        var backslashes = escaping;
+                        for (int i = 0; i < backslashes; i++) { currentArg.Append('\\'); }
+                    }
+                    escaping = 0;
+                }
+                if (inDoubleQuotes)
+                {
+                    if (current == '"')
+                    {
+                        // ending argument
+                        FinishArgument(line, start, args, currentArg, index, true);
+                        start = index + 1;
+                        inDoubleQuotes = false;
+                        continue;
+                    }
+                }
+                else // not in quotes
+                {
+                    if (Char.IsWhiteSpace(current))
+                    {
+                        // end previous, start new
+                        FinishArgument(line, start, args, currentArg, index, false);
+                        start = index + 1;
+                        continue;
+                    }
+                    if (current == '"')
+                    {
+                        // starting double quote
+                        if (index != start)
+                        {
+                            AddError("Response file '{0}' line {1}, char {2} contains '\"' not starting or ending an argument", responseFileName, lineNo, index);
+                        }
+                        start = index + 1;
+                        inDoubleQuotes = true;
+                        continue;
+                    }
+                }
+            }
+            // add outstanding escape characters
+            while (escaping > 0) { currentArg.Append('\\'); escaping--; }
+            FinishArgument(line, start, args, currentArg, line.Length, inDoubleQuotes);
+            return args.ToArray();
+        }
+
+
+        [Pure]
+        static private void FinishArgument(string line, int start, List<string> args, StringBuilder currentArg, int index, bool includeEmpty)
+        {
+            currentArg.Append(line.Substring(start, index - start));
+            if (includeEmpty || currentArg.Length > 0)
+            {
+                args.Add(currentArg.ToString());
+                currentArg.Length = 0;
+            }
+        }
+
+        [Pure]
+        static private bool ContainsQuote(string line)
+        {
+            var index = line.IndexOf('"');
+            if (index >= 0) return true;
+            index = line.IndexOf('\'');
+            if (index >= 0) return true;
+            return false;
+        }
+
+
+        [Pure]
+        private void CheckRequiredOptions()
+        {
+            foreach (var missed in requiredOptions)
+            {
+                AddError("Required option '-{0}' was not given.", missed);
+            }
+        }
+
+        private IList<string> GatherRequiredOptions()
+        {
+            List<string> result = new List<string>();
+
+            foreach (var field in this.GetType().GetFields(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public))
+            {
+                var options = field.GetCustomAttributes(typeof(OptionDescription), false);
+                foreach (OptionDescription attr in options)
+                {
+                    if (attr.Required)
+                    {
+                        result.Add(field.Name.ToLowerInvariant());
+                    }
+                }
+            }
+            return result;
+        }
+
+        private bool ParseValue<T>(Converter<string, T> parser, string equalArgument, string[] args, ref int index, ref object result)
+        {
+            if (equalArgument == null)
+            {
+                if (index + 1 < args.Length)
+                {
+                    equalArgument = args[++index];
+                }
+            }
+            bool success = false;
+            if (equalArgument != null)
+            {
+                try
+                {
+                    result = parser(equalArgument);
+                    success = true;
+                }
+                catch
+                {
+                }
+            }
+            return success;
+        }
+
+        private bool ParseValue<T>(Converter<string, T> parser, string argument, ref object result)
+        {
+            bool success = false;
+            if (argument != null)
+            {
+                try
+                {
+                    result = parser(argument);
+                    success = true;
+                }
+                catch
+                {
+                }
+            }
+            return success;
+        }
+
+        private object ParseValue(Type type, string argument, string option)
+        {
+            object result = null;
+            if (type == typeof(bool))
+            {
+                if (argument != null)
+                {
+                    // Allow "+/-" to turn on/off boolean options
+                    if (argument.Equals("-"))
+                    {
+                        result = false;
+                    }
+                    else if (argument.Equals("+"))
+                    {
+                        result = true;
+                    }
+                    else if (!ParseValue<bool>(Boolean.Parse, argument, ref result))
+                    {
+                        AddError("option -{0} requires a bool argument", option);
+                    }
+                }
+                else
+                {
+                    result = true;
+                }
+            }
+            else if (type == typeof(string))
+            {
+                if (!ParseValue<string>(Identity, argument, ref result))
+                {
+                    AddError("option -{0} requires a string argument", option);
+                }
+            }
+            else if (type == typeof(int))
+            {
+                if (!ParseValue<int>(Int32.Parse, argument, ref result))
+                {
+                    AddError("option -{0} requires an int argument", option);
+                }
+            }
+            else if (type == typeof(uint))
+            {
+                if (!ParseValue<uint>(UInt32.Parse, argument, ref result))
+                {
+                    AddError("option -{0} requires an unsigned int argument", option);
+                }
+            }
+            else if (type == typeof(long))
+            {
+                if (!ParseValue<long>(Int64.Parse, argument, ref result))
+                {
+                    AddError("option -{0} requires a long argument", option);
+                }
+            }
+            else if (type.IsEnum)
+            {
+                if (!ParseValue<object>(ParseEnum(type), argument, ref result))
+                {
+                    AddError("option -{0} expects one of", option);
+
+                    foreach (System.Reflection.FieldInfo enumConstant in type.GetFields(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public))
+                    {
+                        if (enumConstant.IsLiteral)
+                        {
+                            AddMessage("  {0}", enumConstant.Name);
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        [Pure]
+        private string AdvanceArgumentIfNoExplicitArg(Type type, string explicitArg, string[] args, ref int index)
+        {
+            if (explicitArg != null) return explicitArg;
+            if (type == typeof(bool))
+            {
+                // bool args don't grab the next arg
+                return null;
+            }
+            if (index + 1 < args.Length)
+            {
+                return args[++index];
+            }
+            return null;
+        }
+
+        private bool FindOptionByReflection(string arg, string[] args, ref int index, string explicitArgument)
+        {
+            System.Reflection.FieldInfo fi = this.GetType().GetField(arg, System.Reflection.BindingFlags.IgnoreCase | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+            if (fi != null)
+            {
+                requiredOptions.Remove(arg.ToLowerInvariant());
+                return ProcessOptionWithMatchingField(arg, args, ref index, explicitArgument, ref fi);
+            }
+            else
+            {
+                // derived options
+                fi = this.GetType().GetField(arg, System.Reflection.BindingFlags.IgnoreCase | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.FlattenHierarchy);
+                if (fi != null)
+                {
+                    object derived = fi.GetValue(this);
+
+                    if (derived is string)
+                    {
+                        this.Parse(((string)derived).Split(' '));
+                        requiredOptions.Remove(arg.ToLowerInvariant());
+                        return true;
+                    }
+                }
+
+                // Try to see if the arg matches any ShortForm of an option
+                var allFields = this.GetType().GetFields();
+                System.Reflection.FieldInfo matchingField = null;
+                foreach (var f in allFields)
+                {
+                    matchingField = f;
+                    var options = matchingField.GetCustomAttributes(typeof(OptionDescription), false);
+                    foreach (OptionDescription attr in options)
+                    {
+                        if (attr.ShortForm != null)
+                        {
+                            var lower1 = attr.ShortForm.ToLowerInvariant();
+                            var lower2 = arg.ToLowerInvariant();
+                            if (lower1.Equals(lower2))
+                            {
+                                requiredOptions.Remove(matchingField.Name.ToLowerInvariant());
+                                return ProcessOptionWithMatchingField(arg, args, ref index, explicitArgument, ref matchingField);
+                            }
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        private bool ProcessOptionWithMatchingField(string arg, string[] args, ref int index, string explicitArgument, ref System.Reflection.FieldInfo fi)
+        {
+            Type type = fi.FieldType;
+            bool isList = false;
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
+            {
+                isList = true;
+                type = type.GetGenericArguments()[0];
+            }
+            if (isList && explicitArgument == "!!")
+            {
+                // way to set list to empty
+                System.Collections.IList listhandle = (System.Collections.IList)fi.GetValue(this);
+                listhandle.Clear();
+                return true;
+            }
+            string argument = AdvanceArgumentIfNoExplicitArg(type, explicitArgument, args, ref index);
+            if (isList)
+            {
+                if (argument == null)
+                {
+                    AddError("option -{0} requires an argument", arg);
+                    return true;
+                }
+                string[] listargs = argument.Split(';');
+                for (int i = 0; i < listargs.Length; i++)
+                {
+                    if (listargs[i].Length == 0) continue; // skip empty values
+                    bool remove = listargs[i][0] == '!';
+                    string listarg = remove ? listargs[i].Substring(1) : listargs[i];
+                    object value = ParseValue(type, listarg, arg);
+                    if (value != null)
+                    {
+                        if (remove)
+                        {
+                            this.GetListField(fi).Remove(value);
+                        }
+                        else
+                        {
+                            this.GetListField(fi).Add(value);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                object value = ParseValue(type, argument, arg);
+                if (value != null)
+                {
+                    fi.SetValue(this, value);
+
+                    string argname;
+                    if (value is Int32 && HasOptionForAttribute(fi, out argname))
+                    {
+                        this.Parse(DerivedOptionFor(argname, (Int32)value).Split(' '));
+                    }
+                }
+            }
+            return true;
+        }
+
+        [Pure]
+        private bool HasOptionForAttribute(System.Reflection.FieldInfo fi, out string argname)
+        {
+            var options = fi.GetCustomAttributes(typeof(OptionFor), true);
+            if (options != null && options.Length == 1)
+            {
+                argname = ((OptionFor)options[0]).options;
+                return true;
+            }
+
+            argname = null;
+            return false;
+        }
+
+        /// <summary>
+        /// For the given field, returns the derived option that is indexed by
+        /// option in the list of derived options.
+        /// </summary>
+        [Pure]
+        protected string DerivedOptionFor(string fieldWithOptions, int option)
+        {
+            string[] options;
+            if (TryGetOptions(fieldWithOptions, out options))
+            {
+                if (option < 0 || option >= options.Length)
+                {
+                    return "";
+                }
+
+                return options[option];
+            }
+
+            return "";
+        }
+
+        /// <summary>
+        /// Returns the options associated with the field, specified as a string.
+        /// If there are none, options is set to null and false is returned.
+        /// </summary>
+        [Pure]
+        protected bool TryGetOptions(string fieldWithOptions, out string[] options)
+        {
+            var fi = this.GetType().GetField(fieldWithOptions,
+              System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.FlattenHierarchy | System.Reflection.BindingFlags.Public);
+
+            if (fi != null)
+            {
+                var obj = fi.GetValue(this);
+
+                if (obj is string[])
+                {
+                    options = (string[])obj;
+                    return true;
+                }
+            }
+
+            options = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Use this 
+        /// </summary>
+        [Pure]
+        public long GetCheckCode()
+        {
+            var res = 0L;
+            foreach (var f in this.GetType().GetFields())
+            {
+                foreach (var a in f.GetCustomAttributes(true))
+                {
+                    if (a is OptionWitness)
+                    {
+                        res += (f.GetValue(this).GetHashCode()) * f.GetHashCode();
+
+                        break;
+                    }
+                }
+            }
+
+            return res;
+        }
+
+        [Pure]
+        private string Identity(string s) { return s; }
+
+        private Converter<string, object> ParseEnum(Type enumType)
+        {
+            return delegate (string s) { return Enum.Parse(enumType, s, true); };
+        }
+
+        private System.Collections.IList GetListField(System.Reflection.FieldInfo fi)
+        {
+            object obj = fi.GetValue(this);
+            if (obj != null) { return (System.Collections.IList)obj; }
+            System.Collections.IList result = (System.Collections.IList)fi.FieldType.GetConstructor(new Type[] { }).Invoke(new object[] { });
+            fi.SetValue(this, result);
+            return result;
+        }
+
+        /// <summary>
+        /// Writes all of the options out to the console.
+        /// </summary>
+        [Pure]
+        public void PrintOptions(string indent, TextWriter output)
+        {
+            foreach (System.Reflection.FieldInfo f in this.GetType().GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+            {
+                System.Type opttype = f.FieldType;
+                bool isList;
+                if (opttype.IsGenericType && opttype.GetGenericTypeDefinition() == typeof(List<>))
+                {
+                    opttype = opttype.GetGenericArguments()[0];
+                    isList = true;
+                }
+                else
+                {
+                    isList = false;
+                }
+                string description = GetOptionAttribute(f);
+                string option = null;
+                if (opttype == typeof(bool))
+                {
+                    if (!isList && f.GetValue(this).Equals(true))
+                    {
+                        option = String.Format("{0} (default=true)", f.Name);
+                    }
+                    else
+                    {
+                        option = f.Name;
+                    }
+                }
+                else if (opttype == typeof(string))
+                {
+                    if (!f.IsLiteral)
+                    {
+                        object defaultValue = f.GetValue(this);
+                        if (!isList && defaultValue != null)
+                        {
+                            option = String.Format("{0} <string-arg> (default={1})", f.Name, defaultValue);
+                        }
+                        else
+                        {
+                            option = String.Format("{0} <string-arg>", f.Name);
+                        }
+                    }
+                }
+                else if (opttype == typeof(int))
+                {
+                    if (!isList)
+                    {
+                        option = String.Format("{0} <int-arg> (default={1})", f.Name, f.GetValue(this));
+                    }
+                    else
+                    {
+                        option = String.Format("{0} <int-arg>", f.Name);
+                    }
+                }
+                else if (opttype.IsEnum)
+                {
+                    StringBuilder sb = new StringBuilder();
+                    sb.Append(f.Name).Append(" (");
+                    bool first = true;
+                    foreach (System.Reflection.FieldInfo enumConstant in opttype.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
+                    {
+                        if (enumConstant.IsLiteral)
+                        {
+                            if (!first)
+                            {
+                                if (isList)
+                                {
+                                    sb.Append(" + ");
+                                }
+                                else
+                                {
+                                    sb.Append(" | ");
+                                }
+                            }
+                            else
+                            {
+                                first = false;
+                            }
+                            sb.Append(enumConstant.Name);
+                        }
+                    }
+                    sb.Append(") ");
+                    if (!isList)
+                    {
+                        sb.AppendFormat("(default={0})", f.GetValue(this));
+                    }
+                    else
+                    {
+                        sb.Append("(default=");
+                        bool first2 = true;
+                        foreach (object eval in (System.Collections.IEnumerable)f.GetValue(this))
+                        {
+                            if (!first2)
+                            {
+                                sb.Append(',');
+                            }
+                            else
+                            {
+                                first2 = false;
+                            }
+                            sb.Append(eval.ToString());
+                        }
+                        sb.Append(')');
+                    }
+                    option = sb.ToString();
+                }
+                if (option != null)
+                {
+                    output.Write("{1}   -{0,-30}", option, indent);
+
+                    if (description != null)
+                    {
+                        output.WriteLine(" : {0}", description);
+                    }
+                    else
+                    {
+                        output.WriteLine();
+                    }
+                }
+            }
+            output.WriteLine(Environment.NewLine + "To clear a list, use -<option>=!!");
+            output.WriteLine(Environment.NewLine + "To remove an item from a list, use -<option> !<item>");
+        }
+
+        /// <summary>
+        /// Prints all of the derived options to the console.
+        /// </summary>
+        public void PrintDerivedOptions(string indent, TextWriter output)
+        {
+            foreach (System.Reflection.FieldInfo f in this.GetType().GetFields(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public))
+            {
+                if (f.IsLiteral)
+                {
+                    output.WriteLine("{2}   -{0} is '{1}'", f.Name, f.GetValue(this), indent);
+                }
+            }
+        }
+
+        private string GetOptionAttribute(System.Reflection.FieldInfo f)
+        {
+            object[] attrs = f.GetCustomAttributes(typeof(OptionDescription), true);
+            if (attrs != null && attrs.Length == 1)
+            {
+                StringBuilder result = new StringBuilder();
+                OptionDescription descr = (OptionDescription)attrs[0];
+                if (descr.Required)
+                {
+                    result.Append("(required) ");
+                }
+                result.Append(descr.Description);
+                if (descr.ShortForm != null)
+                {
+                    result.Append("[short form: " + descr.ShortForm + "]");
+                }
+                object[] optionsFor = f.GetCustomAttributes(typeof(OptionFor), true);
+                string[] options;
+
+                if (optionsFor != null && optionsFor.Length == 1 && TryGetOptions(((OptionFor)optionsFor[0]).options, out options))
+                {
+                    result.AppendLine(Environment.NewLine + "Detailed explanation:");
+                    for (int i = 0; i < options.Length; i++)
+                    {
+                        result.Append(string.Format("{0} : {1}" + Environment.NewLine, i, options[i]));
+                    }
+                }
+
+                return result.ToString();
+            }
+            return null;
+        }
+
+
+        #endregion
+
+        public void PrintErrors(TextWriter output)
+        {
+            foreach (string message in errorMessages)
+            {
+                output.WriteLine(message);
+            }
             output.WriteLine();
-          }
+            output.WriteLine("  use /? to see a list of options");
         }
-      }
-      output.WriteLine(Environment.NewLine + "To clear a list, use -<option>=!!");
-      output.WriteLine(Environment.NewLine + "To remove an item from a list, use -<option> !<item>");
 
-    }
-
-    /// <summary>
-    /// Prints all of the derived options to the console.
-    /// </summary>
-    public void PrintDerivedOptions(string indent, TextWriter output)
-    {
-      foreach (System.Reflection.FieldInfo f in this.GetType().GetFields(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public))
-      {
-        if (f.IsLiteral)
+        public void PrintErrorsAndExit(TextWriter output)
         {
-          output.WriteLine("{2}   -{0} is '{1}'", f.Name, f.GetValue(this), indent);
+            this.PrintErrors(output);
+            Environment.Exit(-1);
         }
-      }
     }
-
-    private string GetOptionAttribute(System.Reflection.FieldInfo f)
-    {
-      object[] attrs = f.GetCustomAttributes(typeof(OptionDescription), true);
-      if (attrs != null && attrs.Length == 1)
-      {
-        StringBuilder result = new StringBuilder();
-        OptionDescription descr = (OptionDescription)attrs[0];
-        if (descr.Required)
-        {
-          result.Append("(required) ");
-        }
-        result.Append(descr.Description);
-        if (descr.ShortForm != null)
-        {
-          result.Append("[short form: " + descr.ShortForm + "]");
-        }
-        object[] optionsFor = f.GetCustomAttributes(typeof(OptionFor), true);
-        string[] options;
-
-        if (optionsFor != null && optionsFor.Length == 1 && TryGetOptions(((OptionFor)optionsFor[0]).options, out options))
-        {
-          result.AppendLine(Environment.NewLine + "Detailed explanation:");
-          for (int i = 0; i < options.Length; i++)
-          {
-            result.Append(string.Format("{0} : {1}" + Environment.NewLine, i, options[i]));
-          }
-        }
-
-        return result.ToString();
-      }
-      return null;
-    }
-
-
-    #endregion
-
-    public void PrintErrors(TextWriter output)
-    {
-      foreach (string message in this.errorMessages)
-      {
-        output.WriteLine(message);
-      }
-      output.WriteLine();
-      output.WriteLine("  use /? to see a list of options");
-    }
-     
-    public void PrintErrorsAndExit(TextWriter output)
-    {
-      this.PrintErrors(output);
-      Environment.Exit(-1);
-    }
-  }
 }

--- a/Microsoft.Research/DataStructures/PriorityQueue.cs
+++ b/Microsoft.Research/DataStructures/PriorityQueue.cs
@@ -1,186 +1,190 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Research.DataStructures
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Diagnostics;
-  using System.Text;
-  using System.IO;
-  using System.Diagnostics.Contracts;
-
-  /// <summary>
-  /// A priority queue based on heaps
-  /// </summary>
-  [ContractVerification(true)]
-  public class PriorityQueue<T>
-  {
-
-    #region Object invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.array != null);
-      Contract.Invariant(this.basis != null);
-      Contract.Invariant(this.compare != null);
-    }
-
-    #endregion
-
-    readonly protected List<T> array = new List<T>();
-    readonly protected Set<T> basis = new Set<T>();
-    readonly Comparison<T> compare;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using System.IO;
+    using System.Diagnostics.Contracts;
 
     /// <summary>
-    /// A priority queue where larger elements according to compare come out first
+    /// A priority queue based on heaps
     /// </summary>
-    public PriorityQueue(Comparison<T> compare) {
-      Contract.Requires(compare  != null);
-
-      this.compare = compare;
-    }
-
-    // algorithm is written with array of base 1, so adjust here
-    private T this[int index] {
-      get {
-        Contract.Requires(index >= 1);
-        Contract.Requires(index <= array.Count);
-
-        return array[index - 1];
-      }
-
-      set {
-        Contract.Requires(index >= 1);
-        Contract.Requires(index <= array.Count);
-
-        array[index - 1] = value;
-      }
-    }
-
-    [Pure]
-    private bool GreaterThan(T o1, T o2) {
-      return this.compare(o1, o2) > 0;
-    }
-
-    [Pure]
-    private static int Left(int i) {
-      Contract.Ensures(Contract.Result<int>() == 2 * i);      
-
-      return 2 * i;
-    }
-
-    [Pure]
-    private static int Right(int i) {
-      Contract.Ensures(Contract.Result<int>() == 2 * i +1);      
-
-      return 2 * i + 1;
-    }
-
-    [Pure]
-    private static int Parent(int i) {
-      Contract.Ensures(Contract.Result<int>() == i/2);      
-
-      return i / 2;
-    }
-
-    private int HeapSize {
-      get {
-        Contract.Ensures(Contract.Result<int>() == this.array.Count);
-        return this.array.Count; }
-    }
-
-    private void Heapify(int i) {
-      Contract.Requires(i>= 1);
-      
-      int l = Left(i);
-      int r = Right(i);
-      int largest;
-
-      if (l <= HeapSize && GreaterThan(this[l], this[i])) {
-        largest = l;
-      }
-      else {
-        largest = i;
-      }
-      if (r <= HeapSize && GreaterThan(this[r], this[largest])) {
-        largest = r;
-      }
-      if (largest != i) {
-        T tmp = this[largest];
-        this[largest] = this[i];
-        this[i] = tmp;
-        Heapify(largest);
-      }
-    }
-
-    public void Dump(TextWriter tw)
+    [ContractVerification(true)]
+    public class PriorityQueue<T>
     {
-      Contract.Requires(tw != null);
-
-      tw.Write("  basis: ");
-      foreach (var elem in this.basis)
-      {
-        tw.Write("{0} ", elem.ToString());
-      }
-      tw.WriteLine();
-      tw.Write("  array: ");
-      for (int i = 0; i < this.HeapSize; i++)
-      {
-        tw.Write("{0} ", this.array[i].ToString());
-      }
-      tw.WriteLine();
-    }
-
-    public int Count { get { return this.basis.Count; } }
-
-    public bool Add(T o) {
-      if (basis.AddQ(o)) {
-        array.Add(o);
-        int i = HeapSize;
-        while (i > 1 && GreaterThan(o, this[Parent(i)])) {
-          this[i] = this[Parent(i)];
-          i = Parent(i);
+        #region Object invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.array != null);
+            Contract.Invariant(this.basis != null);
+            Contract.Invariant(compare != null);
         }
-        this[i] = o;
 
-        return true;
-      }
-      return false;
-    }
+        #endregion
 
-    public T Pull() {
+        readonly protected List<T> array = new List<T>();
+        readonly protected Set<T> basis = new Set<T>();
+        private readonly Comparison<T> compare;
+
+        /// <summary>
+        /// A priority queue where larger elements according to compare come out first
+        /// </summary>
+        public PriorityQueue(Comparison<T> compare)
+        {
+            Contract.Requires(compare != null);
+
+            this.compare = compare;
+        }
+
+        // algorithm is written with array of base 1, so adjust here
+        private T this[int index]
+        {
+            get
+            {
+                Contract.Requires(index >= 1);
+                Contract.Requires(index <= array.Count);
+
+                return array[index - 1];
+            }
+
+            set
+            {
+                Contract.Requires(index >= 1);
+                Contract.Requires(index <= array.Count);
+
+                array[index - 1] = value;
+            }
+        }
+
+        [Pure]
+        private bool GreaterThan(T o1, T o2)
+        {
+            return compare(o1, o2) > 0;
+        }
+
+        [Pure]
+        private static int Left(int i)
+        {
+            Contract.Ensures(Contract.Result<int>() == 2 * i);
+
+            return 2 * i;
+        }
+
+        [Pure]
+        private static int Right(int i)
+        {
+            Contract.Ensures(Contract.Result<int>() == 2 * i + 1);
+
+            return 2 * i + 1;
+        }
+
+        [Pure]
+        private static int Parent(int i)
+        {
+            Contract.Ensures(Contract.Result<int>() == i / 2);
+
+            return i / 2;
+        }
+
+        private int HeapSize
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() == this.array.Count);
+                return this.array.Count;
+            }
+        }
+
+        private void Heapify(int i)
+        {
+            Contract.Requires(i >= 1);
+
+            int l = Left(i);
+            int r = Right(i);
+            int largest;
+
+            if (l <= HeapSize && GreaterThan(this[l], this[i]))
+            {
+                largest = l;
+            }
+            else
+            {
+                largest = i;
+            }
+            if (r <= HeapSize && GreaterThan(this[r], this[largest]))
+            {
+                largest = r;
+            }
+            if (largest != i)
+            {
+                T tmp = this[largest];
+                this[largest] = this[i];
+                this[i] = tmp;
+                Heapify(largest);
+            }
+        }
+
+        public void Dump(TextWriter tw)
+        {
+            Contract.Requires(tw != null);
+
+            tw.Write("  basis: ");
+            foreach (var elem in this.basis)
+            {
+                tw.Write("{0} ", elem.ToString());
+            }
+            tw.WriteLine();
+            tw.Write("  array: ");
+            for (int i = 0; i < this.HeapSize; i++)
+            {
+                tw.Write("{0} ", this.array[i].ToString());
+            }
+            tw.WriteLine();
+        }
+
+        public int Count { get { return this.basis.Count; } }
+
+        public bool Add(T o)
+        {
+            if (basis.AddQ(o))
+            {
+                array.Add(o);
+                int i = HeapSize;
+                while (i > 1 && GreaterThan(o, this[Parent(i)]))
+                {
+                    this[i] = this[Parent(i)];
+                    i = Parent(i);
+                }
+                this[i] = o;
+
+                return true;
+            }
+            return false;
+        }
+
+        public T Pull()
+        {
 #if false
-      Console.WriteLine("Priority Queue Pull");
-      Dump(Console.Out);
+            Console.WriteLine("Priority Queue Pull");
+            Dump(Console.Out);
 #endif
-      if (HeapSize < 1) throw new InvalidOperationException("priority queue is empty");
+            if (HeapSize < 1) throw new InvalidOperationException("priority queue is empty");
 
-      T max = this[1];
-      this[1] = this[HeapSize];
-      array.RemoveAt(HeapSize - 1); // remove last element.
+            T max = this[1];
+            this[1] = this[HeapSize];
+            array.RemoveAt(HeapSize - 1); // remove last element.
 
-      Heapify(1);
-      basis.Remove(max);
+            Heapify(1);
+            basis.Remove(max);
 #if false
-      Console.WriteLine("  returning {0}", max.ToString());
+            Console.WriteLine("  returning {0}", max.ToString());
 #endif
-      return max;
+            return max;
+        }
     }
-
-
-  }
-
-
 }

--- a/Microsoft.Research/DataStructures/ProjectedDictionary.cs
+++ b/Microsoft.Research/DataStructures/ProjectedDictionary.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -18,217 +7,216 @@ using System.Linq;
 
 namespace Microsoft.Research.DataStructures
 {
-  class ProjectionEqualityComparer<T, TSub> : EqualityComparer<T>
-  {
-    private readonly Func<T, TSub> projection;
-
-    public ProjectionEqualityComparer(Func<T, TSub> projection)
+    internal class ProjectionEqualityComparer<T, TSub> : EqualityComparer<T>
     {
-      this.projection = projection;
+        private readonly Func<T, TSub> projection;
+
+        public ProjectionEqualityComparer(Func<T, TSub> projection)
+        {
+            this.projection = projection;
+        }
+
+        public override bool Equals(T x, T y)
+        {
+            return projection(x).Equals(projection(y));
+        }
+
+        public override int GetHashCode(T obj)
+        {
+            return projection(obj).GetHashCode();
+        }
     }
 
-    public override bool Equals(T x, T y)
+    internal interface IProjector<T1, T2>
     {
-      return this.projection(x).Equals(this.projection(y));
+        T2 Project(T1 x);
     }
 
-    public override int GetHashCode(T obj)
+    internal class ProjectionDictionary<TKey, TSubKey, TValue> : Dictionary<TKey, TValue>
     {
-      return this.projection(obj).GetHashCode();
-    }
-  }
+        public ProjectionDictionary(Func<TKey, TSubKey> projection)
+          : base(new ProjectionEqualityComparer<TKey, TSubKey>(projection))
+        { }
 
-  interface IProjector<T1, T2>
-  {
-    T2 Project(T1 x);
-  }
-
-  class ProjectionDictionary<TKey, TSubKey, TValue> : Dictionary<TKey, TValue>
-  {
-    public ProjectionDictionary(Func<TKey, TSubKey> projection)
-      : base(new ProjectionEqualityComparer<TKey, TSubKey>(projection))
-    { }
-
-    public class For<TProjector> : ProjectionDictionary<TKey, TSubKey, TValue>
-      where TProjector : IProjector<TKey, TSubKey>, new()
-    {
-      public For() : base((new TProjector()).Project) { }
-    }
-  }
-
-  public class ProjectedDictionary<TKey, TSubKey, TValue> : Dictionary<TSubKey, KeyValuePair<TKey, TValue>>, IDictionary<TKey, TValue>
-  {
-    private readonly Func<TKey, TSubKey> projection;
-
-    /// <summary>
-    /// Wrapper so we get contract check.
-    /// </summary>
-    new public int Count { get { return base.Count; } }
-
-    /// <summary>
-    /// Wrapper so we get contract check.
-    /// </summary>
-    new public void Clear() { base.Clear(); }
-
-    public ProjectedDictionary(Func<TKey, TSubKey> projection)
-    {
-      this.projection = projection;
+        public class For<TProjector> : ProjectionDictionary<TKey, TSubKey, TValue>
+          where TProjector : IProjector<TKey, TSubKey>, new()
+        {
+            public For() : base((new TProjector()).Project) { }
+        }
     }
 
-    public virtual void Add(KeyValuePair<TKey, TValue> item)
+    public class ProjectedDictionary<TKey, TSubKey, TValue> : Dictionary<TSubKey, KeyValuePair<TKey, TValue>>, IDictionary<TKey, TValue>
     {
-      this.Add(this.projection(item.Key), item);
+        private readonly Func<TKey, TSubKey> projection;
+
+        /// <summary>
+        /// Wrapper so we get contract check.
+        /// </summary>
+        new public int Count { get { return base.Count; } }
+
+        /// <summary>
+        /// Wrapper so we get contract check.
+        /// </summary>
+        new public void Clear() { base.Clear(); }
+
+        public ProjectedDictionary(Func<TKey, TSubKey> projection)
+        {
+            this.projection = projection;
+        }
+
+        public virtual void Add(KeyValuePair<TKey, TValue> item)
+        {
+            this.Add(projection(item.Key), item);
+        }
+
+        public virtual void Add(TKey key, TValue value)
+        {
+            this.Add(projection(key), new KeyValuePair<TKey, TValue>(key, value));
+        }
+
+        public virtual bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return this.Contains(new KeyValuePair<TSubKey, KeyValuePair<TKey, TValue>>(projection(item.Key), item));
+        }
+
+        public virtual bool ContainsKey(TKey key)
+        {
+            return this.ContainsKey(projection(key));
+        }
+
+        public virtual bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return ((IDictionary<TSubKey, KeyValuePair<TKey, TValue>>)this).Remove(new KeyValuePair<TSubKey, KeyValuePair<TKey, TValue>>(projection(item.Key), item));
+        }
+
+        public virtual bool Remove(TKey key)
+        {
+            return this.Remove(projection(key));
+        }
+
+        public virtual bool TryGetValue(TKey key, out TValue value)
+        {
+            KeyValuePair<TKey, TValue> p;
+            if (!this.TryGetValue(projection(key), out p))
+            {
+                value = default(TValue);
+                return false;
+            }
+            value = p.Value;
+            return true;
+        }
+
+        private Dictionary<TSubKey, KeyValuePair<TKey, TValue>> Base { get { return this; } }
+        private Dictionary<TKey, TValue> BaseDictionary { get { return this.Base.Select(p => p.Value).ToDictionary(p => p.Key, p => p.Value); } }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        {
+            return this.Base.Select(p => p.Value).GetEnumerator();
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { return false; } }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
+        {
+            this.Base.Select(p => p.Value).ToArray().CopyTo(array, index);
+        }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { return this.BaseDictionary.Values; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { return this.BaseDictionary.Keys; } }
+
+        TValue IDictionary<TKey, TValue>.this[TKey key]
+        {
+            get
+            {
+                return this[projection(key)].Value;
+            }
+            set
+            {
+                this[projection(key)] = new KeyValuePair<TKey, TValue>(key, value);
+            }
+        }
     }
 
-    public virtual void Add(TKey key, TValue value)
+    public class ProjectedDictionary<TKey, TSubKey1, TSubKey2, TValue> : ProjectedDictionary<TKey, TSubKey1, TValue>
     {
-      this.Add(this.projection(key), new KeyValuePair<TKey, TValue>(key, value));
+        private readonly ProjectedDictionary<TKey, TSubKey2, TValue> dict2;
+
+        public ProjectedDictionary(Func<TKey, TSubKey1> proj1, Func<TKey, TSubKey2> proj2)
+          : base(proj1)
+        {
+            dict2 = new ProjectedDictionary<TKey, TSubKey2, TValue>(proj2);
+        }
+
+        public override void Add(TKey key, TValue value)
+        {
+            base.Add(key, value);
+            dict2.Add(key, value);
+        }
+
+        public new void Clear()
+        {
+            base.Clear();
+            dict2.Clear();
+        }
+
+        public virtual bool ContainsKey(TSubKey2 subkey2)
+        {
+            return dict2.ContainsKey(subkey2);
+        }
+
+        public override bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return base.Remove(item) || dict2.Remove(item);
+        }
+
+        public override bool Remove(TKey key)
+        {
+            return base.Remove(key) || dict2.Remove(key);
+        }
+
+        public new bool Remove(TSubKey1 subkey1)
+        {
+            KeyValuePair<TKey, TValue> item;
+            if (!base.TryGetValue(subkey1, out item))
+                return false;
+            base.Remove(subkey1);
+            dict2.Remove(item.Key);
+            return true;
+        }
+
+        public virtual bool Remove(TSubKey2 subkey2)
+        {
+            KeyValuePair<TKey, TValue> item;
+            if (!dict2.TryGetValue(subkey2, out item))
+                return false;
+            base.Remove(item.Key);
+            dict2.Remove(subkey2);
+            return true;
+        }
+
+        public bool TryGetValue(TSubKey1 subkey1, out TValue value)
+        {
+            KeyValuePair<TKey, TValue> item;
+            if (!base.TryGetValue(subkey1, out item))
+            {
+                value = default(TValue);
+                return false;
+            }
+            value = item.Value;
+            return true;
+        }
+
+        public virtual bool TryGetValue(TSubKey2 subkey2, out TValue value)
+        {
+            KeyValuePair<TKey, TValue> item;
+            if (!dict2.TryGetValue(subkey2, out item))
+            {
+                value = default(TValue);
+                return false;
+            }
+            value = item.Value;
+            return true;
+        }
     }
-
-    public virtual bool Contains(KeyValuePair<TKey, TValue> item)
-    {
-      return this.Contains(new KeyValuePair<TSubKey, KeyValuePair<TKey, TValue>>(this.projection(item.Key), item));
-    }
-
-    public virtual bool ContainsKey(TKey key)
-    {
-      return this.ContainsKey(this.projection(key));
-    }
-
-    public virtual bool Remove(KeyValuePair<TKey, TValue> item)
-    {
-      return ((IDictionary<TSubKey, KeyValuePair<TKey, TValue>>)this).Remove(new KeyValuePair<TSubKey, KeyValuePair<TKey, TValue>>(this.projection(item.Key), item));
-    }
-
-    public virtual bool Remove(TKey key)
-    {
-      return this.Remove(this.projection(key));
-    }
-
-    public virtual bool TryGetValue(TKey key, out TValue value)
-    {
-      KeyValuePair<TKey, TValue> p;
-      if (!this.TryGetValue(this.projection(key), out p))
-      {
-        value = default(TValue);
-        return false;
-      }
-      value = p.Value;
-      return true;
-    }
-
-    private Dictionary<TSubKey, KeyValuePair<TKey, TValue>> Base { get { return this; } }
-    private Dictionary<TKey, TValue> BaseDictionary { get { return this.Base.Select(p => p.Value).ToDictionary(p => p.Key, p => p.Value); } }
-
-    IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
-    {
-      return this.Base.Select(p => p.Value).GetEnumerator();
-    }
-
-    bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { return false; } }
-
-    void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
-    {
-      this.Base.Select(p => p.Value).ToArray().CopyTo(array, index);
-    }
-
-    ICollection<TValue> IDictionary<TKey, TValue>.Values { get { return this.BaseDictionary.Values; } }
-
-    ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { return this.BaseDictionary.Keys; } }
-
-    TValue IDictionary<TKey, TValue>.this[TKey key]
-    {
-      get
-      {
-        return this[this.projection(key)].Value;
-      }
-      set
-      {
-        this[this.projection(key)] = new KeyValuePair<TKey, TValue>(key, value);
-      }
-    }
-  }
-
-  public class ProjectedDictionary<TKey, TSubKey1, TSubKey2, TValue> : ProjectedDictionary<TKey, TSubKey1, TValue>
-  {
-    private readonly ProjectedDictionary<TKey, TSubKey2, TValue> dict2;
-
-    public ProjectedDictionary(Func<TKey, TSubKey1> proj1, Func<TKey, TSubKey2> proj2)
-      : base(proj1)
-    {
-      this.dict2 = new ProjectedDictionary<TKey,TSubKey2,TValue>(proj2);
-    }
-
-    public override void Add(TKey key, TValue value)
-    {
-      base.Add(key, value);
-      this.dict2.Add(key, value);
-    }
-
-    public new void Clear()
-    {
-      base.Clear();
-      this.dict2.Clear();
-    }
-
-    public virtual bool ContainsKey(TSubKey2 subkey2)
-    {
-      return this.dict2.ContainsKey(subkey2);
-    }
-
-    public override bool Remove(KeyValuePair<TKey, TValue> item)
-    {
-      return base.Remove(item) || this.dict2.Remove(item);
-    }
-
-    public override bool Remove(TKey key)
-    {
-      return base.Remove(key) || this.dict2.Remove(key);
-    }
-
-    public new bool Remove(TSubKey1 subkey1)
-    {
-      KeyValuePair<TKey, TValue> item;
-      if (!base.TryGetValue(subkey1, out item))
-        return false;
-      base.Remove(subkey1);
-      this.dict2.Remove(item.Key);
-      return true;
-    }
-
-    public virtual bool Remove(TSubKey2 subkey2)
-    {
-      KeyValuePair<TKey, TValue> item;
-      if (!this.dict2.TryGetValue(subkey2, out item))
-        return false;
-      base.Remove(item.Key);
-      this.dict2.Remove(subkey2);
-      return true;
-    }
-
-    public bool TryGetValue(TSubKey1 subkey1, out TValue value)
-    {
-      KeyValuePair<TKey, TValue> item;
-      if (!base.TryGetValue(subkey1, out item))
-      {
-        value = default(TValue);
-        return false;
-      }
-      value = item.Value;
-      return true;
-    }
-
-    public virtual bool TryGetValue(TSubKey2 subkey2, out TValue value)
-    {
-      KeyValuePair<TKey, TValue> item;
-      if (!this.dict2.TryGetValue(subkey2, out item))
-      {
-        value = default(TValue);
-        return false;
-      }
-      value = item.Value;
-      return true;
-    }
-  }
-
 }

--- a/Microsoft.Research/DataStructures/Properties/AssemblyInfo.cs
+++ b/Microsoft.Research/DataStructures/Properties/AssemblyInfo.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/Microsoft.Research/DataStructures/Relation.cs
+++ b/Microsoft.Research/DataStructures/Relation.cs
@@ -1,46 +1,38 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Research.DataStructures
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Diagnostics;
-  using System.Text;
-  using System.IO;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using System.IO;
 
 
-  public class Relation<S, T> {
-    private DoubleTable<S, T, bool> representation = new DoubleTable<S,T,bool>();
+    public class Relation<S, T>
+    {
+        private DoubleTable<S, T, bool> representation = new DoubleTable<S, T, bool>();
 
-    public void Add(S s, T t) {
-      representation.Add(s, t, true);
-    }
-
-    private static readonly ICollection<T> EmptyRange = new T[0];
-
-    public ICollection<T> this[S key] {
-      get {
-        Dictionary<T, bool>/*?*/ range;
-        if (representation.TryGetValue(key, out range)) {
-          //^ assume range != null;
-          return range.Keys;
+        public void Add(S s, T t)
+        {
+            representation.Add(s, t, true);
         }
-        return EmptyRange;
-      }
+
+        private static readonly ICollection<T> EmptyRange = new T[0];
+
+        public ICollection<T> this[S key]
+        {
+            get
+            {
+                Dictionary<T, bool>/*?*/ range;
+                if (representation.TryGetValue(key, out range))
+                {
+                    //^ assume range != null;
+                    return range.Keys;
+                }
+                return EmptyRange;
+            }
+        }
     }
-  }
-
-
 }

--- a/Microsoft.Research/DataStructures/Set.cs
+++ b/Microsoft.Research/DataStructures/Set.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // #define SET_WITH_DICTIONARY
 
@@ -25,2481 +14,2479 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.DataStructures
 {
-  [ContractClass(typeof(IReadOnlySetContracts<>))]
-  public interface IReadonlySet<T> : IEnumerable<T>
-  {
-    /// <summary>
-    /// Returns the cardinality of the set
-    /// </summary>
-    int Count { get; }
-
-    /// <summary>
-    /// Return true if element is part of the set
-    /// </summary>
-    bool Contains(T element);
-
-    /// <summary>
-    /// Convert all the elements in the set
-    /// </summary>
-    IMutableSet<U> ConvertAll<U>(Converter<T, U> converter);
-
-    /// <summary>
-    /// Set difference (this \ b).
-    /// We want the result to be a fresh set
-    /// </summary>
-    IMutableSet<T> Difference(IEnumerable<T> b);
-
-    /// <summary>
-    /// Return the subset of elements in this set that satisfy the predicate
-    /// </summary>
-    IMutableSet<T> FindAll(Predicate<T> predicate);
-
-    /// <summary>
-    /// Apply the <code>action</code> to all the elements of the set
-    /// </summary>
-    void ForEach(Action<T> action);
-
-    /// <summary>
-    /// Does it exist an element in the set that satisfies <code>predicate</code>
-    /// </summary>
-    bool Exists(Predicate<T> predicate);
-
-    /// <summary>
-    /// Set intersection.
-    /// We want the result to be a fresh set
-    /// </summary>
-    IMutableSet<T> Intersection(IReadonlySet<T> b);
-
-    /// <summary>
-    /// True iff this is a subset of <code>s</code>
-    /// </summary>
-    bool IsSubset(IReadonlySet<T> s);
-
-    ///<summary>
-    /// True iff the set is empty
-    ///</summary>
-    bool IsEmpty { get; }
-
-    /// <summary>
-    /// True iff the set contains just one element
-    /// </summary>
-    bool IsSingleton { get; }
-
-    /// <returns>
-    /// An element of the set.
-    /// It is not removed!!!
-    /// </returns>
-    T PickAnElement();
-
-    /// <summary>
-    ///  Check if the predicate holds for all the elements in the set
-    /// </summary>
-    bool TrueForAll(Predicate<T> predicate);
-
-    /// <summary>
-    /// Set union.
-    /// We want the result to be a fresh set
-    /// </summary>
-    IMutableSet<T> Union(IReadonlySet<T> b);
-  }
-
-  [ContractClass(typeof(IMutabSetContracts<>))]
-  public interface IMutableSet<T> : IReadonlySet<T>
-  {
-    /// <summary>
-    /// Add element to set
-    /// Returns true if the element was added, false if it was present
-    /// </summary>
-    bool Add(T element);
-
-    /// <summary>
-    /// Add all the elements in the <code>range</code> to this set
-    /// </summary>
-    void AddRange(IEnumerable<T> range);
-  }
-
-  #region Contracts
-  [ContractClassFor(typeof(IReadonlySet<>))]
-  abstract class IReadOnlySetContracts<T> : IReadonlySet<T>
-  {
-
-    #region IReadonlySet<T> Members
-
-    int IReadonlySet<T>.Count
+    [ContractClass(typeof(IReadOnlySetContracts<>))]
+    public interface IReadonlySet<T> : IEnumerable<T>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-   
-        throw new NotImplementedException();
-      }
+        /// <summary>
+        /// Returns the cardinality of the set
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Return true if element is part of the set
+        /// </summary>
+        bool Contains(T element);
+
+        /// <summary>
+        /// Convert all the elements in the set
+        /// </summary>
+        IMutableSet<U> ConvertAll<U>(Converter<T, U> converter);
+
+        /// <summary>
+        /// Set difference (this \ b).
+        /// We want the result to be a fresh set
+        /// </summary>
+        IMutableSet<T> Difference(IEnumerable<T> b);
+
+        /// <summary>
+        /// Return the subset of elements in this set that satisfy the predicate
+        /// </summary>
+        IMutableSet<T> FindAll(Predicate<T> predicate);
+
+        /// <summary>
+        /// Apply the <code>action</code> to all the elements of the set
+        /// </summary>
+        void ForEach(Action<T> action);
+
+        /// <summary>
+        /// Does it exist an element in the set that satisfies <code>predicate</code>
+        /// </summary>
+        bool Exists(Predicate<T> predicate);
+
+        /// <summary>
+        /// Set intersection.
+        /// We want the result to be a fresh set
+        /// </summary>
+        IMutableSet<T> Intersection(IReadonlySet<T> b);
+
+        /// <summary>
+        /// True iff this is a subset of <code>s</code>
+        /// </summary>
+        bool IsSubset(IReadonlySet<T> s);
+
+        ///<summary>
+        /// True iff the set is empty
+        ///</summary>
+        bool IsEmpty { get; }
+
+        /// <summary>
+        /// True iff the set contains just one element
+        /// </summary>
+        bool IsSingleton { get; }
+
+        /// <returns>
+        /// An element of the set.
+        /// It is not removed!!!
+        /// </returns>
+        T PickAnElement();
+
+        /// <summary>
+        ///  Check if the predicate holds for all the elements in the set
+        /// </summary>
+        bool TrueForAll(Predicate<T> predicate);
+
+        /// <summary>
+        /// Set union.
+        /// We want the result to be a fresh set
+        /// </summary>
+        IMutableSet<T> Union(IReadonlySet<T> b);
     }
 
-    bool IReadonlySet<T>.Contains(T element)
-    {      
-      throw new NotImplementedException();
-    }
-
-    IMutableSet<U> IReadonlySet<T>.ConvertAll<U>(Converter<T, U> converter)
+    [ContractClass(typeof(IMutabSetContracts<>))]
+    public interface IMutableSet<T> : IReadonlySet<T>
     {
-      Contract.Requires(converter != null);
-      Contract.Ensures(Contract.Result<IMutableSet<U>>() != null);
-      
-      throw new NotImplementedException();
+        /// <summary>
+        /// Add element to set
+        /// Returns true if the element was added, false if it was present
+        /// </summary>
+        bool Add(T element);
+
+        /// <summary>
+        /// Add all the elements in the <code>range</code> to this set
+        /// </summary>
+        void AddRange(IEnumerable<T> range);
     }
 
-    IMutableSet<T> IReadonlySet<T>.Difference(IEnumerable<T> b)
+    #region Contracts
+    [ContractClassFor(typeof(IReadonlySet<>))]
+    internal abstract class IReadOnlySetContracts<T> : IReadonlySet<T>
     {
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<IMutableSet<T>>() != null);
-      
-      throw new NotImplementedException();
+        #region IReadonlySet<T> Members
+
+        int IReadonlySet<T>.Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+
+                throw new NotImplementedException();
+            }
+        }
+
+        bool IReadonlySet<T>.Contains(T element)
+        {
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<U> IReadonlySet<T>.ConvertAll<U>(Converter<T, U> converter)
+        {
+            Contract.Requires(converter != null);
+            Contract.Ensures(Contract.Result<IMutableSet<U>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Difference(IEnumerable<T> b)
+        {
+            Contract.Requires(b != null);
+            Contract.Ensures(Contract.Result<IMutableSet<T>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<T> IReadonlySet<T>.FindAll(Predicate<T> predicate)
+        {
+            Contract.Requires(predicate != null);
+            Contract.Ensures(Contract.Result<IMutableSet<T>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        void IReadonlySet<T>.ForEach(Action<T> action)
+        {
+            Contract.Requires(action != null);
+
+            throw new NotImplementedException();
+        }
+
+        bool IReadonlySet<T>.Exists(Predicate<T> predicate)
+        {
+            Contract.Requires(predicate != null);
+
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Intersection(IReadonlySet<T> b)
+        {
+            Contract.Requires(b != null);
+            Contract.Ensures(Contract.Result<IMutableSet<T>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        bool IReadonlySet<T>.IsSubset(IReadonlySet<T> s)
+        {
+            Contract.Requires(s != null);
+
+            throw new NotImplementedException();
+        }
+
+        bool IReadonlySet<T>.IsEmpty
+        {
+            get
+            {
+                return default(bool);
+            }
+        }
+
+        bool IReadonlySet<T>.IsSingleton
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        T IReadonlySet<T>.PickAnElement()
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IReadonlySet<T>.TrueForAll(Predicate<T> predicate)
+        {
+            Contract.Requires(predicate != null);
+
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Union(IReadonlySet<T> b)
+        {
+            Contract.Requires(b != null);
+            Contract.Ensures(Contract.Result<IMutableSet<T>>() != null);
+
+
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IEnumerable<T> Members
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
     }
 
-    IMutableSet<T> IReadonlySet<T>.FindAll(Predicate<T> predicate)
+    [ContractClassFor(typeof(IMutableSet<>))]
+    internal abstract class IMutabSetContracts<T> : IMutableSet<T>
     {
-      Contract.Requires(predicate != null);
-      Contract.Ensures(Contract.Result<IMutableSet<T>>() != null);
+        #region ISet<T> Members
 
-      throw new NotImplementedException();
+        bool IMutableSet<T>.Add(T element)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IMutableSet<T>.AddRange(IEnumerable<T> range)
+        {
+            Contract.Requires(range != null);
+
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IReadonlySet<T> Members
+
+        int IReadonlySet<T>.Count
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IReadonlySet<T>.Contains(T element)
+        {
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<U> IReadonlySet<T>.ConvertAll<U>(Converter<T, U> converter)
+        {
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Difference(IEnumerable<T> b)
+        {
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<T> IReadonlySet<T>.FindAll(Predicate<T> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IReadonlySet<T>.ForEach(Action<T> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IReadonlySet<T>.Exists(Predicate<T> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Intersection(IReadonlySet<T> b)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IReadonlySet<T>.IsSubset(IReadonlySet<T> s)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IReadonlySet<T>.IsEmpty
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IReadonlySet<T>.IsSingleton
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        T IReadonlySet<T>.PickAnElement()
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IReadonlySet<T>.TrueForAll(Predicate<T> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Union(IReadonlySet<T> b)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IEnumerable<T> Members
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
     }
-
-    void IReadonlySet<T>.ForEach(Action<T> action)
-    {
-      Contract.Requires(action != null);
-
-      throw new NotImplementedException();
-    }
-
-    bool IReadonlySet<T>.Exists(Predicate<T> predicate)
-    {
-      Contract.Requires(predicate != null);
-
-      throw new NotImplementedException();
-    }
-
-    IMutableSet<T> IReadonlySet<T>.Intersection(IReadonlySet<T> b)
-    {
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<IMutableSet<T>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    bool IReadonlySet<T>.IsSubset(IReadonlySet<T> s)
-    {
-      Contract.Requires(s != null);
-
-      throw new NotImplementedException();
-    }
-
-    bool IReadonlySet<T>.IsEmpty
-    {
-      get {
-        return default(bool);
-      }
-    }
-
-    bool IReadonlySet<T>.IsSingleton
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    T IReadonlySet<T>.PickAnElement()
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IReadonlySet<T>.TrueForAll(Predicate<T> predicate)
-    {
-      Contract.Requires(predicate != null);
-
-      throw new NotImplementedException();
-    }
-
-    IMutableSet<T> IReadonlySet<T>.Union(IReadonlySet<T> b)
-    {
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<IMutableSet<T>>() != null);
-
-
-      throw new NotImplementedException();
-    }
-
     #endregion
-
-    #region IEnumerable<T> Members
-
-    IEnumerator<T> IEnumerable<T>.GetEnumerator()
-    {      
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-  }
-  
-  [ContractClassFor(typeof(IMutableSet<>))]
-  abstract class IMutabSetContracts<T> : IMutableSet<T>
-  {
-
-    #region ISet<T> Members
-
-    bool IMutableSet<T>.Add(T element)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IMutableSet<T>.AddRange(IEnumerable<T> range)
-    {
-      Contract.Requires(range != null);
-      
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IReadonlySet<T> Members
-
-    int IReadonlySet<T>.Count
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    bool IReadonlySet<T>.Contains(T element)
-    {
-      throw new NotImplementedException();
-    }
-
-    IMutableSet<U> IReadonlySet<T>.ConvertAll<U>(Converter<T, U> converter)
-    {
-      throw new NotImplementedException();
-    }
-
-    IMutableSet<T> IReadonlySet<T>.Difference(IEnumerable<T> b)
-    {
-      throw new NotImplementedException();
-    }
-
-    IMutableSet<T> IReadonlySet<T>.FindAll(Predicate<T> predicate)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IReadonlySet<T>.ForEach(Action<T> action)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IReadonlySet<T>.Exists(Predicate<T> predicate)
-    {
-      throw new NotImplementedException();
-    }
-
-    IMutableSet<T> IReadonlySet<T>.Intersection(IReadonlySet<T> b)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IReadonlySet<T>.IsSubset(IReadonlySet<T> s)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IReadonlySet<T>.IsEmpty
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    bool IReadonlySet<T>.IsSingleton
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    T IReadonlySet<T>.PickAnElement()
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IReadonlySet<T>.TrueForAll(Predicate<T> predicate)
-    {
-      throw new NotImplementedException();
-    }
-
-    IMutableSet<T> IReadonlySet<T>.Union(IReadonlySet<T> b)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IEnumerable<T> Members
-
-    IEnumerator<T> IEnumerable<T>.GetEnumerator()
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-  }
-  #endregion
 
 #if SET_WITH_SIMPLEHASHTABLE
-  /// <summary>
-  /// An implementation of ISet based on the BCL class Dictionary
-  /// </summary>
-  /// <typeparam name="T">The type of the elements of the set</typeparam>
-  [Serializable]
-  public class Set<T> : ISet<T>
-  {
-  #region Private Fields
-    private struct Dummy { }
-    private static readonly Dummy dummy = new Dummy();
-    private SimpleHashtable<T, Dummy> data;
-  #endregion
-
-  #region Constructors
     /// <summary>
-    /// Create an empty set of standard capacity
+    /// An implementation of ISet based on the BCL class Dictionary
     /// </summary>
-    public Set()
+    /// <typeparam name="T">The type of the elements of the set</typeparam>
+    [Serializable]
+    public class Set<T> : ISet<T>
     {
-      this.data = new SimpleHashtable<T, Dummy>();
-    }
+        #region Private Fields
+        private struct Dummy { }
+        private static readonly Dummy dummy = new Dummy();
+        private SimpleHashtable<T, Dummy> data;
+        #endregion
 
-    /// <summary>
-    /// Create a set of initial <code>capacity</code>
-    /// </summary>
-    public Set(int capacity)
-    {
-      this.data = new SimpleHashtable<T, Dummy>((uint) capacity);
-    }
-
-    /// <summary>
-    /// Create a singleton
-    /// </summary>
-    public Set(T singleton)
-    {
-      this.data = new SimpleHashtable<T, Dummy>();
-      this.Add(singleton);
-    }
-
-    /// <summary>
-    /// Create a set containing the same elements than <code>original</code>
-    /// </summary>
-    public Set(Set<T> original)
-    {
-      this.data = new SimpleHashtable<T, Dummy>(original.data);
-    }
-
-    /// <summary>
-    /// Create a set containing the same elements than <code>original</code>
-    /// </summary>
-    public Set(IEnumerable<T> original)
-    {
-      this.data = new SimpleHashtable<T, Dummy>();
-      AddRange(original);
-    }
-  #endregion
-
-    public int Count
-    {
-      get
-      {
-        return this.data.Count;
-      }
-    }
-
-    public bool IsEmpty
-    {
-      get
-      {
-        return this.Count == 0;
-      }
-    }
-
-    public bool IsSingleton
-    {
-      get
-      {
-        return this.Count == 1;
-      }
-    }
-
-    /// <summary>
-    /// Add an element to the set. 
-    /// If it already exists, it does nothing
-    /// </summary>
-    /// <returns>true if element was NOT previously present</returns>
-    public bool AddQ(T a)
-    {
-      if (!this.data.ContainsKey(a))
-      {
-        this.data.Add(a, dummy);
-        return true;
-      }
-      return false;
-    }
-
-    public void Add(T a)
-    {
-      this.data[a] = dummy;
-    }
-
-    /// <summary>
-    /// Add all the elements in the <code>range</code> to this set
-    /// </summary>
-    public void AddRange(IEnumerable<T> range)
-    {
-      foreach (T a in range)
-        Add(a);
-    }
-
-    /// <summary>
-    /// Convert all the elements of the set
-    /// </summary>
-    public Set<U> ConvertAll<U>(Converter<T, U> converter)
-    {
-      Set<U> result = new Set<U>(this.Count);
-      foreach (T element in this)
-      {
-        result.Add(converter(element));
-      }
-      return result;
-    }
-
-    /// <summary>
-    ///  Check if the predicate holds for all the elements in the set
-    /// </summary>
-    public bool TrueForAll(Predicate<T> predicate)
-    {
-      foreach (T element in this)
-        if (!predicate(element))
-          return false;
-      return true;
-    }
-
-    /// <summary>
-    /// Return the subset of elements in this set that satisfy the predicate
-    /// </summary>
-    /// <param name="predicate"></param>
-    /// <returns></returns>
-    public Set<T> FindAll(Predicate<T> predicate)
-    {
-      var result = new Set<T>();
-      foreach (T element in this)
-        if (predicate(element))
-          result.Add(element);
-      return result;
-    }
-
-    /// <summary>
-    /// Does it exist an element in the set that satisfies <code>predicate</code>
-    /// </summary>
-    public bool Exists(Predicate<T> predicate)
-    {
-      foreach (T element in this)
-      {
-        if(predicate(element))
-          return true;
-      }
-
-      return false;
-    }
-
-    /// <summary>
-    /// Apply the <code>action</code> to all the elements of the set
-    /// </summary>
-    public void ForEach(Action<T> action)
-    {
-      foreach (T element in this)
-        action(element);
-    }
-
-    /// <returns>
-    /// An element of the set.
-    /// It is not removed;
-    /// </returns>
-    public T PickAnElement()
-    {
-      IEnumerator<T> e = this.data.Keys.GetEnumerator();
-      e.MoveNext();
-      return e.Current;
-    }
-
-    /// <summary>
-    /// Remove all the elements from this set.
-    /// </summary>
-    public void Clear()
-    {
-      data.Clear();
-    }
-
-    /// <summary>
-    /// True iff <code>a</code> is in the set
-    /// </summary>
-    public bool Contains(T a)
-    {
-      return data.ContainsKey(a);
-    }
-
-    /// <summary>
-    /// True iff this is a subset of <code>s</code>
-    /// </summary>
-    public bool IsSubset(Set<T> s)
-    {
-      if (this.Count > s.Count)
-      {
-        return false;
-      }
-
-      foreach (T e in this)
-      {
-        if (!s.Contains(e))
+        #region Constructors
+        /// <summary>
+        /// Create an empty set of standard capacity
+        /// </summary>
+        public Set()
         {
-          return false;
+            this.data = new SimpleHashtable<T, Dummy>();
         }
-      }
 
-      return true;
-    }
+        /// <summary>
+        /// Create a set of initial <code>capacity</code>
+        /// </summary>
+        public Set(int capacity)
+        {
+            this.data = new SimpleHashtable<T, Dummy>((uint)capacity);
+        }
 
-    /// <summary>
-    /// Remove the element <code>a</code> from the set
-    /// </summary>
-    /// <param name="a"></param>
-    /// <returns></returns>
-    public bool Remove(T a)
-    {
-      return this.data.Remove(a);
-    }
+        /// <summary>
+        /// Create a singleton
+        /// </summary>
+        public Set(T singleton)
+        {
+            this.data = new SimpleHashtable<T, Dummy>();
+            this.Add(singleton);
+        }
 
-    //^ [Pure]
-    public IEnumerator<T>/*!*/ GetEnumerator()
-    {
-      return data.Keys.GetEnumerator();
-    }
+        /// <summary>
+        /// Create a set containing the same elements than <code>original</code>
+        /// </summary>
+        public Set(Set<T> original)
+        {
+            this.data = new SimpleHashtable<T, Dummy>(original.data);
+        }
 
-    public bool IsReadOnly
-    {
-      get
-      {
-        return false;
-      }
-    }
+        /// <summary>
+        /// Create a set containing the same elements than <code>original</code>
+        /// </summary>
+        public Set(IEnumerable<T> original)
+        {
+            this.data = new SimpleHashtable<T, Dummy>();
+            AddRange(original);
+        }
+        #endregion
 
-    /// <summary>
-    /// Set union in infix form
-    /// </summary>
-    public static Set<T> operator |(Set<T> a, Set<T> b)
-    {
-      var result = new Set<T>(a);
-      result.AddRange(b);
+        public int Count
+        {
+            get
+            {
+                return this.data.Count;
+            }
+        }
 
-      return result;
-    }
+        public bool IsEmpty
+        {
+            get
+            {
+                return this.Count == 0;
+            }
+        }
 
-    /// <summary>
-    /// Set union in 
-    /// </summary>
-    public Set<T> Union(Set<T> b)
-    {
-      if (this.Count == 0)
-        return b;
+        public bool IsSingleton
+        {
+            get
+            {
+                return this.Count == 1;
+            }
+        }
 
-      if (b.Count == 0)
-        return this;
+        /// <summary>
+        /// Add an element to the set. 
+        /// If it already exists, it does nothing
+        /// </summary>
+        /// <returns>true if element was NOT previously present</returns>
+        public bool AddQ(T a)
+        {
+            if (!this.data.ContainsKey(a))
+            {
+                this.data.Add(a, dummy);
+                return true;
+            }
+            return false;
+        }
 
-      Set<T> asSet = b as Set<T>;
+        public void Add(T a)
+        {
+            this.data[a] = dummy;
+        }
 
-      if (asSet == null)
-        asSet = new Set<T>(b);
+        /// <summary>
+        /// Add all the elements in the <code>range</code> to this set
+        /// </summary>
+        public void AddRange(IEnumerable<T> range)
+        {
+            foreach (T a in range)
+                Add(a);
+        }
 
-      return this | asSet;
-    }
+        /// <summary>
+        /// Convert all the elements of the set
+        /// </summary>
+        public Set<U> ConvertAll<U>(Converter<T, U> converter)
+        {
+            Set<U> result = new Set<U>(this.Count);
+            foreach (T element in this)
+            {
+                result.Add(converter(element));
+            }
+            return result;
+        }
 
-    /// <summary>
-    /// Set intersection in infix form
-    /// </summary>
-    public static Set<T> operator &(Set<T> a, Set<T> b)
-    {
-      Set<T> result = new Set<T>();
-      foreach (T element in a)
-      {
-        if (b.Contains(element))
-          result.Add(element);
-      }
-      return result;
-    }
+        /// <summary>
+        ///  Check if the predicate holds for all the elements in the set
+        /// </summary>
+        public bool TrueForAll(Predicate<T> predicate)
+        {
+            foreach (T element in this)
+                if (!predicate(element))
+                    return false;
+            return true;
+        }
 
-    /// <summary>
-    /// Set intersection 
-    /// </summary>
-    public Set<T> Intersection(Set<T> b)
-    {
-      if (b.Count == 0)
-        return b;
+        /// <summary>
+        /// Return the subset of elements in this set that satisfy the predicate
+        /// </summary>
+        /// <param name="predicate"></param>
+        /// <returns></returns>
+        public Set<T> FindAll(Predicate<T> predicate)
+        {
+            var result = new Set<T>();
+            foreach (T element in this)
+                if (predicate(element))
+                    result.Add(element);
+            return result;
+        }
 
-      if (this.Count == 0)
-        return this;
+        /// <summary>
+        /// Does it exist an element in the set that satisfies <code>predicate</code>
+        /// </summary>
+        public bool Exists(Predicate<T> predicate)
+        {
+            foreach (T element in this)
+            {
+                if (predicate(element))
+                    return true;
+            }
 
-      Set<T> asSet = b as Set<T>;
+            return false;
+        }
 
-      if (asSet == null)
-        asSet = new Set<T>(b);
+        /// <summary>
+        /// Apply the <code>action</code> to all the elements of the set
+        /// </summary>
+        public void ForEach(Action<T> action)
+        {
+            foreach (T element in this)
+                action(element);
+        }
 
-      return this & asSet;
-    }
+        /// <returns>
+        /// An element of the set.
+        /// It is not removed;
+        /// </returns>
+        public T PickAnElement()
+        {
+            IEnumerator<T> e = this.data.Keys.GetEnumerator();
+            e.MoveNext();
+            return e.Current;
+        }
 
-    /// <summary>
-    /// Set difference in infix form
-    /// </summary>
-    public static Set<T> operator -(Set<T> a, Set<T> b)
-    {
-      Set<T> result = new Set<T>();
-      foreach (T element in a)
-        if (!b.Contains(element))
-          result.Add(element);
-      return result;
-    }
+        /// <summary>
+        /// Remove all the elements from this set.
+        /// </summary>
+        public void Clear()
+        {
+            data.Clear();
+        }
 
-    /// <summary>
-    /// Set difference
-    /// </summary>
-    public Set<T> Difference(IEnumerable<T> b)
-    {
-      return this - new Set<T>(b);
-    }
+        /// <summary>
+        /// True iff <code>a</code> is in the set
+        /// </summary>
+        public bool Contains(T a)
+        {
+            return data.ContainsKey(a);
+        }
 
-  #region Unused methods on sets
+        /// <summary>
+        /// True iff this is a subset of <code>s</code>
+        /// </summary>
+        public bool IsSubset(Set<T> s)
+        {
+            if (this.Count > s.Count)
+            {
+                return false;
+            }
 
-    public static Set<T> operator ^(Set<T> a, Set<T> b)
-    {
-      Set<T> result = new Set<T>();
-      foreach (T element in a)
-        if (!b.Contains(element))
-          result.Add(element);
-      foreach (T element in b)
-        if (!a.Contains(element))
-          result.Add(element);
-      return result;
-    }
-    public Set<T> SymmetricDifference(IEnumerable<T> b)
-    {
-      return this ^ new Set<T>(b);
-    }
+            foreach (T e in this)
+            {
+                if (!s.Contains(e))
+                {
+                    return false;
+                }
+            }
 
-    public static Set<T> Empty
-    {
-      get
-      {
-        return new Set<T>(0);
-      }
-    }
+            return true;
+        }
 
-    public static bool operator <=(Set<T> a, Set<T> b)
-    {
-      foreach (T element in a)
-        if (!b.Contains(element))
-          return false;
-      return true;
-    }
-    public static bool operator <(Set<T> a, Set<T> b)
-    {
-      return (a.Count < b.Count) && (a <= b);
-    }
+        /// <summary>
+        /// Remove the element <code>a</code> from the set
+        /// </summary>
+        /// <param name="a"></param>
+        /// <returns></returns>
+        public bool Remove(T a)
+        {
+            return this.data.Remove(a);
+        }
 
-    public static bool operator >(Set<T> a, Set<T> b)
-    {
-      return b < a;
-    }
-    public static bool operator >=(Set<T> a, Set<T> b)
-    {
-      return (b <= a);
-    }
+        //^ [Pure]
+        public IEnumerator<T>/*!*/ GetEnumerator()
+        {
+            return data.Keys.GetEnumerator();
+        }
 
-    //^ [StateIndependent]
-    public override bool Equals(object/*?*/ obj)
-    {
-      Set<T> a = this;
-      Set<T>/*?*/ b = obj as Set<T>;
-      if (Object.Equals(b, null))
-        return false;
-      return a == b;
-    }
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
 
-    //^ [Confined]
-    public override int GetHashCode()
-    {
-      int hashcode = 0;
-      foreach (T element in this)
-      {
-        Debug.Assert(element != null, "I was not expecting a null element in the set...");
-        //^ assert element != null;
+        /// <summary>
+        /// Set union in infix form
+        /// </summary>
+        public static Set<T> operator |(Set<T> a, Set<T> b)
+        {
+            var result = new Set<T>(a);
+            result.AddRange(b);
 
-        hashcode ^= element.GetHashCode();
-      }
-      return hashcode;
-    }
+            return result;
+        }
 
-  #endregion
+        /// <summary>
+        /// Set union in 
+        /// </summary>
+        public Set<T> Union(Set<T> b)
+        {
+            if (this.Count == 0)
+                return b;
 
-    //^ [Pure]
-    IEnumerator/*!*/ IEnumerable.GetEnumerator()
-    {
-      return ((IEnumerable)data.Keys).GetEnumerator();
-    }
+            if (b.Count == 0)
+                return this;
 
-    public void CopyTo(T[]/*!*/ array, int index)
-    {
-      int i = index;
-      foreach (var x in this)
-      {
-        array[i++] = x;
-      }
+            Set<T> asSet = b as Set<T>;
 
-      //this.data.Keys.CopyTo(array, index);
-    }
+            if (asSet == null)
+                asSet = new Set<T>(b);
 
-    //^ [Confined]
-    override public string/*!*/ ToString()
-    {
+            return this | asSet;
+        }
+
+        /// <summary>
+        /// Set intersection in infix form
+        /// </summary>
+        public static Set<T> operator &(Set<T> a, Set<T> b)
+        {
+            Set<T> result = new Set<T>();
+            foreach (T element in a)
+            {
+                if (b.Contains(element))
+                    result.Add(element);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Set intersection 
+        /// </summary>
+        public Set<T> Intersection(Set<T> b)
+        {
+            if (b.Count == 0)
+                return b;
+
+            if (this.Count == 0)
+                return this;
+
+            Set<T> asSet = b as Set<T>;
+
+            if (asSet == null)
+                asSet = new Set<T>(b);
+
+            return this & asSet;
+        }
+
+        /// <summary>
+        /// Set difference in infix form
+        /// </summary>
+        public static Set<T> operator -(Set<T> a, Set<T> b)
+        {
+            Set<T> result = new Set<T>();
+            foreach (T element in a)
+                if (!b.Contains(element))
+                    result.Add(element);
+            return result;
+        }
+
+        /// <summary>
+        /// Set difference
+        /// </summary>
+        public Set<T> Difference(IEnumerable<T> b)
+        {
+            return this - new Set<T>(b);
+        }
+
+        #region Unused methods on sets
+
+        public static Set<T> operator ^(Set<T> a, Set<T> b)
+        {
+            Set<T> result = new Set<T>();
+            foreach (T element in a)
+                if (!b.Contains(element))
+                    result.Add(element);
+            foreach (T element in b)
+                if (!a.Contains(element))
+                    result.Add(element);
+            return result;
+        }
+        public Set<T> SymmetricDifference(IEnumerable<T> b)
+        {
+            return this ^ new Set<T>(b);
+        }
+
+        public static Set<T> Empty
+        {
+            get
+            {
+                return new Set<T>(0);
+            }
+        }
+
+        public static bool operator <=(Set<T> a, Set<T> b)
+        {
+            foreach (T element in a)
+                if (!b.Contains(element))
+                    return false;
+            return true;
+        }
+        public static bool operator <(Set<T> a, Set<T> b)
+        {
+            return (a.Count < b.Count) && (a <= b);
+        }
+
+        public static bool operator >(Set<T> a, Set<T> b)
+        {
+            return b < a;
+        }
+        public static bool operator >=(Set<T> a, Set<T> b)
+        {
+            return (b <= a);
+        }
+
+        //^ [StateIndependent]
+        public override bool Equals(object/*?*/ obj)
+        {
+            Set<T> a = this;
+            Set<T>/*?*/ b = obj as Set<T>;
+            if (Object.Equals(b, null))
+                return false;
+            return a == b;
+        }
+
+        //^ [Confined]
+        public override int GetHashCode()
+        {
+            int hashcode = 0;
+            foreach (T element in this)
+            {
+                Debug.Assert(element != null, "I was not expecting a null element in the set...");
+                //^ assert element != null;
+
+                hashcode ^= element.GetHashCode();
+            }
+            return hashcode;
+        }
+
+        #endregion
+
+        //^ [Pure]
+        IEnumerator/*!*/ IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)data.Keys).GetEnumerator();
+        }
+
+        public void CopyTo(T[]/*!*/ array, int index)
+        {
+            int i = index;
+            foreach (var x in this)
+            {
+                array[i++] = x;
+            }
+
+            //this.data.Keys.CopyTo(array, index);
+        }
+
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
 #if DEBUG
-      string res = "{";
+            string res = "{";
 
-      foreach (T e in this)
-      {
-        res += (e != null? e.ToString() : "<null>") + " ,";
-      }
-      if (res[res.Length - 1] == ',')
-          res=res.Substring(0, res.Length - 2);
-            
-      res += "}";
+            foreach (T e in this)
+            {
+                res += (e != null ? e.ToString() : "<null>") + " ,";
+            }
+            if (res[res.Length - 1] == ',')
+                res = res.Substring(0, res.Length - 2);
+
+            res += "}";
 #else
-      string res = this.Count.ToString() + " elements";
+            string res = this.Count.ToString() + " elements";
 #endif
-      return res;
+            return res;
+        }
+
+        #region ISet<T> Members
+
+        void ISet<T>.AddRange(IEnumerable<T> range)
+        {
+            this.AddRange(range);
+        }
+
+        ISet<U> ISet<T>.ConvertAll<U>(Converter<T, U> converter)
+        {
+            return this.ConvertAll(converter);
+        }
+
+        ISet<T> ISet<T>.Difference(IEnumerable<T> b)
+        {
+            return this.Difference(b);
+        }
+
+        ISet<T> ISet<T>.FindAll(Predicate<T> predicate)
+        {
+            return this.FindAll(predicate);
+        }
+
+        void ISet<T>.ForEach(Action<T> action)
+        {
+            this.ForEach(action);
+        }
+
+        bool ISet<T>.Exists(Predicate<T> predicate)
+        {
+            return this.Exists(predicate);
+        }
+
+        ISet<T> ISet<T>.Intersection(ISet<T> b)
+        {
+            Set<T> bAsSet = b as Set<T>;
+            if (bAsSet != null)
+                return this.Intersection(bAsSet);
+            else
+                return this.Intersection(new Set<T>(b));
+        }
+
+        bool ISet<T>.IsSubset(ISet<T> s)
+        {
+            Set<T> sAsSet = s as Set<T>;
+            if (sAsSet != null)
+                return this.IsSubset(sAsSet);
+            else
+                return this.IsSubset(new Set<T>(s));
+        }
+
+        bool ISet<T>.IsEmpty
+        {
+            get { return this.IsEmpty; }
+        }
+
+        bool ISet<T>.IsSingleton
+        {
+            get { return this.IsSingleton; }
+        }
+
+        T ISet<T>.PickAnElement()
+        {
+            return this.PickAnElement();
+        }
+
+        bool ISet<T>.TrueForAll(Predicate<T> predicate)
+        {
+            return this.TrueForAll(predicate);
+        }
+
+        ISet<T> ISet<T>.Union(ISet<T> b)
+        {
+            Set<T> bAsSet = b as Set<T>;
+            if (bAsSet != null)
+                return this.Union(bAsSet);
+            else
+                return this.Union(new Set<T>(b));
+        }
+
+        #endregion
+
     }
-
-  #region ISet<T> Members
-
-    void ISet<T>.AddRange(IEnumerable<T> range)
-    {
-      this.AddRange(range);
-    }
-
-    ISet<U> ISet<T>.ConvertAll<U>(Converter<T, U> converter)
-    {
-      return this.ConvertAll(converter);
-    }
-
-    ISet<T> ISet<T>.Difference(IEnumerable<T> b)
-    {
-      return this.Difference(b);
-    }
-
-    ISet<T> ISet<T>.FindAll(Predicate<T> predicate)
-    {
-      return this.FindAll(predicate);
-    }
-
-    void ISet<T>.ForEach(Action<T> action)
-    {
-      this.ForEach(action);
-    }
-
-    bool ISet<T>.Exists(Predicate<T> predicate)
-    {
-      return this.Exists(predicate);
-    }
-
-    ISet<T> ISet<T>.Intersection(ISet<T> b)
-    {
-      Set<T> bAsSet = b as Set<T>;
-      if (bAsSet != null)
-        return this.Intersection(bAsSet);
-      else
-        return this.Intersection(new Set<T>(b));
-    }
-
-    bool ISet<T>.IsSubset(ISet<T> s)
-    {
-      Set<T> sAsSet = s as Set<T>;
-      if (sAsSet != null)
-        return this.IsSubset(sAsSet);
-      else
-        return this.IsSubset(new Set<T>(s));
-    }
-
-    bool ISet<T>.IsEmpty
-    {
-      get { return this.IsEmpty; }
-    }
-
-    bool ISet<T>.IsSingleton
-    {
-      get { return this.IsSingleton; }
-    }
-
-    T ISet<T>.PickAnElement()
-    {
-      return this.PickAnElement();
-    }
-
-    bool ISet<T>.TrueForAll(Predicate<T> predicate)
-    {
-      return this.TrueForAll(predicate);
-    }
-
-    ISet<T> ISet<T>.Union(ISet<T> b)
-    {
-      Set<T> bAsSet = b as Set<T>;
-      if (bAsSet != null)
-        return this.Union(bAsSet);
-      else
-        return this.Union(new Set<T>(b));
-    }
-
-  #endregion
-
-  }
 #endif
 
 #if SET_WITH_HASHSET
-  /// <summary>
-  /// An implementation of ISet based on the System.dll class HashSet
-  /// </summary>
-  /// <typeparam name="T">The type of the elements of the set</typeparam>
-  [ContractVerification(true)]
-  [Serializable]
-  public class Set<T> : IMutableSet<T>
-  {
-    #region Static
-    static private int idCount = 0;
-    #endregion
-
-    #region Invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.data != null);
-    }
-    #endregion
-
-    #region Private Fields
-
-    private readonly HashSet<T> data;
-    private readonly int id; // unused?
-
-    #endregion
-
-    #region Constructors
     /// <summary>
-    /// Create an empty set of standard capacity
+    /// An implementation of ISet based on the System.dll class HashSet
     /// </summary>
-    public Set()
+    /// <typeparam name="T">The type of the elements of the set</typeparam>
+    [ContractVerification(true)]
+    [Serializable]
+    public class Set<T> : IMutableSet<T>
     {
-      this.data = new HashSet<T>();
-      this.id = idCount++;
-    }
-
-    /// <summary>
-    /// Create an empty set using given comparison
-    /// </summary>
-    public Set(IEqualityComparer<T> comparer)
-    {
-      this.data = new HashSet<T>(comparer);
-      this.id = idCount++;
-    }
-
-    /// <summary>
-    /// Create a set of initial <code>capacity</code>
-    /// </summary>
-    public Set(int capacity)
-    {
-      this.data = new HashSet<T>();
-      this.id = idCount++;
-    }
-
-    /// <summary>
-    /// Create a singleton
-    /// </summary>
-    public Set(T singleton)
-    {
-      this.data = new HashSet<T>();
-      this.Add(singleton);
-      this.id = idCount++;
-    }
-
-    /// <summary>
-    /// Create a set containing the same elements than <code>original</code>
-    /// </summary>
-    public Set(Set<T> original)
-    {
-      Contract.Requires(original != null);
-
-      Contract.Assume(original.data != null);
-
-      this.data = new HashSet<T>(original.data, original.data.Comparer);
-      this.id = idCount++;
-    }
-
-    /// <summary>
-    /// Create a set containing the same elements as <code>original</code>
-    /// </summary>
-    public Set(IEnumerable<T> original)
-    {
-      Contract.Requires(original != null);
-
-      this.data = new HashSet<T>();
-      AddRange(original);
-      this.id = idCount++;
-    }
-
-    /// <summary>
-    /// Create a set containing the same elements as <code>original</code>
-    /// using the given comparer
-    /// </summary>
-    public Set(IEnumerable<T> original, IEqualityComparer<T> comparer)
-    {
-      Contract.Requires(original != null);
-
-      this.data = new HashSet<T>(comparer);
-      AddRange(original);
-      this.id = idCount++;
-    }
-
-    public Set(IEnumerable<T> original, IEnumerable<T> original2)
-    {
-      Contract.Requires(original != null);
-      Contract.Requires(original2 != null);
-
-      this.data = new HashSet<T>();
-      AddRange(original);
-      if (!object.ReferenceEquals(original, original2))
-      {
-        AddRange(original2);
-      }
-      this.id = idCount++;
-    }
-
-    private Set(HashSet<T> set)
-    {
-      Contract.Requires(set != null);
-
-      this.data = set;
-      this.id = idCount++;
-    }
-    #endregion
-
-    public int Count
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        Contract.Ensures(Contract.Result<int>() == this.data.Count);
-
-        return this.data.Count;
-      }
-    }
-
-    public bool IsEmpty
-    {
-      get
-      {
-        return this.Count == 0;
-      }
-    }
-
-    public bool IsSingleton
-    {
-      get
-      {
-        return this.Count == 1;
-      }
-    }
-
-    /// <summary>
-    /// Add an element to the set. 
-    /// If it already exists, it does nothing
-    /// </summary>
-    /// <returns>true if element was NOT previously present</returns>
-    public bool AddQ(T a)
-    {
-      if (!this.data.Contains(a))
-      {
-        this.data.Add(a);
-        return true;
-      }
-      return false;
-    }
-
-    public bool Add(T a)
-    {
-      return this.data.Add(a);
-    }
-
-    /// <summary>
-    /// Add all the elements in the <code>range</code> to this set
-    /// </summary>
-    public void AddRange(IEnumerable<T> range)
-    {
-      foreach (var a in range)
-        Add(a);
-    }
-
-    public void AddRange(Set<T> set)
-    {
-      Contract.Requires(set != null);
-      this.data.UnionWith(set.data);
-    }
-
-    /// <summary>
-    /// Convert all the elements of the set
-    /// </summary>
-    public Set<U> ConvertAll<U>(Converter<T, U> converter)
-    {
-      Contract.Requires(converter != null);
-      Contract.Ensures(Contract.Result<Set<U>>() != null);
-      
-      var result = new Set<U>(this.Count);
-      foreach (var element in this)
-      {
-        result.Add(converter(element));
-      }
-      return result;
-    }
-
-    /// <summary>
-    ///  Check if the predicate holds for all the elements in the set
-    /// </summary>
-    [Pure]
-    public bool TrueForAll(Predicate<T> predicate)
-    {
-      Contract.Requires(predicate != null);
-
-      foreach (T element in this)
-        if (!predicate(element))
-          return false;
-      return true;
-    }
-
-    /// <summary>
-    /// Return the subset of elements in this set that satisfy the predicate
-    /// </summary>
-    /// <param name="predicate"></param>
-    /// <returns></returns>
-    public Set<T> FindAll(Predicate<T> predicate)
-    {
-      Contract.Requires(predicate != null);
-      Contract.Ensures(Contract.Result<Set<T>>() != null);      
-
-      return FindAllInternal(predicate, new Set<T>());
-    }
-
-    protected R FindAllInternal<R>(Predicate<T> predicate, R result)
-      where R : IMutableSet<T>
-    {
-      Contract.Requires(predicate != null);
-      Contract.Requires(result != null);
-
-      Contract.Ensures(Contract.Result<R>() != null);      
-
-      foreach (T element in this)
-        if (predicate(element))
-          result.Add(element);
-
-      Contract.Assume(result != null);
-
-      return result;
-    }
-
-    /// <summary>
-    /// Does it exist an element in the set that satisfies <code>predicate</code>
-    /// </summary>
-    [Pure]
-    public bool Exists(Predicate<T> predicate)
-    {
-      Contract.Requires(predicate != null);
-
-      foreach (T element in this)
-      {
-        if (predicate(element))
-          return true;
-      }
-
-      return false;
-    }
-
-    /// <summary>
-    /// Apply the <code>action</code> to all the elements of the set
-    /// </summary>
-    public void ForEach(Action<T> action)
-    {
-      Contract.Requires(action != null);
-
-      foreach (T element in this)
-        action(element);
-    }
-
-    /// <returns>
-    /// An element of the set.
-    /// It is not removed;
-    /// </returns>
-    [Pure]
-    public T PickAnElement()
-    {
-      var e = this.data.GetEnumerator();
-      e.MoveNext();
-      return e.Current;
-    }
-
-    /// <summary>
-    /// Remove all the elements from this set.
-    /// </summary>
-    public void Clear()
-    {
-      data.Clear();
-    }
-
-    [Pure]
-    public List<T> ToList()
-    {
-      Contract.Ensures(Contract.Result<List<T>>() != null);
-
-      var result = new List<T>(this.Count);
-      foreach (var x in this)
-      {
-        result.Add(x);
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// True iff <code>a</code> is in the set
-    /// </summary>
-    [Pure]
-    public bool Contains(T a)
-    {
-      return data.Contains(a);
-    }
-
-    /// <summary>
-    /// True iff this is a subset of <code>s</code>
-    /// </summary>
-    [Pure]
-    public bool IsSubset(Set<T> s)
-    {
-      Contract.Requires(s != null);
-
-      if (this.Count > s.Count)
-      {
-        return false;
-      }
-
-      return data.IsSubsetOf(s.data);
-    }
-
-    /// <summary>
-    /// Remove the element <code>a</code> from the set
-    /// </summary>
-    /// <param name="a"></param>
-    /// <returns></returns>
-    public bool Remove(T a)
-    {
-      return this.data.Remove(a);
-    }
-
-    [Pure]
-    public IEnumerator<T> GetEnumerator()
-    {
-      return data.GetEnumerator();
-    }
-
-    public bool IsReadOnly
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// Set union in infix form
-    /// </summary>
-    public static Set<T> operator |(Set<T> a, Set<T> b)
-    {
-      Contract.Requires(a != null);
-      Contract.Requires(b != null);
-
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
-      
-
-      var result = new HashSet<T>(a.data);
-      result.UnionWith(b.data);
-
-      return new Set<T>(result);
-    }
-
-    /// <summary>
-    /// Set union in 
-    /// </summary>
-    public Set<T> Union(Set<T> b)
-    {
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
-      
-      if (this.Count == 0)
-        return b;
-
-      if (b.Count == 0)
-        return this;
-
-      return this | b;
-    }
-
-    /// <summary>
-    /// Set intersection in infix form
-    /// </summary>
-    public static Set<T> operator &(Set<T> a, Set<T> b)
-    {
-      Contract.Requires(a != null);
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
-
-      return a.Count <= b.Count ? IntersectionInternal(a, b) : IntersectionInternal(b, a);
-    }
-
-    private static Set<T> IntersectionInternal(Set<T> a, Set<T> b)
-    {
-      Contract.Requires(a != null);
-      Contract.Requires(b != null);
-      Contract.Requires(a.Count <= b.Count);
-
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
-      /*
-      var intersection = new Set<T>(a.Count);
-
-      foreach (var x in a)
-      {
-        if (b.Contains(x))
-          intersection.Add(x);
-      }
-
-      return intersection;*/
-      var intersection = new HashSet<T>(a.data);
-      intersection.IntersectWith(b.data);
-
-      return new Set<T>(intersection);
-    }
-
-    /// <summary>
-    /// Set intersection 
-    /// </summary>
-    public Set<T> Intersection(Set<T> b)
-    {
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<Set<T>>() != null);      
-
-      if (b.Count == 0)
-        return b;
-
-      if (this.Count == 0)
-        return this;
-
-      return this & b;
-    }
-
-    public Set<T> Intersection(IEnumerable<T> xs)
-    {
-      Contract.Requires(xs != null);
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
-
-      var result = new Set<T>();
-
-      if (this.Count == 0)
-        return result; // empty set
-
-      foreach (var x in xs)
-      {
-        if (this.Contains(x))
+        #region Static
+        static private int idCount = 0;
+        #endregion
+
+        #region Invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          result.Add(x);
+            Contract.Invariant(data != null);
         }
-      }
+        #endregion
 
-      return result;
-    }
+        #region Private Fields
 
-    /// <summary>
-    /// Set difference in infix form
-    /// </summary>
-    public static Set<T> operator -(Set<T> a, Set<T> b)
-    {
-      Contract.Requires(a != null);
-      Contract.Requires(b != null);
+        private readonly HashSet<T> data;
+        private readonly int id; // unused?
 
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
-      
-      var result = new Set<T>();
-      foreach (T element in a)
-        if (!b.Contains(element))
-          result.Add(element);
-      return result;
-    }
+        #endregion
 
-    /// <summary>
-    /// Set difference
-    /// </summary>
-    public Set<T> Difference(IEnumerable<T> b)
-    {
-      Contract.Requires(b != null);
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
-      
-      return this - new Set<T>(b);
-    }
+        #region Constructors
+        /// <summary>
+        /// Create an empty set of standard capacity
+        /// </summary>
+        public Set()
+        {
+            data = new HashSet<T>();
+            id = idCount++;
+        }
 
-    public Set<T> Difference(Set<T> s)
-    {
-      Contract.Requires(s != null);
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
+        /// <summary>
+        /// Create an empty set using given comparison
+        /// </summary>
+        public Set(IEqualityComparer<T> comparer)
+        {
+            data = new HashSet<T>(comparer);
+            id = idCount++;
+        }
 
-      return this - s;
-    }
+        /// <summary>
+        /// Create a set of initial <code>capacity</code>
+        /// </summary>
+        public Set(int capacity)
+        {
+            data = new HashSet<T>();
+            id = idCount++;
+        }
 
-    #region Unused methods on sets
+        /// <summary>
+        /// Create a singleton
+        /// </summary>
+        public Set(T singleton)
+        {
+            data = new HashSet<T>();
+            this.Add(singleton);
+            id = idCount++;
+        }
 
-    public static Set<T> operator ^(Set<T> a, Set<T> b)
-    {
-      Contract.Requires(a != null);
-      Contract.Requires(b != null);
+        /// <summary>
+        /// Create a set containing the same elements than <code>original</code>
+        /// </summary>
+        public Set(Set<T> original)
+        {
+            Contract.Requires(original != null);
 
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
+            Contract.Assume(original.data != null);
 
-      Set<T> result = new Set<T>();
-      foreach (T element in a)
-        if (!b.Contains(element))
-          result.Add(element);
-      foreach (T element in b)
-        if (!a.Contains(element))
-          result.Add(element);
-      return result;
-    }
+            data = new HashSet<T>(original.data, original.data.Comparer);
+            id = idCount++;
+        }
 
-    public Set<T> SymmetricDifference(IEnumerable<T> b)
-    {
-      Contract.Requires(b != null);
+        /// <summary>
+        /// Create a set containing the same elements as <code>original</code>
+        /// </summary>
+        public Set(IEnumerable<T> original)
+        {
+            Contract.Requires(original != null);
 
-      Contract.Ensures(Contract.Result<Set<T>>() != null);
+            data = new HashSet<T>();
+            AddRange(original);
+            id = idCount++;
+        }
 
-      return this ^ new Set<T>(b);
-    }
+        /// <summary>
+        /// Create a set containing the same elements as <code>original</code>
+        /// using the given comparer
+        /// </summary>
+        public Set(IEnumerable<T> original, IEqualityComparer<T> comparer)
+        {
+            Contract.Requires(original != null);
 
-    public static Set<T> Empty
-    {
-      get
-      {
-        return new Set<T>(0);
-      }
-    }
+            data = new HashSet<T>(comparer);
+            AddRange(original);
+            id = idCount++;
+        }
 
-    public static bool operator <=(Set<T> a, Set<T> b)
-    {
-      Contract.Requires(a != null);
-      Contract.Requires(b != null);
+        public Set(IEnumerable<T> original, IEnumerable<T> original2)
+        {
+            Contract.Requires(original != null);
+            Contract.Requires(original2 != null);
 
-      foreach (T element in a)
-        if (!b.Contains(element))
-          return false;
-      return true;
-    }
+            data = new HashSet<T>();
+            AddRange(original);
+            if (!object.ReferenceEquals(original, original2))
+            {
+                AddRange(original2);
+            }
+            id = idCount++;
+        }
 
-    public static bool operator <(Set<T> a, Set<T> b)
-    {
-      Contract.Requires(a != null);
-      Contract.Requires(b != null);
+        private Set(HashSet<T> set)
+        {
+            Contract.Requires(set != null);
 
-      return (a.Count < b.Count) && (a <= b);
-    }
+            data = set;
+            id = idCount++;
+        }
+        #endregion
 
-    public static bool operator >(Set<T> a, Set<T> b)
-    {
-      Contract.Requires(a != null);
-      Contract.Requires(b != null);
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                Contract.Ensures(Contract.Result<int>() == data.Count);
 
-      return b < a;
-    }
-    public static bool operator >=(Set<T> a, Set<T> b)
-    {
-      Contract.Requires(a != null);
-      Contract.Requires(b != null);
+                return data.Count;
+            }
+        }
 
-      return (b <= a);
-    }
+        public bool IsEmpty
+        {
+            get
+            {
+                return this.Count == 0;
+            }
+        }
 
-    public override bool Equals(object obj)
-    {
-      if (obj == null)
-      {
-        return false;
-      }
+        public bool IsSingleton
+        {
+            get
+            {
+                return this.Count == 1;
+            }
+        }
 
-      if (Object.ReferenceEquals(this, obj))
-      {
-        return true;
-      }
+        /// <summary>
+        /// Add an element to the set. 
+        /// If it already exists, it does nothing
+        /// </summary>
+        /// <returns>true if element was NOT previously present</returns>
+        public bool AddQ(T a)
+        {
+            if (!data.Contains(a))
+            {
+                data.Add(a);
+                return true;
+            }
+            return false;
+        }
 
-      var a = this;
-      var b = obj as Set<T>;
+        public bool Add(T a)
+        {
+            return data.Add(a);
+        }
 
-      if (Object.Equals(b, null))
-      {
-        return false;
-      }
+        /// <summary>
+        /// Add all the elements in the <code>range</code> to this set
+        /// </summary>
+        public void AddRange(IEnumerable<T> range)
+        {
+            foreach (var a in range)
+                Add(a);
+        }
 
-      if (a.Count != b.Count)
-        return false;
+        public void AddRange(Set<T> set)
+        {
+            Contract.Requires(set != null);
+            data.UnionWith(set.data);
+        }
 
-      foreach (var el in a)
-      {
-        if (!b.Contains(el))
-          return false;
-      }
+        /// <summary>
+        /// Convert all the elements of the set
+        /// </summary>
+        public Set<U> ConvertAll<U>(Converter<T, U> converter)
+        {
+            Contract.Requires(converter != null);
+            Contract.Ensures(Contract.Result<Set<U>>() != null);
 
-      return true;
-    }
+            var result = new Set<U>(this.Count);
+            foreach (var element in this)
+            {
+                result.Add(converter(element));
+            }
+            return result;
+        }
 
-    public override int GetHashCode()
-    {
-      int hashcode = 0;
-      foreach (var element in this.data)
-      {
-        Contract.Assume(element != null, "I was not expecting a null element in the set...");
+        /// <summary>
+        ///  Check if the predicate holds for all the elements in the set
+        /// </summary>
+        [Pure]
+        public bool TrueForAll(Predicate<T> predicate)
+        {
+            Contract.Requires(predicate != null);
 
-        hashcode ^= element.GetHashCode();
-      }
-      return hashcode;
-    }
+            foreach (T element in this)
+                if (!predicate(element))
+                    return false;
+            return true;
+        }
 
-    #endregion
+        /// <summary>
+        /// Return the subset of elements in this set that satisfy the predicate
+        /// </summary>
+        /// <param name="predicate"></param>
+        /// <returns></returns>
+        public Set<T> FindAll(Predicate<T> predicate)
+        {
+            Contract.Requires(predicate != null);
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-      return ((IEnumerable)data).GetEnumerator();
-    }
+            return FindAllInternal(predicate, new Set<T>());
+        }
 
-    public void CopyTo(T[] array, int index)
-    {
-      Contract.Requires(array != null);
-      Contract.Requires(index >= 0);
-      Contract.Requires(index + this.Count <= array.Length);
+        protected R FindAllInternal<R>(Predicate<T> predicate, R result)
+          where R : IMutableSet<T>
+        {
+            Contract.Requires(predicate != null);
+            Contract.Requires(result != null);
 
-      this.data.CopyTo(array, index);
-    }
+            Contract.Ensures(Contract.Result<R>() != null);
 
-    override public string ToString()
-    {
+            foreach (T element in this)
+                if (predicate(element))
+                    result.Add(element);
+
+            Contract.Assume(result != null);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Does it exist an element in the set that satisfies <code>predicate</code>
+        /// </summary>
+        [Pure]
+        public bool Exists(Predicate<T> predicate)
+        {
+            Contract.Requires(predicate != null);
+
+            foreach (T element in this)
+            {
+                if (predicate(element))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Apply the <code>action</code> to all the elements of the set
+        /// </summary>
+        public void ForEach(Action<T> action)
+        {
+            Contract.Requires(action != null);
+
+            foreach (T element in this)
+                action(element);
+        }
+
+        /// <returns>
+        /// An element of the set.
+        /// It is not removed;
+        /// </returns>
+        [Pure]
+        public T PickAnElement()
+        {
+            var e = data.GetEnumerator();
+            e.MoveNext();
+            return e.Current;
+        }
+
+        /// <summary>
+        /// Remove all the elements from this set.
+        /// </summary>
+        public void Clear()
+        {
+            data.Clear();
+        }
+
+        [Pure]
+        public List<T> ToList()
+        {
+            Contract.Ensures(Contract.Result<List<T>>() != null);
+
+            var result = new List<T>(this.Count);
+            foreach (var x in this)
+            {
+                result.Add(x);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// True iff <code>a</code> is in the set
+        /// </summary>
+        [Pure]
+        public bool Contains(T a)
+        {
+            return data.Contains(a);
+        }
+
+        /// <summary>
+        /// True iff this is a subset of <code>s</code>
+        /// </summary>
+        [Pure]
+        public bool IsSubset(Set<T> s)
+        {
+            Contract.Requires(s != null);
+
+            if (this.Count > s.Count)
+            {
+                return false;
+            }
+
+            return data.IsSubsetOf(s.data);
+        }
+
+        /// <summary>
+        /// Remove the element <code>a</code> from the set
+        /// </summary>
+        /// <param name="a"></param>
+        /// <returns></returns>
+        public bool Remove(T a)
+        {
+            return data.Remove(a);
+        }
+
+        [Pure]
+        public IEnumerator<T> GetEnumerator()
+        {
+            return data.GetEnumerator();
+        }
+
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Set union in infix form
+        /// </summary>
+        public static Set<T> operator |(Set<T> a, Set<T> b)
+        {
+            Contract.Requires(a != null);
+            Contract.Requires(b != null);
+
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+
+            var result = new HashSet<T>(a.data);
+            result.UnionWith(b.data);
+
+            return new Set<T>(result);
+        }
+
+        /// <summary>
+        /// Set union in 
+        /// </summary>
+        public Set<T> Union(Set<T> b)
+        {
+            Contract.Requires(b != null);
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            if (this.Count == 0)
+                return b;
+
+            if (b.Count == 0)
+                return this;
+
+            return this | b;
+        }
+
+        /// <summary>
+        /// Set intersection in infix form
+        /// </summary>
+        public static Set<T> operator &(Set<T> a, Set<T> b)
+        {
+            Contract.Requires(a != null);
+            Contract.Requires(b != null);
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            return a.Count <= b.Count ? IntersectionInternal(a, b) : IntersectionInternal(b, a);
+        }
+
+        private static Set<T> IntersectionInternal(Set<T> a, Set<T> b)
+        {
+            Contract.Requires(a != null);
+            Contract.Requires(b != null);
+            Contract.Requires(a.Count <= b.Count);
+
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+            /*
+            var intersection = new Set<T>(a.Count);
+
+            foreach (var x in a)
+            {
+              if (b.Contains(x))
+                intersection.Add(x);
+            }
+
+            return intersection;*/
+            var intersection = new HashSet<T>(a.data);
+            intersection.IntersectWith(b.data);
+
+            return new Set<T>(intersection);
+        }
+
+        /// <summary>
+        /// Set intersection 
+        /// </summary>
+        public Set<T> Intersection(Set<T> b)
+        {
+            Contract.Requires(b != null);
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            if (b.Count == 0)
+                return b;
+
+            if (this.Count == 0)
+                return this;
+
+            return this & b;
+        }
+
+        public Set<T> Intersection(IEnumerable<T> xs)
+        {
+            Contract.Requires(xs != null);
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            var result = new Set<T>();
+
+            if (this.Count == 0)
+                return result; // empty set
+
+            foreach (var x in xs)
+            {
+                if (this.Contains(x))
+                {
+                    result.Add(x);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Set difference in infix form
+        /// </summary>
+        public static Set<T> operator -(Set<T> a, Set<T> b)
+        {
+            Contract.Requires(a != null);
+            Contract.Requires(b != null);
+
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            var result = new Set<T>();
+            foreach (T element in a)
+                if (!b.Contains(element))
+                    result.Add(element);
+            return result;
+        }
+
+        /// <summary>
+        /// Set difference
+        /// </summary>
+        public Set<T> Difference(IEnumerable<T> b)
+        {
+            Contract.Requires(b != null);
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            return this - new Set<T>(b);
+        }
+
+        public Set<T> Difference(Set<T> s)
+        {
+            Contract.Requires(s != null);
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            return this - s;
+        }
+
+        #region Unused methods on sets
+
+        public static Set<T> operator ^(Set<T> a, Set<T> b)
+        {
+            Contract.Requires(a != null);
+            Contract.Requires(b != null);
+
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            Set<T> result = new Set<T>();
+            foreach (T element in a)
+                if (!b.Contains(element))
+                    result.Add(element);
+            foreach (T element in b)
+                if (!a.Contains(element))
+                    result.Add(element);
+            return result;
+        }
+
+        public Set<T> SymmetricDifference(IEnumerable<T> b)
+        {
+            Contract.Requires(b != null);
+
+            Contract.Ensures(Contract.Result<Set<T>>() != null);
+
+            return this ^ new Set<T>(b);
+        }
+
+        public static Set<T> Empty
+        {
+            get
+            {
+                return new Set<T>(0);
+            }
+        }
+
+        public static bool operator <=(Set<T> a, Set<T> b)
+        {
+            Contract.Requires(a != null);
+            Contract.Requires(b != null);
+
+            foreach (T element in a)
+                if (!b.Contains(element))
+                    return false;
+            return true;
+        }
+
+        public static bool operator <(Set<T> a, Set<T> b)
+        {
+            Contract.Requires(a != null);
+            Contract.Requires(b != null);
+
+            return (a.Count < b.Count) && (a <= b);
+        }
+
+        public static bool operator >(Set<T> a, Set<T> b)
+        {
+            Contract.Requires(a != null);
+            Contract.Requires(b != null);
+
+            return b < a;
+        }
+        public static bool operator >=(Set<T> a, Set<T> b)
+        {
+            Contract.Requires(a != null);
+            Contract.Requires(b != null);
+
+            return (b <= a);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+
+            if (Object.ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            var a = this;
+            var b = obj as Set<T>;
+
+            if (Object.Equals(b, null))
+            {
+                return false;
+            }
+
+            if (a.Count != b.Count)
+                return false;
+
+            foreach (var el in a)
+            {
+                if (!b.Contains(el))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashcode = 0;
+            foreach (var element in data)
+            {
+                Contract.Assume(element != null, "I was not expecting a null element in the set...");
+
+                hashcode ^= element.GetHashCode();
+            }
+            return hashcode;
+        }
+
+        #endregion
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)data).GetEnumerator();
+        }
+
+        public void CopyTo(T[] array, int index)
+        {
+            Contract.Requires(array != null);
+            Contract.Requires(index >= 0);
+            Contract.Requires(index + this.Count <= array.Length);
+
+            data.CopyTo(array, index);
+        }
+
+        override public string ToString()
+        {
 #if DEBUG
-      var elems = new List<string>();
+            var elems = new List<string>();
 
-      foreach (T e in this)
-      {
-        elems.Add(e!= null? e.ToString() : "<null>");
-      }
+            foreach (T e in this)
+            {
+                elems.Add(e != null ? e.ToString() : "<null>");
+            }
 
-      // Sort it to have easier debugging
-      elems.Sort();
+            // Sort it to have easier debugging
+            elems.Sort();
 
-      var res = new StringBuilder();
+            var res = new StringBuilder();
 
-      int count = 0;
-      foreach (var s in elems)
-      {
-        res.AppendFormat("{0}{1}", s, count != elems.Count - 1 ? ',' : ' ');
-        count++;
-      }
+            int count = 0;
+            foreach (var s in elems)
+            {
+                res.AppendFormat("{0}{1}", s, count != elems.Count - 1 ? ',' : ' ');
+                count++;
+            }
 
 #else
-      string res = this.Count.ToString() + " elements";
+            string res = this.Count.ToString() + " elements";
 #endif
-      return res.ToString();
+            return res.ToString();
+        }
+
+        #region ISet<T> Members
+
+        IMutableSet<U> IReadonlySet<T>.ConvertAll<U>(Converter<T, U> converter)
+        {
+            return this.ConvertAll(converter);
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Difference(IEnumerable<T> b)
+        {
+            return this.Difference(b);
+        }
+
+        IMutableSet<T> IReadonlySet<T>.FindAll(Predicate<T> predicate)
+        {
+            return this.FindAll(predicate);
+        }
+
+        void IReadonlySet<T>.ForEach(Action<T> action)
+        {
+            this.ForEach(action);
+        }
+
+        bool IReadonlySet<T>.Exists(Predicate<T> predicate)
+        {
+            return this.Exists(predicate);
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Intersection(IReadonlySet<T> b)
+        {
+            Set<T> bAsSet = b as Set<T>;
+            if (bAsSet != null)
+                return this.Intersection(bAsSet);
+            else
+                return this.Intersection(new Set<T>(b));
+        }
+
+        bool IReadonlySet<T>.IsSubset(IReadonlySet<T> s)
+        {
+            Set<T> sAsSet = s as Set<T>;
+            if (sAsSet != null)
+                return this.IsSubset(sAsSet);
+            else
+                return this.IsSubset(new Set<T>(s));
+        }
+
+        bool IReadonlySet<T>.IsEmpty
+        {
+            get { return this.IsEmpty; }
+        }
+
+        bool IReadonlySet<T>.IsSingleton
+        {
+            get { return this.IsSingleton; }
+        }
+
+        T IReadonlySet<T>.PickAnElement()
+        {
+            return this.PickAnElement();
+        }
+
+        bool IReadonlySet<T>.TrueForAll(Predicate<T> predicate)
+        {
+            return this.TrueForAll(predicate);
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Union(IReadonlySet<T> b)
+        {
+            Set<T> bAsSet = b as Set<T>;
+            if (bAsSet != null)
+                return this.Union(bAsSet);
+            else
+                return this.Union(new Set<T>(b));
+        }
+
+        #endregion
     }
 
-    #region ISet<T> Members
+    //[Serializable]
+    //public class SetOfNonNull<T> : Set<T>
+    //  where T : class
+    //{
+    //  public SetOfNonNull()
+    //    : base()
+    //  {
+    //  }
 
-    IMutableSet<U> IReadonlySet<T>.ConvertAll<U>(Converter<T, U> converter)
-    {
-      return this.ConvertAll(converter);
-    }
+    //  public SetOfNonNull(IEqualityComparer<T> comparer)
+    //    : base(comparer)
+    //  {
+    //    Contract.Requires(comparer != null);
+    //  }
 
-    IMutableSet<T> IReadonlySet<T>.Difference(IEnumerable<T> b)
-    {
-      return this.Difference(b);
-    }
+    //  public SetOfNonNull(int capacity)
+    //    : base(capacity)
+    //  {
+    //  }
 
-    IMutableSet<T> IReadonlySet<T>.FindAll(Predicate<T> predicate)
-    {
-      return this.FindAll(predicate);
-    }
+    //  public SetOfNonNull(T singleton)
+    //    : base(singleton)
+    //  {
+    //    Contract.Requires(singleton != null);
+    //  }
 
-    void IReadonlySet<T>.ForEach(Action<T> action)
-    {
-      this.ForEach(action);
-    }
+    //  public SetOfNonNull(SetOfNonNull<T> original)
+    //    : base(original)
+    //  {
+    //  }
 
-    bool IReadonlySet<T>.Exists(Predicate<T> predicate)
-    {
-      return this.Exists(predicate);
-    }
+    //  public SetOfNonNull(IEnumerable<T> original)
+    //    : base(original)
+    //  {
+    //    Contract.Requires(Contract.ForAll(original, x => x != null));
+    //  }
 
-    IMutableSet<T> IReadonlySet<T>.Intersection(IReadonlySet<T> b)
-    {
-      Set<T> bAsSet = b as Set<T>;
-      if (bAsSet != null)
-        return this.Intersection(bAsSet);
-      else
-        return this.Intersection(new Set<T>(b));
-    }
+    //  new public bool AddQ(T a)
+    //  {
+    //    Contract.Requires(a != null);
 
-    bool IReadonlySet<T>.IsSubset(IReadonlySet<T> s)
-    {
-      Set<T> sAsSet = s as Set<T>;
-      if (sAsSet != null)
-        return this.IsSubset(sAsSet);
-      else
-        return this.IsSubset(new Set<T>(s));
-    }
+    //    return base.AddQ(a);
+    //  }
 
-    bool IReadonlySet<T>.IsEmpty
-    {
-      get { return this.IsEmpty; }
-    }
+    //  new public bool Add(T a)
+    //  {
+    //    Contract.Requires(a != null);
 
-    bool IReadonlySet<T>.IsSingleton
-    {
-      get { return this.IsSingleton; }
-    }
+    //    return base.Add(a);
+    //  }
 
-    T IReadonlySet<T>.PickAnElement()
-    {
-      return this.PickAnElement();
-    }
+    //  new public void AddRange(IEnumerable<T> range)
+    //  {
+    //    Contract.Requires(Contract.ForAll(range, x => x != null));
 
-    bool IReadonlySet<T>.TrueForAll(Predicate<T> predicate)
-    {
-      return this.TrueForAll(predicate);
-    }
+    //    base.AddRange(range);
+    //  }
 
-    IMutableSet<T> IReadonlySet<T>.Union(IReadonlySet<T> b)
-    {
-      Set<T> bAsSet = b as Set<T>;
-      if (bAsSet != null)
-        return this.Union(bAsSet);
-      else
-        return this.Union(new Set<T>(b));
-    }
+    //  new public SetOfNonNull<T> FindAll(Predicate<T> predicate)
+    //  {
+    //    return FindAllInternal(predicate, new SetOfNonNull<T>());
+    //  }
 
-    #endregion
+    //  new public void ForEach(Action<T> action)
+    //  {
+    //    foreach (T element in this)
+    //    {
+    //      action(element);
+    //      Contract.Assume(element != null);
+    //    }
+    //  }
 
-  }
+    //  new public T PickAnElement()
+    //  {
+    //    Contract.Ensures(Contract.Result<T>() != null);
 
-  //[Serializable]
-  //public class SetOfNonNull<T> : Set<T>
-  //  where T : class
-  //{
-  //  public SetOfNonNull()
-  //    : base()
-  //  {
-  //  }
+    //    var el = base.PickAnElement();
 
-  //  public SetOfNonNull(IEqualityComparer<T> comparer)
-  //    : base(comparer)
-  //  {
-  //    Contract.Requires(comparer != null);
-  //  }
+    //    Contract.Assert(el != null);
 
-  //  public SetOfNonNull(int capacity)
-  //    : base(capacity)
-  //  {
-  //  }
+    //    return el;
+    //  }
 
-  //  public SetOfNonNull(T singleton)
-  //    : base(singleton)
-  //  {
-  //    Contract.Requires(singleton != null);
-  //  }
+    //  new public SetOfNonNull<T> Intersection(SetOfNonNull<T> b)
+    //  {
+    //    Contract.Requires(b != null);
+    //    Contract.Ensures(Contract.Result<SetOfNonNull<T>>() != null);
 
-  //  public SetOfNonNull(SetOfNonNull<T> original)
-  //    : base(original)
-  //  {
-  //  }
+    //    return new SetOfNonNull<T>(base.Intersection(b));
 
-  //  public SetOfNonNull(IEnumerable<T> original)
-  //    : base(original)
-  //  {
-  //    Contract.Requires(Contract.ForAll(original, x => x != null));
-  //  }
+    //  }
 
-  //  new public bool AddQ(T a)
-  //  {
-  //    Contract.Requires(a != null);
-
-  //    return base.AddQ(a);
-  //  }
-
-  //  new public bool Add(T a)
-  //  {
-  //    Contract.Requires(a != null);
-
-  //    return base.Add(a);
-  //  }
-
-  //  new public void AddRange(IEnumerable<T> range)
-  //  {
-  //    Contract.Requires(Contract.ForAll(range, x => x != null));
-
-  //    base.AddRange(range);
-  //  }
-
-  //  new public SetOfNonNull<T> FindAll(Predicate<T> predicate)
-  //  {
-  //    return FindAllInternal(predicate, new SetOfNonNull<T>());
-  //  }
-
-  //  new public void ForEach(Action<T> action)
-  //  {
-  //    foreach (T element in this)
-  //    {
-  //      action(element);
-  //      Contract.Assume(element != null);
-  //    }
-  //  }
-
-  //  new public T PickAnElement()
-  //  {
-  //    Contract.Ensures(Contract.Result<T>() != null);
-
-  //    var el = base.PickAnElement();
-
-  //    Contract.Assert(el != null);
-
-  //    return el;
-  //  }
-
-  //  new public SetOfNonNull<T> Intersection(SetOfNonNull<T> b)
-  //  {
-  //    Contract.Requires(b != null);
-  //    Contract.Ensures(Contract.Result<SetOfNonNull<T>>() != null);
-
-  //    return new SetOfNonNull<T>(base.Intersection(b));
-      
-  //  }
-
-  //}
+    //}
 #endif
 
 #if SET_WITH_DICTIONARY
-  /// <summary>
-  /// An implementation of ISet based on the BCL class Dictionary
-  /// </summary>
-  /// <typeparam name="T">The type of the elements of the set</typeparam>
-  [Serializable]
-  public class Set<T> : ISet<T>
-  {
-    #region Private Fields
-    private struct Dummy { }
-    private static Dummy dummy = new Dummy();
-    private Dictionary<T, Dummy> data;
-    #endregion
-
-    #region Constructors
     /// <summary>
-    /// Create an empty set of standard capacity
+    /// An implementation of ISet based on the BCL class Dictionary
     /// </summary>
-    public Set()
+    /// <typeparam name="T">The type of the elements of the set</typeparam>
+    [Serializable]
+    public class Set<T> : ISet<T>
     {
-      this.data = new Dictionary<T, Dummy>();
-    }
+        #region Private Fields
+        private struct Dummy { }
+        private static Dummy dummy = new Dummy();
+        private Dictionary<T, Dummy> data;
+        #endregion
 
-    /// <summary>
-    /// Create a set of initial <code>capacity</code>
-    /// </summary>
-    public Set(int capacity)
-    {
-      this.data = new Dictionary<T, Dummy>(capacity);
-    }
-
-    /// <summary>
-    /// Create a singleton
-    /// </summary>
-    public Set(T singleton)
-    {
-      this.data = new Dictionary<T, Dummy>();
-      this.Add(singleton);
-    }
-
-    /// <summary>
-    /// Create a set containing the same elements than <code>original</code>
-    /// </summary>
-    public Set(Set<T> original)
-    {
-      this.data = new Dictionary<T, Dummy>(original.data);
-    }
-
-    /// <summary>
-    /// Create a set containing the same elements than <code>original</code>
-    /// </summary>
-    public Set(IEnumerable<T> original)
-    {
-      this.data = new Dictionary<T, Dummy>();
-      AddRange(original);
-    }
-    #endregion
-
-    public int Count
-    {
-      get
-      {
-        return this.data.Count;
-      }
-    }
-
-    public bool IsEmpty
-    {
-      get
-      {
-        return this.Count == 0;
-      }
-    }
-
-    public bool IsSingleton
-    {
-      get
-      {
-        return this.Count == 1;
-      }
-    }
-
-    /// <summary>
-    /// Add an element to the set. 
-    /// If it already exists, it does nothing
-    /// </summary>
-    /// <returns>true if element was NOT previously present</returns>
-    public bool AddQ(T a)
-    {
-      if (!this.data.ContainsKey(a))
-      {
-        this.data.Add(a, dummy);
-        return true;
-      }
-      return false;
-    }
-
-    public void Add(T a)
-    {
-      this.data[a] = dummy;
-    }
-
-    /// <summary>
-    /// Add all the elements in the <code>range</code> to this set
-    /// </summary>
-    public void AddRange(IEnumerable<T> range)
-    {
-      foreach (T a in range)
-        Add(a);
-    }
-
-    /// <summary>
-    /// Convert all the elements of the set
-    /// </summary>
-    public Set<U> ConvertAll<U>(Converter<T, U> converter)
-    {
-      Set<U> result = new Set<U>(this.Count);
-      foreach (T element in this)
-      {
-        result.Add(converter(element));
-      }
-      return result;
-    }
-
-    /// <summary>
-    ///  Check if the predicate holds for all the elements in the set
-    /// </summary>
-    public bool TrueForAll(Predicate<T> predicate)
-    {
-      foreach (T element in this)
-        if (!predicate(element))
-          return false;
-      return true;
-    }
-
-    /// <summary>
-    /// Return the subset of elements in this set that satisfy the predicate
-    /// </summary>
-    /// <param name="predicate"></param>
-    /// <returns></returns>
-    public Set<T> FindAll(Predicate<T> predicate)
-    {
-      var result = new Set<T>();
-      foreach (T element in this)
-        if (predicate(element))
-          result.Add(element);
-      return result;
-    }
-
-    /// <summary>
-    /// Does it exist an element in the set that satisfies <code>predicate</code>
-    /// </summary>
-    public bool Exists(Predicate<T> predicate)
-    {
-      foreach (T element in this)
-      {
-        if (predicate(element))
-          return true;
-      }
-
-      return false;
-    }
-
-    /// <summary>
-    /// Apply the <code>action</code> to all the elements of the set
-    /// </summary>
-    public void ForEach(Action<T> action)
-    {
-      foreach (T element in this)
-        action(element);
-    }
-
-    /// <returns>
-    /// An element of the set.
-    /// It is not removed;
-    /// </returns>
-    public T PickAnElement()
-    {
-      IEnumerator<T> e = this.data.Keys.GetEnumerator();
-      e.MoveNext();
-      return e.Current;
-    }
-
-    /// <summary>
-    /// Remove all the elements from this set.
-    /// </summary>
-    public void Clear()
-    {
-      data.Clear();
-    }
-
-    /// <summary>
-    /// True iff <code>a</code> is in the set
-    /// </summary>
-    public bool Contains(T a)
-    {
-      return data.ContainsKey(a);
-    }
-
-    /// <summary>
-    /// True iff this is a subset of <code>s</code>
-    /// </summary>
-    public bool IsSubset(Set<T> s)
-    {
-      if (this.Count > s.Count)
-      {
-        return false;
-      }
-
-      foreach (T e in this)
-      {
-        if (!s.Contains(e))
+        #region Constructors
+        /// <summary>
+        /// Create an empty set of standard capacity
+        /// </summary>
+        public Set()
         {
-          return false;
+            this.data = new Dictionary<T, Dummy>();
         }
-      }
 
-      return true;
-    }
+        /// <summary>
+        /// Create a set of initial <code>capacity</code>
+        /// </summary>
+        public Set(int capacity)
+        {
+            this.data = new Dictionary<T, Dummy>(capacity);
+        }
 
-    /// <summary>
-    /// Remove the element <code>a</code> from the set
-    /// </summary>
-    /// <param name="a"></param>
-    /// <returns></returns>
-    public bool Remove(T a)
-    {
-      return this.data.Remove(a);
-    }
+        /// <summary>
+        /// Create a singleton
+        /// </summary>
+        public Set(T singleton)
+        {
+            this.data = new Dictionary<T, Dummy>();
+            this.Add(singleton);
+        }
 
-    //^ [Pure]
-    public IEnumerator<T>/*!*/ GetEnumerator()
-    {
-      return data.Keys.GetEnumerator();
-    }
+        /// <summary>
+        /// Create a set containing the same elements than <code>original</code>
+        /// </summary>
+        public Set(Set<T> original)
+        {
+            this.data = new Dictionary<T, Dummy>(original.data);
+        }
 
-    public bool IsReadOnly
-    {
-      get
-      {
-        return false;
-      }
-    }
+        /// <summary>
+        /// Create a set containing the same elements than <code>original</code>
+        /// </summary>
+        public Set(IEnumerable<T> original)
+        {
+            this.data = new Dictionary<T, Dummy>();
+            AddRange(original);
+        }
+        #endregion
 
-    /// <summary>
-    /// Set union in infix form
-    /// </summary>
-    public static Set<T> operator |(Set<T> a, Set<T> b)
-    {
-      var result = new Set<T>(a);
-      result.AddRange(b);
+        public int Count
+        {
+            get
+            {
+                return this.data.Count;
+            }
+        }
 
-      return result;
-    }
+        public bool IsEmpty
+        {
+            get
+            {
+                return this.Count == 0;
+            }
+        }
 
-    /// <summary>
-    /// Set union in 
-    /// </summary>
-    public Set<T> Union(Set<T> b)
-    {
-      if (this.Count == 0)
-        return b;
+        public bool IsSingleton
+        {
+            get
+            {
+                return this.Count == 1;
+            }
+        }
 
-      if (b.Count == 0)
-        return this;
+        /// <summary>
+        /// Add an element to the set. 
+        /// If it already exists, it does nothing
+        /// </summary>
+        /// <returns>true if element was NOT previously present</returns>
+        public bool AddQ(T a)
+        {
+            if (!this.data.ContainsKey(a))
+            {
+                this.data.Add(a, dummy);
+                return true;
+            }
+            return false;
+        }
 
-      Set<T> asSet = b as Set<T>;
+        public void Add(T a)
+        {
+            this.data[a] = dummy;
+        }
 
-      if (asSet == null)
-        asSet = new Set<T>(b);
+        /// <summary>
+        /// Add all the elements in the <code>range</code> to this set
+        /// </summary>
+        public void AddRange(IEnumerable<T> range)
+        {
+            foreach (T a in range)
+                Add(a);
+        }
 
-      return this | asSet;
-    }
+        /// <summary>
+        /// Convert all the elements of the set
+        /// </summary>
+        public Set<U> ConvertAll<U>(Converter<T, U> converter)
+        {
+            Set<U> result = new Set<U>(this.Count);
+            foreach (T element in this)
+            {
+                result.Add(converter(element));
+            }
+            return result;
+        }
 
-    /// <summary>
-    /// Set intersection in infix form
-    /// </summary>
-    public static Set<T> operator &(Set<T> a, Set<T> b)
-    {
-      Set<T> result = new Set<T>();
-      foreach (T element in a)
-      {
-        if (b.Contains(element))
-          result.Add(element);
-      }
-      return result;
-    }
+        /// <summary>
+        ///  Check if the predicate holds for all the elements in the set
+        /// </summary>
+        public bool TrueForAll(Predicate<T> predicate)
+        {
+            foreach (T element in this)
+                if (!predicate(element))
+                    return false;
+            return true;
+        }
 
-    /// <summary>
-    /// Set intersection 
-    /// </summary>
-    public Set<T> Intersection(Set<T> b)
-    {
-      if (b.Count == 0)
-        return b;
+        /// <summary>
+        /// Return the subset of elements in this set that satisfy the predicate
+        /// </summary>
+        /// <param name="predicate"></param>
+        /// <returns></returns>
+        public Set<T> FindAll(Predicate<T> predicate)
+        {
+            var result = new Set<T>();
+            foreach (T element in this)
+                if (predicate(element))
+                    result.Add(element);
+            return result;
+        }
 
-      if (this.Count == 0)
-        return this;
+        /// <summary>
+        /// Does it exist an element in the set that satisfies <code>predicate</code>
+        /// </summary>
+        public bool Exists(Predicate<T> predicate)
+        {
+            foreach (T element in this)
+            {
+                if (predicate(element))
+                    return true;
+            }
 
-      Set<T> asSet = b as Set<T>;
+            return false;
+        }
 
-      if (asSet == null)
-        asSet = new Set<T>(b);
+        /// <summary>
+        /// Apply the <code>action</code> to all the elements of the set
+        /// </summary>
+        public void ForEach(Action<T> action)
+        {
+            foreach (T element in this)
+                action(element);
+        }
 
-      return this & asSet;
-    }
+        /// <returns>
+        /// An element of the set.
+        /// It is not removed;
+        /// </returns>
+        public T PickAnElement()
+        {
+            IEnumerator<T> e = this.data.Keys.GetEnumerator();
+            e.MoveNext();
+            return e.Current;
+        }
 
-    /// <summary>
-    /// Set difference in infix form
-    /// </summary>
-    public static Set<T> operator -(Set<T> a, Set<T> b)
-    {
-      Set<T> result = new Set<T>();
-      foreach (T element in a)
-        if (!b.Contains(element))
-          result.Add(element);
-      return result;
-    }
+        /// <summary>
+        /// Remove all the elements from this set.
+        /// </summary>
+        public void Clear()
+        {
+            data.Clear();
+        }
 
-    /// <summary>
-    /// Set difference
-    /// </summary>
-    public Set<T> Difference(IEnumerable<T> b)
-    {
-      return this - new Set<T>(b);
-    }
+        /// <summary>
+        /// True iff <code>a</code> is in the set
+        /// </summary>
+        public bool Contains(T a)
+        {
+            return data.ContainsKey(a);
+        }
 
-    #region Unused methods on sets
+        /// <summary>
+        /// True iff this is a subset of <code>s</code>
+        /// </summary>
+        public bool IsSubset(Set<T> s)
+        {
+            if (this.Count > s.Count)
+            {
+                return false;
+            }
 
-    public static Set<T> operator ^(Set<T> a, Set<T> b)
-    {
-      Set<T> result = new Set<T>();
-      foreach (T element in a)
-        if (!b.Contains(element))
-          result.Add(element);
-      foreach (T element in b)
-        if (!a.Contains(element))
-          result.Add(element);
-      return result;
-    }
-    public Set<T> SymmetricDifference(IEnumerable<T> b)
-    {
-      return this ^ new Set<T>(b);
-    }
+            foreach (T e in this)
+            {
+                if (!s.Contains(e))
+                {
+                    return false;
+                }
+            }
 
-    public static Set<T> Empty
-    {
-      get
-      {
-        return new Set<T>(0);
-      }
-    }
+            return true;
+        }
 
-    public static bool operator <=(Set<T> a, Set<T> b)
-    {
-      foreach (T element in a)
-        if (!b.Contains(element))
-          return false;
-      return true;
-    }
-    public static bool operator <(Set<T> a, Set<T> b)
-    {
-      return (a.Count < b.Count) && (a <= b);
-    }
+        /// <summary>
+        /// Remove the element <code>a</code> from the set
+        /// </summary>
+        /// <param name="a"></param>
+        /// <returns></returns>
+        public bool Remove(T a)
+        {
+            return this.data.Remove(a);
+        }
 
-    public static bool operator >(Set<T> a, Set<T> b)
-    {
-      return b < a;
-    }
-    public static bool operator >=(Set<T> a, Set<T> b)
-    {
-      return (b <= a);
-    }
+        //^ [Pure]
+        public IEnumerator<T>/*!*/ GetEnumerator()
+        {
+            return data.Keys.GetEnumerator();
+        }
 
-    //^ [StateIndependent]
-    public override bool Equals(object/*?*/ obj)
-    {
-      Set<T> a = this;
-      Set<T>/*?*/ b = obj as Set<T>;
-      if (Object.Equals(b, null))
-        return false;
-      return a == b;
-    }
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
 
-    //^ [Confined]
-    public override int GetHashCode()
-    {
-      int hashcode = 0;
-      foreach (T element in this)
-      {
-        Debug.Assert(element != null, "I was not expecting a null element in the set...");
-        //^ assert element != null;
+        /// <summary>
+        /// Set union in infix form
+        /// </summary>
+        public static Set<T> operator |(Set<T> a, Set<T> b)
+        {
+            var result = new Set<T>(a);
+            result.AddRange(b);
 
-        hashcode ^= element.GetHashCode();
-      }
-      return hashcode;
-    }
+            return result;
+        }
 
-    #endregion
+        /// <summary>
+        /// Set union in 
+        /// </summary>
+        public Set<T> Union(Set<T> b)
+        {
+            if (this.Count == 0)
+                return b;
 
-    //^ [Pure]
-    IEnumerator/*!*/ IEnumerable.GetEnumerator()
-    {
-      return ((IEnumerable)data.Keys).GetEnumerator();
-    }
+            if (b.Count == 0)
+                return this;
 
-    public void CopyTo(T[]/*!*/ array, int index)
-    {
-      this.data.Keys.CopyTo(array, index);
-    }
+            Set<T> asSet = b as Set<T>;
 
-    //^ [Confined]
-    override public string/*!*/ ToString()
-    {
+            if (asSet == null)
+                asSet = new Set<T>(b);
+
+            return this | asSet;
+        }
+
+        /// <summary>
+        /// Set intersection in infix form
+        /// </summary>
+        public static Set<T> operator &(Set<T> a, Set<T> b)
+        {
+            Set<T> result = new Set<T>();
+            foreach (T element in a)
+            {
+                if (b.Contains(element))
+                    result.Add(element);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Set intersection 
+        /// </summary>
+        public Set<T> Intersection(Set<T> b)
+        {
+            if (b.Count == 0)
+                return b;
+
+            if (this.Count == 0)
+                return this;
+
+            Set<T> asSet = b as Set<T>;
+
+            if (asSet == null)
+                asSet = new Set<T>(b);
+
+            return this & asSet;
+        }
+
+        /// <summary>
+        /// Set difference in infix form
+        /// </summary>
+        public static Set<T> operator -(Set<T> a, Set<T> b)
+        {
+            Set<T> result = new Set<T>();
+            foreach (T element in a)
+                if (!b.Contains(element))
+                    result.Add(element);
+            return result;
+        }
+
+        /// <summary>
+        /// Set difference
+        /// </summary>
+        public Set<T> Difference(IEnumerable<T> b)
+        {
+            return this - new Set<T>(b);
+        }
+
+        #region Unused methods on sets
+
+        public static Set<T> operator ^(Set<T> a, Set<T> b)
+        {
+            Set<T> result = new Set<T>();
+            foreach (T element in a)
+                if (!b.Contains(element))
+                    result.Add(element);
+            foreach (T element in b)
+                if (!a.Contains(element))
+                    result.Add(element);
+            return result;
+        }
+        public Set<T> SymmetricDifference(IEnumerable<T> b)
+        {
+            return this ^ new Set<T>(b);
+        }
+
+        public static Set<T> Empty
+        {
+            get
+            {
+                return new Set<T>(0);
+            }
+        }
+
+        public static bool operator <=(Set<T> a, Set<T> b)
+        {
+            foreach (T element in a)
+                if (!b.Contains(element))
+                    return false;
+            return true;
+        }
+        public static bool operator <(Set<T> a, Set<T> b)
+        {
+            return (a.Count < b.Count) && (a <= b);
+        }
+
+        public static bool operator >(Set<T> a, Set<T> b)
+        {
+            return b < a;
+        }
+        public static bool operator >=(Set<T> a, Set<T> b)
+        {
+            return (b <= a);
+        }
+
+        //^ [StateIndependent]
+        public override bool Equals(object/*?*/ obj)
+        {
+            Set<T> a = this;
+            Set<T>/*?*/ b = obj as Set<T>;
+            if (Object.Equals(b, null))
+                return false;
+            return a == b;
+        }
+
+        //^ [Confined]
+        public override int GetHashCode()
+        {
+            int hashcode = 0;
+            foreach (T element in this)
+            {
+                Debug.Assert(element != null, "I was not expecting a null element in the set...");
+                //^ assert element != null;
+
+                hashcode ^= element.GetHashCode();
+            }
+            return hashcode;
+        }
+
+        #endregion
+
+        //^ [Pure]
+        IEnumerator/*!*/ IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)data.Keys).GetEnumerator();
+        }
+
+        public void CopyTo(T[]/*!*/ array, int index)
+        {
+            this.data.Keys.CopyTo(array, index);
+        }
+
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
 #if DEBUG
-      string res = "{";
+            string res = "{";
 
-      foreach (T e in this)
-      {
-        res += (e != null ? e.ToString() : "<null>") + " ,";
-      }
-      if (res[res.Length - 1] == ',')
-        res = res.Substring(0, res.Length - 2);
+            foreach (T e in this)
+            {
+                res += (e != null ? e.ToString() : "<null>") + " ,";
+            }
+            if (res[res.Length - 1] == ',')
+                res = res.Substring(0, res.Length - 2);
 
-      res += "}";
+            res += "}";
 #else
-      string res = this.Count.ToString() + " elements";
+            string res = this.Count.ToString() + " elements";
 #endif
-      return res;
+            return res;
+        }
+
+        #region ISet<T> Members
+
+        void ISet<T>.AddRange(IEnumerable<T> range)
+        {
+            this.AddRange(range);
+        }
+
+        ISet<U> ISet<T>.ConvertAll<U>(Converter<T, U> converter)
+        {
+            return this.ConvertAll(converter);
+        }
+
+        ISet<T> ISet<T>.Difference(IEnumerable<T> b)
+        {
+            return this.Difference(b);
+        }
+
+        ISet<T> ISet<T>.FindAll(Predicate<T> predicate)
+        {
+            return this.FindAll(predicate);
+        }
+
+        void ISet<T>.ForEach(Action<T> action)
+        {
+            this.ForEach(action);
+        }
+
+        bool ISet<T>.Exists(Predicate<T> predicate)
+        {
+            return this.Exists(predicate);
+        }
+
+        ISet<T> ISet<T>.Intersection(ISet<T> b)
+        {
+            Set<T> bAsSet = b as Set<T>;
+            if (bAsSet != null)
+                return this.Intersection(bAsSet);
+            else
+                return this.Intersection(new Set<T>(b));
+        }
+
+        bool ISet<T>.IsSubset(ISet<T> s)
+        {
+            Set<T> sAsSet = s as Set<T>;
+            if (sAsSet != null)
+                return this.IsSubset(sAsSet);
+            else
+                return this.IsSubset(new Set<T>(s));
+        }
+
+        bool ISet<T>.IsEmpty
+        {
+            get { return this.IsEmpty; }
+        }
+
+        bool ISet<T>.IsSingleton
+        {
+            get { return this.IsSingleton; }
+        }
+
+        T ISet<T>.PickAnElement()
+        {
+            return this.PickAnElement();
+        }
+
+        bool ISet<T>.TrueForAll(Predicate<T> predicate)
+        {
+            return this.TrueForAll(predicate);
+        }
+
+        ISet<T> ISet<T>.Union(ISet<T> b)
+        {
+            Set<T> bAsSet = b as Set<T>;
+            if (bAsSet != null)
+                return this.Union(bAsSet);
+            else
+                return this.Union(new Set<T>(b));
+        }
+
+        #endregion
+
     }
-
-    #region ISet<T> Members
-
-    void ISet<T>.AddRange(IEnumerable<T> range)
-    {
-      this.AddRange(range);
-    }
-
-    ISet<U> ISet<T>.ConvertAll<U>(Converter<T, U> converter)
-    {
-      return this.ConvertAll(converter);
-    }
-
-    ISet<T> ISet<T>.Difference(IEnumerable<T> b)
-    {
-      return this.Difference(b);
-    }
-
-    ISet<T> ISet<T>.FindAll(Predicate<T> predicate)
-    {
-      return this.FindAll(predicate);
-    }
-
-    void ISet<T>.ForEach(Action<T> action)
-    {
-      this.ForEach(action);
-    }
-
-    bool ISet<T>.Exists(Predicate<T> predicate)
-    {
-      return this.Exists(predicate);
-    }
-
-    ISet<T> ISet<T>.Intersection(ISet<T> b)
-    {
-      Set<T> bAsSet = b as Set<T>;
-      if (bAsSet != null)
-        return this.Intersection(bAsSet);
-      else
-        return this.Intersection(new Set<T>(b));
-    }
-
-    bool ISet<T>.IsSubset(ISet<T> s)
-    {
-      Set<T> sAsSet = s as Set<T>;
-      if (sAsSet != null)
-        return this.IsSubset(sAsSet);
-      else
-        return this.IsSubset(new Set<T>(s));
-    }
-
-    bool ISet<T>.IsEmpty
-    {
-      get { return this.IsEmpty; }
-    }
-
-    bool ISet<T>.IsSingleton
-    {
-      get { return this.IsSingleton; }
-    }
-
-    T ISet<T>.PickAnElement()
-    {
-      return this.PickAnElement();
-    }
-
-    bool ISet<T>.TrueForAll(Predicate<T> predicate)
-    {
-      return this.TrueForAll(predicate);
-    }
-
-    ISet<T> ISet<T>.Union(ISet<T> b)
-    {
-      Set<T> bAsSet = b as Set<T>;
-      if (bAsSet != null)
-        return this.Union(bAsSet);
-      else
-        return this.Union(new Set<T>(b));
-    }
-
-    #endregion
-
-  }
 
 #endif
 
-  /// <summary>
-  /// A set implemented with a list.
-  /// Useful when we already know the elements in the list are not redundants
-  /// </summary>
-  /// <typeparam name="T"></typeparam>
-  public class SetList<T> : IMutableSet<T>
-  {
-    readonly private List<T> elements;
-    private int version;
-
-    public SetList()
+    /// <summary>
+    /// A set implemented with a list.
+    /// Useful when we already know the elements in the list are not redundants
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class SetList<T> : IMutableSet<T>
     {
-      this.elements = new List<T>();
-      this.version = 0;
-    }
+        readonly private List<T> elements;
+        private int version;
 
-    public SetList(T el)
-    {
-      this.elements = new List<T>() { el };
-      this.version = 0;
-    }
-
-    public SetList(IMutableSet<T> set)
-    {
-      Contract.Requires(set != null);
-
-      this.elements = new List<T>(set.Count);
-      foreach (var x in set)
-      {
-        this.elements.Add(x);
-      }
-      this.version = 0;
-    }
-
-    private SetList(int count)
-    {
-      this.elements = new List<T>(Math.Max(0, count));
-      this.version = 0;
-    }
-
-    private SetList(List<T> set)
-    {
-      this.elements = set;
-      this.version = 0;
-    }
-    #region ISet<T> Members
-
-    public bool Add(T element)
-    {
-      if (!this.elements.Contains(element))
-      {
-        this.elements.Add(element);
-        this.version++;
-
-        return true;
-      }
-
-      return false;
-    }
-
-    public void AddRange(IEnumerable<T> range)
-    {
-      foreach (var x in range)
-      {
-        this.Add(x);
-      }
-    }
-
-    #endregion
-
-    #region IReadonlySet<T> Members
-
-    public int Count
-    {
-      get { return this.elements.Count; }
-    }
-
-    public bool Contains(T element)
-    {
-      return this.elements.Exists(x => x.Equals(element));
-    }
-
-    IMutableSet<U> IReadonlySet<T>.ConvertAll<U>(Converter<T, U> converter)
-    {
-      return this.ConvertAll(converter);
-    }
-
-    SetList<U> ConvertAll<U>(Converter<T, U> converter)
-    {
-      var result = new SetList<U>(this.Count);
-
-      foreach (var x in this.elements)
-      {
-        result.Add(converter(x));
-      }
-
-      return result;
-    }
-
-    IMutableSet<T> IReadonlySet<T>.Difference(IEnumerable<T> b)
-    {
-      return this.Difference(b);
-    }
-
-    public SetList<T> Difference(IEnumerable<T> b)
-    {
-      var result = new List<T>(this.elements);
-
-      foreach (var x in b)
-      {
-        if (this.elements.Contains(x))
+        public SetList()
         {
-          result.Remove(x);
+            elements = new List<T>();
+            version = 0;
         }
-      }
 
-      return new SetList<T>(this.elements);
-    }
-
-    public IMutableSet<T> FindAll(Predicate<T> predicate)
-    {
-      var result = this.elements.FindAll(predicate);
-
-      return new SetList<T>(result);
-    }
-
-    public void ForEach(Action<T> action)
-    {
-      this.elements.ForEach(action);
-    }
-
-    public bool Exists(Predicate<T> predicate)
-    {
-      return this.elements.Exists(predicate);
-    }
-
-    IMutableSet<T> IReadonlySet<T>.Intersection(IReadonlySet<T> b)
-    {
-      return this.Intersection(b);
-    }
-
-    public SetList<T> Intersection(IReadonlySet<T> b)
-    {
-      var result = new List<T>();
-
-      foreach (var x in this.elements)
-      {
-        if (b.Contains(x))
+        public SetList(T el)
         {
-          result.Add(x);
+            elements = new List<T>() { el };
+            version = 0;
         }
-      }
 
-      return new SetList<T>(result);
-    }
-
-    public SetList<T> Intersection(SetList<T> other)
-    {
-      var result = new List<T>();
-
-      var left = this;
-      var right = other;
-
-      Min(ref left, ref right);
-
-      foreach (var x in left.elements)
-      {
-        if (right.Contains(x))
+        public SetList(IMutableSet<T> set)
         {
-          result.Add(x);
+            Contract.Requires(set != null);
+
+            elements = new List<T>(set.Count);
+            foreach (var x in set)
+            {
+                elements.Add(x);
+            }
+            version = 0;
         }
-      }
 
-      return new SetList<T>(result);
-    }
-
-    public bool IsSubset(IReadonlySet<T> s)
-    {
-      foreach (var x in this.elements)
-      {
-        if (!s.Contains(x))
+        private SetList(int count)
         {
-          return false;
+            elements = new List<T>(Math.Max(0, count));
+            version = 0;
         }
-      }
 
-      return true;
-    }
-
-    public bool IsEmpty
-    {
-      get { return this.elements.Count == 0; }
-    }
-
-    public bool IsSingleton
-    {
-      get { return this.elements.Count == 1; }
-    }
-
-    public T PickAnElement()
-    {
-      return this.elements[0];
-    }
-
-    public bool TrueForAll(Predicate<T> predicate)
-    {
-      return this.elements.TrueForAll(predicate);
-    }
-
-    IMutableSet<T> IReadonlySet<T>.Union(IReadonlySet<T> b)
-    {
-      return this.Union(b);
-    }
-
-    public SetList<T> Union(IReadonlySet<T> b)
-    {
-      var result = new List<T>(this.elements);
-
-      foreach (var x in b)
-      {
-        if (!result.Contains(x))
+        private SetList(List<T> set)
         {
-          result.Add(x);
+            elements = set;
+            version = 0;
         }
-      }
+        #region ISet<T> Members
 
-      return new SetList<T>(result);
+        public bool Add(T element)
+        {
+            if (!elements.Contains(element))
+            {
+                elements.Add(element);
+                version++;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public void AddRange(IEnumerable<T> range)
+        {
+            foreach (var x in range)
+            {
+                this.Add(x);
+            }
+        }
+
+        #endregion
+
+        #region IReadonlySet<T> Members
+
+        public int Count
+        {
+            get { return elements.Count; }
+        }
+
+        public bool Contains(T element)
+        {
+            return elements.Exists(x => x.Equals(element));
+        }
+
+        IMutableSet<U> IReadonlySet<T>.ConvertAll<U>(Converter<T, U> converter)
+        {
+            return this.ConvertAll(converter);
+        }
+
+        private SetList<U> ConvertAll<U>(Converter<T, U> converter)
+        {
+            var result = new SetList<U>(this.Count);
+
+            foreach (var x in elements)
+            {
+                result.Add(converter(x));
+            }
+
+            return result;
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Difference(IEnumerable<T> b)
+        {
+            return this.Difference(b);
+        }
+
+        public SetList<T> Difference(IEnumerable<T> b)
+        {
+            var result = new List<T>(elements);
+
+            foreach (var x in b)
+            {
+                if (elements.Contains(x))
+                {
+                    result.Remove(x);
+                }
+            }
+
+            return new SetList<T>(elements);
+        }
+
+        public IMutableSet<T> FindAll(Predicate<T> predicate)
+        {
+            var result = elements.FindAll(predicate);
+
+            return new SetList<T>(result);
+        }
+
+        public void ForEach(Action<T> action)
+        {
+            elements.ForEach(action);
+        }
+
+        public bool Exists(Predicate<T> predicate)
+        {
+            return elements.Exists(predicate);
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Intersection(IReadonlySet<T> b)
+        {
+            return this.Intersection(b);
+        }
+
+        public SetList<T> Intersection(IReadonlySet<T> b)
+        {
+            var result = new List<T>();
+
+            foreach (var x in elements)
+            {
+                if (b.Contains(x))
+                {
+                    result.Add(x);
+                }
+            }
+
+            return new SetList<T>(result);
+        }
+
+        public SetList<T> Intersection(SetList<T> other)
+        {
+            var result = new List<T>();
+
+            var left = this;
+            var right = other;
+
+            Min(ref left, ref right);
+
+            foreach (var x in left.elements)
+            {
+                if (right.Contains(x))
+                {
+                    result.Add(x);
+                }
+            }
+
+            return new SetList<T>(result);
+        }
+
+        public bool IsSubset(IReadonlySet<T> s)
+        {
+            foreach (var x in elements)
+            {
+                if (!s.Contains(x))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool IsEmpty
+        {
+            get { return elements.Count == 0; }
+        }
+
+        public bool IsSingleton
+        {
+            get { return elements.Count == 1; }
+        }
+
+        public T PickAnElement()
+        {
+            return elements[0];
+        }
+
+        public bool TrueForAll(Predicate<T> predicate)
+        {
+            return elements.TrueForAll(predicate);
+        }
+
+        IMutableSet<T> IReadonlySet<T>.Union(IReadonlySet<T> b)
+        {
+            return this.Union(b);
+        }
+
+        public SetList<T> Union(IReadonlySet<T> b)
+        {
+            var result = new List<T>(elements);
+
+            foreach (var x in b)
+            {
+                if (!result.Contains(x))
+                {
+                    result.Add(x);
+                }
+            }
+
+            return new SetList<T>(result);
+        }
+
+        #endregion
+
+        #region IEnumerable<T> Members
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return elements.GetEnumerator();
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        #endregion
+
+        #region Helpers
+        private static void Min(ref SetList<T> left, ref SetList<T> right)
+        {
+            if (left.Count > right.Count)
+            {
+                var tmp = left;
+                left = right;
+                right = tmp;
+            }
+        }
+        #endregion
     }
 
-    #endregion
-
-    #region IEnumerable<T> Members
-
-    public IEnumerator<T> GetEnumerator()
+    public static class SetHelpers
     {
-      return this.elements.GetEnumerator();
+        static public void AddIfNotNull<T>(this IMutableSet<T> set, T element)
+        {
+            if (element != null)
+                set.Add(element);
+        }
     }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-      return this.GetEnumerator();
-    }
-
-    #endregion
-
-    #region Helpers
-    private static void Min(ref SetList<T> left, ref SetList<T> right)
-    {
-      if (left.Count > right.Count)
-      {
-        var tmp = left;
-        left = right;
-        right = tmp;
-      }
-    }
-    #endregion
-  }
-
-  public static class SetHelpers
-  {
-    static public void AddIfNotNull<T>(this IMutableSet<T> set, T element)
-    {
-      if (element != null)
-        set.Add(element);
-    }
-  }
 }

--- a/Microsoft.Research/DataStructures/SimpleHashTable.cs
+++ b/Microsoft.Research/DataStructures/SimpleHashTable.cs
@@ -1,279 +1,264 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Research.DataStructures
 {
-  internal sealed class HashtableEntry<KeyType, ValueType>
-  {
-    internal KeyType Key;
-    internal ValueType Value;
-    internal uint hashCode;
-    internal HashtableEntry<KeyType, ValueType> next;
-
-    internal HashtableEntry(KeyType key, ValueType value, uint hashCode, HashtableEntry<KeyType, ValueType> next)
+    internal sealed class HashtableEntry<KeyType, ValueType>
     {
-      this.Key = key;
-      this.Value = value;
-      this.hashCode = hashCode;
-      this.next = next;
+        internal KeyType Key;
+        internal ValueType Value;
+        internal uint hashCode;
+        internal HashtableEntry<KeyType, ValueType> next;
+
+        internal HashtableEntry(KeyType key, ValueType value, uint hashCode, HashtableEntry<KeyType, ValueType> next)
+        {
+            this.Key = key;
+            this.Value = value;
+            this.hashCode = hashCode;
+            this.next = next;
+        }
+
+        internal HashtableEntry(HashtableEntry<KeyType, ValueType> template)
+        {
+            this.Key = template.Key;
+            this.Value = template.Value;
+            this.hashCode = template.hashCode;
+            if (template.next != null)
+                this.next = new HashtableEntry<KeyType, ValueType>(template.next);
+        }
     }
 
-    internal HashtableEntry(HashtableEntry<KeyType, ValueType> template)
+    internal struct HashtableEntryEnumerator<KeyType, ValueType>
     {
-      this.Key = template.Key;
-      this.Value = template.Value;
-      this.hashCode = template.hashCode;
-      if (template.next != null)
-        this.next = new HashtableEntry<KeyType, ValueType>(template.next);
-    }
-  }
+        private HashtableEntry<KeyType, ValueType>[] table;
+        private int tableIndex;
+        private HashtableEntry<KeyType, ValueType> currentEntry;
 
-  internal struct HashtableEntryEnumerator<KeyType, ValueType>
-  {
+        internal HashtableEntryEnumerator(HashtableEntry<KeyType, ValueType>[] table)
+        {
+            this.table = table;
+            tableIndex = 0;
+            currentEntry = null;
+        }
 
-    HashtableEntry<KeyType, ValueType>[] table;
-    int tableIndex;
-    HashtableEntry<KeyType, ValueType> currentEntry;
+        public HashtableEntry<KeyType, ValueType> Current
+        {
+            get { return currentEntry; }
+        }
 
-    internal HashtableEntryEnumerator(HashtableEntry<KeyType, ValueType>[] table)
-    {
-      this.table = table;
-      this.tableIndex = 0;
-      this.currentEntry = null;
-    }
-
-    public HashtableEntry<KeyType, ValueType> Current
-    {
-      get { return this.currentEntry; }
-    }
-
-    public bool MoveNext()
-    {
-      if (this.currentEntry != null)
-        this.currentEntry = this.currentEntry.next;
-      while (this.currentEntry == null)
-      {
-        if (this.tableIndex >= this.table.Length)
-          return false;
-        this.currentEntry = this.table[this.tableIndex++];
-      }
-      return true;
+        public bool MoveNext()
+        {
+            if (currentEntry != null)
+                currentEntry = currentEntry.next;
+            while (currentEntry == null)
+            {
+                if (tableIndex >= table.Length)
+                    return false;
+                currentEntry = table[tableIndex++];
+            }
+            return true;
+        }
     }
 
-  }
-
-  public sealed class SimpleHashtable<KeyType, ValueType> 
+    public sealed class SimpleHashtable<KeyType, ValueType>
     // where KeyType : class
-  {
-    private HashtableEntry<KeyType, ValueType>[] table;
-    public int Count;
-    private uint threshold;
-
-    public SimpleHashtable()
-      : this(8)
     {
-    }
+        private HashtableEntry<KeyType, ValueType>[] table;
+        public int Count;
+        private uint threshold;
 
-   public SimpleHashtable(uint threshold)
-    {
-      if (threshold < 8)
-        threshold = 8;
-      this.table = new HashtableEntry<KeyType, ValueType>[(int)(threshold * 2 - 1)];
-      this.threshold = threshold;
-    }
-
-   public SimpleHashtable(SimpleHashtable<KeyType, ValueType> template)
-    {
-      this.Count = template.Count;
-      this.threshold = template.threshold;
-      int n = template.table.Length;
-      this.table = new HashtableEntry<KeyType, ValueType>[n];
-      for (int i = 0; i < n; i++)
-      {
-        var templateEntry = template.table[i];
-        if (templateEntry != null)
-          this.table[i] = new HashtableEntry<KeyType, ValueType>(templateEntry);
-      }
-    }
-
-   public void Add(KeyType key, ValueType value)
-    {
-      uint hashCode = (uint)key.GetHashCode();
-      var e = this.GetHashtableEntry(key, hashCode);
-      if (e != null) throw new InvalidOperationException();
-      if (++this.Count >= this.threshold) this.Rehash();
-      uint index = hashCode % (uint)this.table.Length;
-      this.table[index] = new HashtableEntry<KeyType, ValueType>(key, value, hashCode, this.table[index]);
-    }
-
-    private HashtableEntry<KeyType, ValueType>/*?*/ GetHashtableEntry(KeyType key, uint hashCode)
-    {
-      uint index = hashCode % (uint)this.table.Length;
-      var e = this.table[index];
-      if (e == null) return null;
-      //Run down chain, using only object identity. Perhaps we get lucky. 
-      //At any rate, each loop is as cheap as it gets and the chain should be short.
-      if (Object.Equals(e.Key,key)) return e;
-      var curr = e.next;
-      while (curr != null)
-      {
-        if (Object.Equals(curr.Key,key)) return curr;
-        curr = curr.next;
-      }
-      //now check hash codes and call Equals
-      if (e.hashCode == hashCode && e.Key.Equals(key)) return e;
-      curr = e.next;
-      while (curr != null)
-      {
-        if (curr.hashCode == hashCode && curr.Key.Equals(key)) return curr;
-        curr = curr.next;
-      }
-      return null;
-    }
-
-    public void Clear()
-    {
-      this.Count = 0;
-      int n = this.table.Length;
-      for (int i = 0; i < n; i++) this.table[i] = null;
-    }
-
-    public bool ContainsKey(KeyType key)
-    {
-      return this.GetHashtableEntry(key, (uint)key.GetHashCode()) != null;
-    }
-
-    public IEnumerable<KeyType> Keys
-    {
-      get
-      {
-        foreach (var entry in this.table)
+        public SimpleHashtable()
+          : this(8)
         {
-          var e = entry;
-          while (e != null)
-          {
-            yield return e.Key;
-            e = e.next;
-          }
         }
-      }
-    }
 
-    public IEnumerable<KeyValuePair<KeyType, ValueType>> Elements
-    {
-      get
-      {
-        foreach (var entry in this.table)
+        public SimpleHashtable(uint threshold)
         {
-          var e = entry;
-          while (e != null)
-          {
-            yield return new KeyValuePair<KeyType, ValueType>(e.Key, e.Value);
-            e = e.next;
-          }         
+            if (threshold < 8)
+                threshold = 8;
+            table = new HashtableEntry<KeyType, ValueType>[(int)(threshold * 2 - 1)];
+            this.threshold = threshold;
         }
-      }
-    }
 
-    private void Rehash()
-    {
-      var oldTable = this.table;
-      uint threshold = this.threshold = (uint)(oldTable.Length + 1);
-      uint newCapacity = threshold * 2 - 1;
-      var newTable = this.table = new HashtableEntry<KeyType, ValueType>[newCapacity];
-      for (uint i = threshold - 1; i-- > 0; )
-      {
-        for (var old = oldTable[(int)i]; old != null; )
+        public SimpleHashtable(SimpleHashtable<KeyType, ValueType> template)
         {
-          var e = old; old = old.next;
-          uint index = e.hashCode % newCapacity;
-          e.next = newTable[index];
-          newTable[index] = e;
+            this.Count = template.Count;
+            threshold = template.threshold;
+            int n = template.table.Length;
+            table = new HashtableEntry<KeyType, ValueType>[n];
+            for (int i = 0; i < n; i++)
+            {
+                var templateEntry = template.table[i];
+                if (templateEntry != null)
+                    table[i] = new HashtableEntry<KeyType, ValueType>(templateEntry);
+            }
         }
-      }
-    }
 
-    public bool Remove(KeyType key)
-    {
-      uint hashCode = (uint)key.GetHashCode();
-      uint index = hashCode % (uint)this.table.Length;
-      var e = this.table[index];
-      if (e != null && e.hashCode == hashCode && (Object.Equals(e.Key, key)|| e.Key.Equals(key)))
-      {
-        e = e.next;
-        this.table[index] = e;
-        this.Count--;
-        return true;
-      }
-      do
-      {
-        if (e == null) return false;
-        var f = e.next;
-        if (f != null && f.hashCode == hashCode && (Object.Equals(f.Key, key)|| f.Key.Equals(key)))
+        public void Add(KeyType key, ValueType value)
         {
-          // f = f.next;
-          e.next = f.next;   // F : Changed
-          this.Count--;
-          return true;
+            uint hashCode = (uint)key.GetHashCode();
+            var e = this.GetHashtableEntry(key, hashCode);
+            if (e != null) throw new InvalidOperationException();
+            if (++this.Count >= threshold) this.Rehash();
+            uint index = hashCode % (uint)table.Length;
+            table[index] = new HashtableEntry<KeyType, ValueType>(key, value, hashCode, table[index]);
         }
-        e = f;
-      } while (true);
-    }
 
-
-    public bool TryGetValue(KeyType key, out ValueType result)
-    {
-      HashtableEntry<KeyType, ValueType> e = this.GetHashtableEntry(key, (uint)key.GetHashCode());
-      if (e == null)
-      {
-        result = default(ValueType);
-        return false;
-      }
-      else
-      {
-        result = e.Value;
-        return true;
-      }
-    }
-
-    public ValueType this[KeyType key]
-    {
-      get
-      {
-        var e = this.GetHashtableEntry(key, (uint)key.GetHashCode());
-        if (e == null) return default(ValueType);
-        return e.Value;
-      }
-      set
-      {
-        uint hashCode = (uint)key.GetHashCode();
-        var e = this.GetHashtableEntry(key, hashCode);
-        if (e != null)
+        private HashtableEntry<KeyType, ValueType>/*?*/ GetHashtableEntry(KeyType key, uint hashCode)
         {
-          e.Key = key;
-          e.Value = value;
-          return;
+            uint index = hashCode % (uint)table.Length;
+            var e = table[index];
+            if (e == null) return null;
+            //Run down chain, using only object identity. Perhaps we get lucky. 
+            //At any rate, each loop is as cheap as it gets and the chain should be short.
+            if (Object.Equals(e.Key, key)) return e;
+            var curr = e.next;
+            while (curr != null)
+            {
+                if (Object.Equals(curr.Key, key)) return curr;
+                curr = curr.next;
+            }
+            //now check hash codes and call Equals
+            if (e.hashCode == hashCode && e.Key.Equals(key)) return e;
+            curr = e.next;
+            while (curr != null)
+            {
+                if (curr.hashCode == hashCode && curr.Key.Equals(key)) return curr;
+                curr = curr.next;
+            }
+            return null;
         }
-        if (++this.Count >= this.threshold) this.Rehash();
-        uint index = hashCode % (uint)this.table.Length;
-        this.table[index] = new HashtableEntry<KeyType, ValueType>(key, value, hashCode, this.table[index]);
-      }
+
+        public void Clear()
+        {
+            this.Count = 0;
+            int n = table.Length;
+            for (int i = 0; i < n; i++) table[i] = null;
+        }
+
+        public bool ContainsKey(KeyType key)
+        {
+            return this.GetHashtableEntry(key, (uint)key.GetHashCode()) != null;
+        }
+
+        public IEnumerable<KeyType> Keys
+        {
+            get
+            {
+                foreach (var entry in table)
+                {
+                    var e = entry;
+                    while (e != null)
+                    {
+                        yield return e.Key;
+                        e = e.next;
+                    }
+                }
+            }
+        }
+
+        public IEnumerable<KeyValuePair<KeyType, ValueType>> Elements
+        {
+            get
+            {
+                foreach (var entry in table)
+                {
+                    var e = entry;
+                    while (e != null)
+                    {
+                        yield return new KeyValuePair<KeyType, ValueType>(e.Key, e.Value);
+                        e = e.next;
+                    }
+                }
+            }
+        }
+
+        private void Rehash()
+        {
+            var oldTable = table;
+            uint threshold = this.threshold = (uint)(oldTable.Length + 1);
+            uint newCapacity = threshold * 2 - 1;
+            var newTable = table = new HashtableEntry<KeyType, ValueType>[newCapacity];
+            for (uint i = threshold - 1; i-- > 0;)
+            {
+                for (var old = oldTable[(int)i]; old != null;)
+                {
+                    var e = old; old = old.next;
+                    uint index = e.hashCode % newCapacity;
+                    e.next = newTable[index];
+                    newTable[index] = e;
+                }
+            }
+        }
+
+        public bool Remove(KeyType key)
+        {
+            uint hashCode = (uint)key.GetHashCode();
+            uint index = hashCode % (uint)table.Length;
+            var e = table[index];
+            if (e != null && e.hashCode == hashCode && (Object.Equals(e.Key, key) || e.Key.Equals(key)))
+            {
+                e = e.next;
+                table[index] = e;
+                this.Count--;
+                return true;
+            }
+            do
+            {
+                if (e == null) return false;
+                var f = e.next;
+                if (f != null && f.hashCode == hashCode && (Object.Equals(f.Key, key) || f.Key.Equals(key)))
+                {
+                    // f = f.next;
+                    e.next = f.next;   // F : Changed
+                    this.Count--;
+                    return true;
+                }
+                e = f;
+            } while (true);
+        }
+
+
+        public bool TryGetValue(KeyType key, out ValueType result)
+        {
+            HashtableEntry<KeyType, ValueType> e = this.GetHashtableEntry(key, (uint)key.GetHashCode());
+            if (e == null)
+            {
+                result = default(ValueType);
+                return false;
+            }
+            else
+            {
+                result = e.Value;
+                return true;
+            }
+        }
+
+        public ValueType this[KeyType key]
+        {
+            get
+            {
+                var e = this.GetHashtableEntry(key, (uint)key.GetHashCode());
+                if (e == null) return default(ValueType);
+                return e.Value;
+            }
+            set
+            {
+                uint hashCode = (uint)key.GetHashCode();
+                var e = this.GetHashtableEntry(key, hashCode);
+                if (e != null)
+                {
+                    e.Key = key;
+                    e.Value = value;
+                    return;
+                }
+                if (++this.Count >= threshold) this.Rehash();
+                uint index = hashCode % (uint)table.Length;
+                table[index] = new HashtableEntry<KeyType, ValueType>(key, value, hashCode, table[index]);
+            }
+        }
     }
-
-  }
-
 }

--- a/Microsoft.Research/DataStructures/SimpleTextWriters.cs
+++ b/Microsoft.Research/DataStructures/SimpleTextWriters.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Concurrent;
@@ -23,431 +12,430 @@ using System.Threading;
 
 namespace Microsoft.Research.DataStructures
 {
-  public interface IVerySimpleLineWriter
-  {
-    // The attribute is needed for services inheriting this interface
-    // The attribute means that the service calling WriteLine does not wait for WriteLine to complete
-    [OperationContract(IsOneWay = true)] 
-    void WriteLine(string value);
-  }
-
-  internal static class VerySimpleLineWriter
-  {
-    internal abstract class BaseToTextWriter : TextWriter
+    public interface IVerySimpleLineWriter
     {
-      protected abstract StringBuilder Buffer { get; }
-      protected abstract IWithEncoding AsWithEncoding { get; }
-      protected abstract void InternalFlush();
+        // The attribute is needed for services inheriting this interface
+        // The attribute means that the service calling WriteLine does not wait for WriteLine to complete
+        [OperationContract(IsOneWay = true)]
+        void WriteLine(string value);
+    }
 
-      #region TextWriter base cases
-      public override void Write(char value)
-      {
-        this.Buffer.Append(value);
-      }
-      public override void Write(char[] value, int index, int count)
-      {
-        this.Buffer.Append(value, index, count);
-      }
-      public override void Write(string value)
-      {
-        this.Buffer.Append(value);
-      }
-      #endregion
-      protected string GetAndEmptyBufferContent()
-      {
-        var res = this.Buffer.ToString();
-        this.Buffer.Clear();
-        return res;
-      }
-      public override void WriteLine(string value)
-      {
-        // TextWriter implementation calls Write(char[], int, int) instead of Write + WriteLine
-        this.Write(value);
-        this.WriteLine();
-      }
-      public override void Flush()
-      {
-        if (this.Buffer.Length > 0)
-          this.InternalFlush();
-      }
-      public override void Close()
-      {
-        this.Flush();
-      }
-      public override Encoding Encoding
-      {
-        get
+    internal static class VerySimpleLineWriter
+    {
+        internal abstract class BaseToTextWriter : TextWriter
         {
-          var withEncoding = this.AsWithEncoding;
-          if (withEncoding != null)
-            return withEncoding.Encoding;
-          return Encoding.Default;
-        }
-      }
-    }
+            protected abstract StringBuilder Buffer { get; }
+            protected abstract IWithEncoding AsWithEncoding { get; }
+            protected abstract void InternalFlush();
 
-    internal abstract class NormalBaseToTextWriter : BaseToTextWriter
-    {
-      protected abstract void WriteStringLine(string value);
-      private readonly StringBuilder buffer = new StringBuilder();
-      protected override StringBuilder Buffer { get { return this.buffer; } }
-      public override void WriteLine()
-      {
-        this.WriteStringLine(this.GetAndEmptyBufferContent());
-      }
-      protected override void InternalFlush()
-      {
-        this.WriteLine(); // this is adding an extra NewLine
-      }
-    }
-
-    internal abstract class MultithreadedBaseToTextWriter : BaseToTextWriter
-    {
-      private readonly ThreadLocal<StringBuilder> buffer = new ThreadLocal<StringBuilder>(() => new StringBuilder());
-      protected override StringBuilder Buffer { get { return this.buffer.Value; } }
-    }
-
-    internal class ToTextWriter : NormalBaseToTextWriter, IFromVerySimpleLineWriter
-    {
-      protected readonly IVerySimpleLineWriter lineWriter;
-
-      public ToTextWriter(IVerySimpleLineWriter lineWriter)
-      {
-        this.lineWriter = lineWriter;
-      }
-
-      protected override void WriteStringLine(string value)
-      {
-        this.lineWriter.WriteLine(value);
-      }
-
-      protected override IWithEncoding AsWithEncoding
-      {
-        get { return this.lineWriter as IWithEncoding; }
-      }
-
-      IVerySimpleLineWriter IFromVerySimpleLineWriter.OriginalLineWriter { get { return this.lineWriter; } }
-    }
-
-    internal class ToTextWriterWithEncoding : ToTextWriter
-    {
-      protected readonly Encoding encoding;
-
-      public ToTextWriterWithEncoding(IVerySimpleLineWriter lineWriter, string encodingWebName)
-        : base(lineWriter)
-      {
-        this.encoding = Encoding.GetEncoding(encodingWebName);
-      }
-
-      public override Encoding Encoding
-      {
-        get { return this.encoding; }
-      }
-    }
-
-    internal class FromTextWriter : IVerySimpleLineWriterWithEncoding, IFromTextWriter
-    {
-      protected readonly TextWriter textWriter;
-
-      public FromTextWriter(TextWriter textWriter)
-      {
-        Contract.Requires(textWriter != null);
-
-        this.textWriter = textWriter;
-      }
-
-      virtual public void WriteLine(string value)
-      {
-        this.textWriter.WriteLine(value);
-      }
-
-      public Encoding Encoding { get { return this.textWriter.Encoding; } }
-
-      public static implicit operator FromTextWriter(TextWriter textWriter)
-      {
-        return new FromTextWriter(textWriter);
-      }
-
-      TextWriter IFromTextWriter.OriginalTextWriter { get { return this.textWriter; } }
-
-      virtual public void Dispose()
-      {
-        // Do nothing
-      }
-    }
-
-    public class FromTextWriterWithBuffer : FromTextWriter, IDisposable
-    {
-      private readonly NonBlockingTextWriter tw;
-      public FromTextWriterWithBuffer(TextWriter inner)
-        : base(inner)
-      {
-        this.tw = new NonBlockingTextWriter(inner);
-      }
-
-      public override void WriteLine(string value)
-      {
-        this.tw.WriteLine(value);
-      }
-
-      public override void Dispose()
-      {
-      }
-    }
-
-    // TODO: add the opportune interface it implements
-    public class NonBlockingTextWriter
-    {
-      private readonly BlockingCollection<string> toWrite = new BlockingCollection<string>();
-      private readonly TextWriter Where;
-
-      public NonBlockingTextWriter(TextWriter where)
-      {
-        this.Where = where;
-
-        var thread = new Thread(
-          () =>
-          {
-            while (true)
+            #region TextWriter base cases
+            public override void Write(char value)
             {
-              where.WriteLine(toWrite.Take());
+                this.Buffer.Append(value);
             }
-          });
-        thread.IsBackground = true;
-        thread.Start();
-      }
+            public override void Write(char[] value, int index, int count)
+            {
+                this.Buffer.Append(value, index, count);
+            }
+            public override void Write(string value)
+            {
+                this.Buffer.Append(value);
+            }
+            #endregion
+            protected string GetAndEmptyBufferContent()
+            {
+                var res = this.Buffer.ToString();
+                this.Buffer.Clear();
+                return res;
+            }
+            public override void WriteLine(string value)
+            {
+                // TextWriter implementation calls Write(char[], int, int) instead of Write + WriteLine
+                this.Write(value);
+                this.WriteLine();
+            }
+            public override void Flush()
+            {
+                if (this.Buffer.Length > 0)
+                    this.InternalFlush();
+            }
+            public override void Close()
+            {
+                this.Flush();
+            }
+            public override Encoding Encoding
+            {
+                get
+                {
+                    var withEncoding = this.AsWithEncoding;
+                    if (withEncoding != null)
+                        return withEncoding.Encoding;
+                    return Encoding.Default;
+                }
+            }
+        }
 
-      public void WriteLine(string value)
-      {
-        toWrite.Add(value);
-      }
+        internal abstract class NormalBaseToTextWriter : BaseToTextWriter
+        {
+            protected abstract void WriteStringLine(string value);
+            private readonly StringBuilder buffer = new StringBuilder();
+            protected override StringBuilder Buffer { get { return buffer; } }
+            public override void WriteLine()
+            {
+                this.WriteStringLine(this.GetAndEmptyBufferContent());
+            }
+            protected override void InternalFlush()
+            {
+                this.WriteLine(); // this is adding an extra NewLine
+            }
+        }
+
+        internal abstract class MultithreadedBaseToTextWriter : BaseToTextWriter
+        {
+            private readonly ThreadLocal<StringBuilder> buffer = new ThreadLocal<StringBuilder>(() => new StringBuilder());
+            protected override StringBuilder Buffer { get { return buffer.Value; } }
+        }
+
+        internal class ToTextWriter : NormalBaseToTextWriter, IFromVerySimpleLineWriter
+        {
+            protected readonly IVerySimpleLineWriter lineWriter;
+
+            public ToTextWriter(IVerySimpleLineWriter lineWriter)
+            {
+                this.lineWriter = lineWriter;
+            }
+
+            protected override void WriteStringLine(string value)
+            {
+                this.lineWriter.WriteLine(value);
+            }
+
+            protected override IWithEncoding AsWithEncoding
+            {
+                get { return this.lineWriter as IWithEncoding; }
+            }
+
+            IVerySimpleLineWriter IFromVerySimpleLineWriter.OriginalLineWriter { get { return this.lineWriter; } }
+        }
+
+        internal class ToTextWriterWithEncoding : ToTextWriter
+        {
+            protected readonly Encoding encoding;
+
+            public ToTextWriterWithEncoding(IVerySimpleLineWriter lineWriter, string encodingWebName)
+              : base(lineWriter)
+            {
+                this.encoding = Encoding.GetEncoding(encodingWebName);
+            }
+
+            public override Encoding Encoding
+            {
+                get { return this.encoding; }
+            }
+        }
+
+        internal class FromTextWriter : IVerySimpleLineWriterWithEncoding, IFromTextWriter
+        {
+            protected readonly TextWriter textWriter;
+
+            public FromTextWriter(TextWriter textWriter)
+            {
+                Contract.Requires(textWriter != null);
+
+                this.textWriter = textWriter;
+            }
+
+            virtual public void WriteLine(string value)
+            {
+                this.textWriter.WriteLine(value);
+            }
+
+            public Encoding Encoding { get { return this.textWriter.Encoding; } }
+
+            public static implicit operator FromTextWriter(TextWriter textWriter)
+            {
+                return new FromTextWriter(textWriter);
+            }
+
+            TextWriter IFromTextWriter.OriginalTextWriter { get { return this.textWriter; } }
+
+            virtual public void Dispose()
+            {
+                // Do nothing
+            }
+        }
+
+        public class FromTextWriterWithBuffer : FromTextWriter, IDisposable
+        {
+            private readonly NonBlockingTextWriter tw;
+            public FromTextWriterWithBuffer(TextWriter inner)
+              : base(inner)
+            {
+                tw = new NonBlockingTextWriter(inner);
+            }
+
+            public override void WriteLine(string value)
+            {
+                tw.WriteLine(value);
+            }
+
+            public override void Dispose()
+            {
+            }
+        }
+
+        // TODO: add the opportune interface it implements
+        public class NonBlockingTextWriter
+        {
+            private readonly BlockingCollection<string> toWrite = new BlockingCollection<string>();
+            private readonly TextWriter Where;
+
+            public NonBlockingTextWriter(TextWriter where)
+            {
+                Where = where;
+
+                var thread = new Thread(
+                  () =>
+                  {
+                      while (true)
+                      {
+                          where.WriteLine(toWrite.Take());
+                      }
+                  });
+                thread.IsBackground = true;
+                thread.Start();
+            }
+
+            public void WriteLine(string value)
+            {
+                toWrite.Add(value);
+            }
+        }
     }
-  }
 
-  [ContractClass(typeof(ISimpleLineWriterContracts))]
-  public interface ISimpleLineWriter
-  {
-    void WriteLine(string format, params object[] args);
-  }
-
-  [ContractClassFor(typeof(ISimpleLineWriter))]
-  abstract class ISimpleLineWriterContracts : ISimpleLineWriter
-  {
-    public void WriteLine(string format, params object[] args)
+    [ContractClass(typeof(ISimpleLineWriterContracts))]
+    public interface ISimpleLineWriter
     {
-      Contract.Requires(format != null);
-      Contract.Requires(args != null);
-
-      throw new NotImplementedException();
+        void WriteLine(string format, params object[] args);
     }
-  }
 
-  public static partial class SimpleLineWriter
-  {
-    internal class ToTextWriter : VerySimpleLineWriter.NormalBaseToTextWriter, IFromSimpleLineWriter
+    [ContractClassFor(typeof(ISimpleLineWriter))]
+    internal abstract class ISimpleLineWriterContracts : ISimpleLineWriter
     {
-      protected readonly ISimpleLineWriter lineWriter;
+        public void WriteLine(string format, params object[] args)
+        {
+            Contract.Requires(format != null);
+            Contract.Requires(args != null);
 
-      public ToTextWriter(ISimpleLineWriter lineWriter)
-      {
-        this.lineWriter = lineWriter;
-      }
-
-      protected override void WriteStringLine(string value)
-      {
-        this.lineWriter.WriteLine("{0}", value);
-      }
-
-      protected override IWithEncoding AsWithEncoding
-      {
-        get { return this.lineWriter as IWithEncoding; }
-      }
-
-      ISimpleLineWriter IFromSimpleLineWriter.OriginalLineWriter { get { return this.lineWriter; } }
+            throw new NotImplementedException();
+        }
     }
 
-    internal class ToMultithreadedTextWriter : VerySimpleLineWriter.MultithreadedBaseToTextWriter
+    public static partial class SimpleLineWriter
     {
-      protected readonly ISimpleLineWriter lineWriter;
+        internal class ToTextWriter : VerySimpleLineWriter.NormalBaseToTextWriter, IFromSimpleLineWriter
+        {
+            protected readonly ISimpleLineWriter lineWriter;
 
-      public ToMultithreadedTextWriter(ISimpleLineWriter lineWriter)
-      {
-        this.lineWriter = lineWriter;
-      }
-      protected override void InternalFlush()
-      {
-        this.lineWriter.WriteLine(this.GetAndEmptyBufferContent());
-      }
-      protected override IWithEncoding AsWithEncoding
-      {
-        get { return this.lineWriter as IWithEncoding; }
-      }
+            public ToTextWriter(ISimpleLineWriter lineWriter)
+            {
+                this.lineWriter = lineWriter;
+            }
+
+            protected override void WriteStringLine(string value)
+            {
+                this.lineWriter.WriteLine("{0}", value);
+            }
+
+            protected override IWithEncoding AsWithEncoding
+            {
+                get { return this.lineWriter as IWithEncoding; }
+            }
+
+            ISimpleLineWriter IFromSimpleLineWriter.OriginalLineWriter { get { return this.lineWriter; } }
+        }
+
+        internal class ToMultithreadedTextWriter : VerySimpleLineWriter.MultithreadedBaseToTextWriter
+        {
+            protected readonly ISimpleLineWriter lineWriter;
+
+            public ToMultithreadedTextWriter(ISimpleLineWriter lineWriter)
+            {
+                this.lineWriter = lineWriter;
+            }
+            protected override void InternalFlush()
+            {
+                this.lineWriter.WriteLine(this.GetAndEmptyBufferContent());
+            }
+            protected override IWithEncoding AsWithEncoding
+            {
+                get { return this.lineWriter as IWithEncoding; }
+            }
+        }
+
+        public class FromTextWriter : ISimpleLineWriterWithEncoding, IFromTextWriter
+        {
+            protected readonly TextWriter textWriter;
+
+            public FromTextWriter(TextWriter textWriter)
+            {
+                Contract.Requires(textWriter != null);
+
+                this.textWriter = textWriter;
+            }
+
+            public virtual void WriteLine(string value, params object[] arg)
+            {
+                this.textWriter.WriteLine(value, arg);
+            }
+
+            public Encoding Encoding { get { return this.textWriter.Encoding; } }
+
+            public static implicit operator FromTextWriter(TextWriter textWriter)
+            {
+                return new FromTextWriter(textWriter);
+            }
+
+            TextWriter IFromTextWriter.OriginalTextWriter { get { return this.textWriter; } }
+        }
     }
 
-    public class FromTextWriter : ISimpleLineWriterWithEncoding, IFromTextWriter
+    // In case of double conversions, these interface allow unboxing instead of double boxing
+
+    internal interface IFromTextWriter
     {
-      protected readonly TextWriter textWriter;
-
-      public FromTextWriter(TextWriter textWriter)
-      {
-        Contract.Requires(textWriter != null);
-
-        this.textWriter = textWriter;
-      }
-
-      public virtual void WriteLine(string value, params object[] arg)
-      {
-        this.textWriter.WriteLine(value, arg);
-      }
-
-      public Encoding Encoding { get { return this.textWriter.Encoding; } }
-
-      public static implicit operator FromTextWriter(TextWriter textWriter)
-      {
-        return new FromTextWriter(textWriter);
-      }
-
-      TextWriter IFromTextWriter.OriginalTextWriter { get { return this.textWriter; } }
+        TextWriter OriginalTextWriter { get; }
     }
-  }
 
-  // In case of double conversions, these interface allow unboxing instead of double boxing
-
-  internal interface IFromTextWriter
-  {
-    TextWriter OriginalTextWriter { get; }
-  }
-
-  internal interface IFromVerySimpleLineWriter
-  {
-    IVerySimpleLineWriter OriginalLineWriter { get; }
-  }
-
-  internal interface IFromSimpleLineWriter
-  {
-    ISimpleLineWriter OriginalLineWriter { get; }
-  }
-
-  public interface IWithEncoding
-  {
-    Encoding Encoding { get; }
-  }
-
-  public interface IVerySimpleLineWriterWithEncoding : IVerySimpleLineWriter, IWithEncoding, IDisposable { }
-  public interface ISimpleLineWriterWithEncoding : ISimpleLineWriter, IWithEncoding { }
-
-  public static class VerySimpleLineWriterExtensions
-  {
-    public static void WriteLine(this IVerySimpleLineWriter writer)
+    internal interface IFromVerySimpleLineWriter
     {
-      writer.WriteLine((string)null);
+        IVerySimpleLineWriter OriginalLineWriter { get; }
     }
 
-    public static void WriteLine(this IVerySimpleLineWriter writer, string format, params object[] args)
+    internal interface IFromSimpleLineWriter
     {
-      writer.WriteLine(String.Format(format, args));
+        ISimpleLineWriter OriginalLineWriter { get; }
     }
 
-    public static TextWriter AsTextWriter(this IVerySimpleLineWriter writer)
+    public interface IWithEncoding
     {
-      var writerAsFromTextWriter = writer as IFromTextWriter;
-      if (writerAsFromTextWriter != null)
-        return writerAsFromTextWriter.OriginalTextWriter;
-      return new VerySimpleLineWriter.ToTextWriter(writer);
+        Encoding Encoding { get; }
     }
 
-    public static TextWriter AsTextWriter(this IVerySimpleLineWriter writer, string encodingWebName)
+    public interface IVerySimpleLineWriterWithEncoding : IVerySimpleLineWriter, IWithEncoding, IDisposable { }
+    public interface ISimpleLineWriterWithEncoding : ISimpleLineWriter, IWithEncoding { }
+
+    public static class VerySimpleLineWriterExtensions
     {
-      var writerAsFromTextWriter = writer as IFromTextWriter;
-      if (writerAsFromTextWriter != null)
-      {
-        if (writerAsFromTextWriter.OriginalTextWriter.Encoding.WebName != encodingWebName)
-          throw new ArgumentException("Encoding name different from original TextWriter encoding");
-        return writerAsFromTextWriter.OriginalTextWriter;
-      }
-      return new VerySimpleLineWriter.ToTextWriterWithEncoding(writer, encodingWebName);
-    }
-  }
+        public static void WriteLine(this IVerySimpleLineWriter writer)
+        {
+            writer.WriteLine((string)null);
+        }
 
-  public static class SimpleLineWriterExtensions
-  {
-    public static void WriteLine(this ISimpleLineWriter writer)
+        public static void WriteLine(this IVerySimpleLineWriter writer, string format, params object[] args)
+        {
+            writer.WriteLine(String.Format(format, args));
+        }
+
+        public static TextWriter AsTextWriter(this IVerySimpleLineWriter writer)
+        {
+            var writerAsFromTextWriter = writer as IFromTextWriter;
+            if (writerAsFromTextWriter != null)
+                return writerAsFromTextWriter.OriginalTextWriter;
+            return new VerySimpleLineWriter.ToTextWriter(writer);
+        }
+
+        public static TextWriter AsTextWriter(this IVerySimpleLineWriter writer, string encodingWebName)
+        {
+            var writerAsFromTextWriter = writer as IFromTextWriter;
+            if (writerAsFromTextWriter != null)
+            {
+                if (writerAsFromTextWriter.OriginalTextWriter.Encoding.WebName != encodingWebName)
+                    throw new ArgumentException("Encoding name different from original TextWriter encoding");
+                return writerAsFromTextWriter.OriginalTextWriter;
+            }
+            return new VerySimpleLineWriter.ToTextWriterWithEncoding(writer, encodingWebName);
+        }
+    }
+
+    public static class SimpleLineWriterExtensions
     {
-      writer.WriteLine("");
+        public static void WriteLine(this ISimpleLineWriter writer)
+        {
+            writer.WriteLine("");
+        }
+
+        public static void WriteLine(this ISimpleLineWriter writer, string value)
+        {
+            writer.WriteLine("{0}", value);
+        }
+
+        public static void WriteLine(this ISimpleLineWriter writer, object value)
+        {
+            writer.WriteLine("{0}", value);
+        }
+
+        public static TextWriter AsTextWriter(this ISimpleLineWriter writer)
+        {
+            var writerAsFromTextWriter = writer as IFromTextWriter;
+            if (writerAsFromTextWriter != null)
+                return writerAsFromTextWriter.OriginalTextWriter;
+            return new SimpleLineWriter.ToTextWriter(writer);
+        }
+
+        public static TextWriter AsMultithreadedTextWriter(this ISimpleLineWriter writer)
+        {
+            return new SimpleLineWriter.ToMultithreadedTextWriter(writer);
+        }
     }
 
-    public static void WriteLine(this ISimpleLineWriter writer, string value)
+    public static class TextWriterExtensions
     {
-      writer.WriteLine("{0}", value);
+        public static IVerySimpleLineWriterWithEncoding AsLineWriter(this TextWriter textWriter)
+        {
+            var asFromVerySimpleLineWriter = textWriter as IFromVerySimpleLineWriter;
+            if (asFromVerySimpleLineWriter != null)
+            {
+                var asWithEncoding = asFromVerySimpleLineWriter.OriginalLineWriter as IVerySimpleLineWriterWithEncoding;
+                if (asWithEncoding != null)
+                    return asWithEncoding;
+            }
+            // Original from mehdi:
+            //     return new VerySimpleLineWriter.FromTextWriter(textWriter);
+
+            return new VerySimpleLineWriter.FromTextWriterWithBuffer(textWriter);
+        }
+
+        public static ISimpleLineWriterWithEncoding AsSimpleLineWriter(this TextWriter textWriter)
+        {
+            var asFromSimpleLineWriter = textWriter as IFromSimpleLineWriter;
+            if (asFromSimpleLineWriter != null)
+            {
+                var asWithEncoding = asFromSimpleLineWriter.OriginalLineWriter as ISimpleLineWriterWithEncoding;
+                if (asWithEncoding != null)
+                    return asWithEncoding;
+            }
+            return new SimpleLineWriter.FromTextWriter(textWriter);
+        }
     }
 
-    public static void WriteLine(this ISimpleLineWriter writer, object value)
+    public static class BufferedTextWriter
     {
-      writer.WriteLine("{0}", value);
+        public static TextWriter Create()
+        {
+            Contract.Ensures(Contract.Result<TextWriter>() != null);
+            return new InternalBufferedTextWriter();
+        }
+        internal class InternalBufferedTextWriter : VerySimpleLineWriter.BaseToTextWriter
+        {
+            private readonly StringBuilder buffer = new StringBuilder();
+            protected override StringBuilder Buffer { get { return buffer; } }
+            protected override IWithEncoding AsWithEncoding { get { return null; } }
+            public override string ToString()
+            {
+                return this.GetAndEmptyBufferContent();
+            }
+            protected override void InternalFlush() { }
+        }
     }
-
-    public static TextWriter AsTextWriter(this ISimpleLineWriter writer)
-    {
-      var writerAsFromTextWriter = writer as IFromTextWriter;
-      if (writerAsFromTextWriter != null)
-        return writerAsFromTextWriter.OriginalTextWriter;
-      return new SimpleLineWriter.ToTextWriter(writer);
-    }
-
-    public static TextWriter AsMultithreadedTextWriter(this ISimpleLineWriter writer)
-    {
-      return new SimpleLineWriter.ToMultithreadedTextWriter(writer);
-    }
-  }
-
-  public static class TextWriterExtensions
-  {
-    public static IVerySimpleLineWriterWithEncoding AsLineWriter(this TextWriter textWriter)
-    {
-      var asFromVerySimpleLineWriter = textWriter as IFromVerySimpleLineWriter;
-      if (asFromVerySimpleLineWriter != null)
-      {
-        var asWithEncoding = asFromVerySimpleLineWriter.OriginalLineWriter as IVerySimpleLineWriterWithEncoding;
-        if (asWithEncoding != null)
-          return asWithEncoding;
-      }
-      // Original from mehdi:
-      //     return new VerySimpleLineWriter.FromTextWriter(textWriter);
-
-      return new VerySimpleLineWriter.FromTextWriterWithBuffer(textWriter);
-    }
-
-    public static ISimpleLineWriterWithEncoding AsSimpleLineWriter(this TextWriter textWriter)
-    {
-      var asFromSimpleLineWriter = textWriter as IFromSimpleLineWriter;
-      if (asFromSimpleLineWriter != null)
-      {
-        var asWithEncoding = asFromSimpleLineWriter.OriginalLineWriter as ISimpleLineWriterWithEncoding;
-        if (asWithEncoding != null)
-          return asWithEncoding;
-      }
-      return new SimpleLineWriter.FromTextWriter(textWriter);
-    }
-  }
-
-  public static class BufferedTextWriter
-  {
-    public static TextWriter Create()
-    {
-      Contract.Ensures(Contract.Result<TextWriter>() != null);
-      return new InternalBufferedTextWriter();
-    }
-    internal class InternalBufferedTextWriter : VerySimpleLineWriter.BaseToTextWriter
-    {
-      private readonly StringBuilder buffer = new StringBuilder();
-      protected override StringBuilder Buffer { get { return this.buffer; } }
-      protected override IWithEncoding AsWithEncoding { get { return null; } }
-      public override string ToString()
-      {
-        return this.GetAndEmptyBufferContent();
-      }
-      protected override void InternalFlush() { }
-    }
-  }
-
 }

--- a/Microsoft.Research/DataStructures/SubKeyDictionary.cs
+++ b/Microsoft.Research/DataStructures/SubKeyDictionary.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -18,274 +7,274 @@ using System.Linq;
 
 namespace Microsoft.Research.DataStructures
 {
-  public class SubKeyDictionary<TKey, TSubKey, TValue> : Dictionary<TKey, TValue>
-  {
-    protected static readonly KeyValuePair<TKey, TValue>[] emptyKVArray = new KeyValuePair<TKey, TValue>[0];
-
-    protected readonly Dictionary<TSubKey, HashSet<TKey>> sub;
-    protected readonly Func<TKey, TSubKey> proj;
-
-    public SubKeyDictionary(Func<TKey, TSubKey> projection)
+    public class SubKeyDictionary<TKey, TSubKey, TValue> : Dictionary<TKey, TValue>
     {
-      this.proj = projection;
-      this.sub = new Dictionary<TSubKey, HashSet<TKey>>();
-    }
+        protected static readonly KeyValuePair<TKey, TValue>[] emptyKVArray = new KeyValuePair<TKey, TValue>[0];
 
-    public virtual new void Add(TKey key, TValue value)
-    {
-      base.Add(key, value);
-      this.SubAdd(this.proj(key), key);
-    }
+        protected readonly Dictionary<TSubKey, HashSet<TKey>> sub;
+        protected readonly Func<TKey, TSubKey> proj;
 
-    private void SubAdd(TSubKey subkey, TKey key)
-    {
-      HashSet<TKey> s;
-      if (this.sub.TryGetValue(subkey, out s))
-        s.Add(key);
-      else
-        this.sub[subkey] = new HashSet<TKey> { key };
-    }
-
-    public virtual new void Clear()
-    {
-      base.Clear();
-      this.sub.Clear();
-    }
-
-    public bool ContainsKey(TSubKey subkey)
-    {
-      return this.sub.ContainsKey(subkey);
-    }
-
-    public virtual new bool Remove(TKey key)
-    {
-      return base.Remove(key) && this.SubRemove(this.proj(key), key);
-    }
-
-    public virtual bool Remove(TKey key, out TValue value)
-    {
-      return base.TryGetValue(key, out value) && this.Remove(key);
-    }
-
-    protected bool BaseRemove(TKey key)
-    {
-      return base.Remove(key);
-    }
-
-    protected virtual bool BaseRemove(TKey key, out TValue value)
-    {
-      return base.TryGetValue(key, out value) && base.Remove(key);
-    }
-
-    private bool SubRemove(TSubKey subkey, TKey key)
-    {
-      HashSet<TKey> s;
-      return this.sub.TryGetValue(subkey, out s) && s.Remove(key) && (s.Any() || this.sub.Remove(subkey));
-    }
-
-    private bool SubRemove(TSubKey subkey, out HashSet<TKey> keys)
-    {
-      return this.sub.TryGetValue(subkey, out keys) && this.sub.Remove(subkey);
-    }
-
-    public bool Remove(TSubKey subkey)
-    {
-      HashSet<TKey> s;
-      return this.sub.TryGetValue(subkey, out s) && s.All(base.Remove) && this.sub.Remove(subkey);
-    }
-
-    public bool Remove(TSubKey subkey, out IEnumerable<KeyValuePair<TKey, TValue>> elements)
-    {
-      HashSet<TKey> s;
-      if (this.SubRemove(subkey, out s))
-      {
-        elements = s.SelectMany(key =>
+        public SubKeyDictionary(Func<TKey, TSubKey> projection)
         {
-          TValue value;
-          return this.BaseRemove(key, out value) ? new KeyValuePair<TKey, TValue>[] { new KeyValuePair<TKey, TValue>(key, value) } : emptyKVArray;
-        });
-        return true;
-      }
-      elements = null;
-      return false;
-    }
+            this.proj = projection;
+            this.sub = new Dictionary<TSubKey, HashSet<TKey>>();
+        }
 
-    public bool TryGetValue(TSubKey subkey, out IEnumerable<KeyValuePair<TKey, TValue>> elements)
-    {
-      HashSet<TKey> s;
-      if (this.sub.TryGetValue(subkey, out s))
-      {
-        elements = s.SelectMany(key =>
+        public virtual new void Add(TKey key, TValue value)
         {
-          TValue value;
-          return base.TryGetValue(key, out value) ? new KeyValuePair<TKey, TValue>[] { new KeyValuePair<TKey, TValue>(key, value) } : emptyKVArray;
-        });
-        return true;
-      }
-      elements = null;
-      return false;
-    }
+            base.Add(key, value);
+            this.SubAdd(this.proj(key), key);
+        }
 
-    public TValue GetValueOrDefault(TKey key)
-    {
-      TValue value;
-      return base.TryGetValue(key, out value) ? value : default(TValue);
-    }
-
-    public IEnumerable<KeyValuePair<TKey, TValue>> GetValueOrEmpty(TSubKey subkey)
-    {
-      IEnumerable<KeyValuePair<TKey, TValue>> elements;
-      return this.TryGetValue(subkey, out elements) ? elements : emptyKVArray;
-    }
-
-    public int SubCount { get { return this.sub.Count; } }
-
-    public Dictionary<TSubKey, HashSet<TKey>>.KeyCollection SubKeys { get { return this.sub.Keys; } }
-  }
-
-  public class SubKeyDictionary<TKey, TSubKey1, TSubKey2, TValue> : SubKeyDictionary<TKey, TSubKey1, TValue>
-  {
-    private readonly Dictionary<TSubKey2, HashSet<TKey>> sub2;
-    private readonly Func<TKey, TSubKey2> proj2;
-
-    public SubKeyDictionary(Func<TKey, TSubKey1> projection1, Func<TKey, TSubKey2> projection2)
-      : base(projection1)
-    {
-      this.proj2 = projection2;
-      this.sub2 = new Dictionary<TSubKey2, HashSet<TKey>>();
-    }
-
-    public override void Add(TKey key, TValue value)
-    {
-      base.Add(key, value);
-      this.SubAdd(this.proj2(key), key);
-    }
-
-    private void SubAdd(TSubKey2 subkey2, TKey key)
-    {
-      HashSet<TKey> s;
-      if (this.sub2.TryGetValue(subkey2, out s))
-        s.Add(key);
-      else
-        this.sub2[subkey2] = new HashSet<TKey> { key };
-    }
-
-    public override void Clear()
-    {
-      base.Clear();
-      this.sub2.Clear();
-    }
-
-    public bool ContainsKey(TSubKey2 subkey2)
-    {
-      return this.sub2.ContainsKey(subkey2);
-    }
-
-    public override bool Remove(TKey key)
-    {
-      return base.Remove(key) && this.SubRemove(this.proj2(key), key);
-    }
-
-    public override bool Remove(TKey key, out TValue value)
-    {
-      return base.TryGetValue(key, out value) && this.Remove(key);
-    }
-
-    protected override bool BaseRemove(TKey key, out TValue value)
-    {
-      return base.TryGetValue(key, out value) && base.Remove(key);
-    }
-
-    private bool SubRemove(TSubKey2 subkey2, TKey key)
-    {
-      HashSet<TKey> s;
-      return this.sub2.TryGetValue(subkey2, out s) && s.Remove(key) && (s.Any() || this.sub2.Remove(subkey2));
-    }
-
-    private bool SubRemove(TSubKey2 subkey2, out HashSet<TKey> keys)
-    {
-      return this.sub2.TryGetValue(subkey2, out keys) && this.sub2.Remove(subkey2);
-    }
-
-    public bool Remove(TSubKey2 subkey2)
-    {
-      HashSet<TKey> s;
-      return this.sub2.TryGetValue(subkey2, out s) && s.All(base.Remove) && this.sub2.Remove(subkey2);
-    }
-
-    public bool Remove(TSubKey2 subkey2, out IEnumerable<KeyValuePair<TKey, TValue>> elements)
-    {
-      HashSet<TKey> s;
-      if (this.SubRemove(subkey2, out s))
-      {
-        elements = s.SelectMany(key =>
+        private void SubAdd(TSubKey subkey, TKey key)
         {
-          TValue value;
-          return this.BaseRemove(key, out value) ? new KeyValuePair<TKey, TValue>[] { new KeyValuePair<TKey, TValue>(key, value) } : emptyKVArray;
-        });
-        return true;
-      }
-      elements = null;
-      return false;
-    }
+            HashSet<TKey> s;
+            if (this.sub.TryGetValue(subkey, out s))
+                s.Add(key);
+            else
+                this.sub[subkey] = new HashSet<TKey> { key };
+        }
 
-    public bool Remove(TSubKey1 subkey1, TSubKey2 subkey2)
-    {
-      HashSet<TKey> s1, s2;
-      if (!this.sub.TryGetValue(subkey1, out s1))
-        return false;
-      if (!this.sub2.TryGetValue(subkey2, out s2))
-        return false;
-      var s = s1.Intersect(s2).ToArray(); // force evaluation
-      s1.ExceptWith(s);
-      if (!s1.Any())
-        this.sub.Remove(subkey1);
-      s2.ExceptWith(s);
-      if (!s2.Any())
-        this.sub2.Remove(subkey2);
-      return s.All(base.BaseRemove);
-    }
-
-    public bool TryGetValue(TSubKey2 subkey2, out IEnumerable<KeyValuePair<TKey, TValue>> elements)
-    {
-      HashSet<TKey> s;
-      if (this.sub2.TryGetValue(subkey2, out s))
-      {
-        elements = s.SelectMany(key =>
+        public virtual new void Clear()
         {
-          TValue value;
-          return base.TryGetValue(key, out value) ? new KeyValuePair<TKey, TValue>[] { new KeyValuePair<TKey, TValue>(key, value) } : emptyKVArray;
-        });
-        return true;
-      }
-      elements = null;
-      return false;
+            base.Clear();
+            this.sub.Clear();
+        }
+
+        public bool ContainsKey(TSubKey subkey)
+        {
+            return this.sub.ContainsKey(subkey);
+        }
+
+        public virtual new bool Remove(TKey key)
+        {
+            return base.Remove(key) && this.SubRemove(this.proj(key), key);
+        }
+
+        public virtual bool Remove(TKey key, out TValue value)
+        {
+            return base.TryGetValue(key, out value) && this.Remove(key);
+        }
+
+        protected bool BaseRemove(TKey key)
+        {
+            return base.Remove(key);
+        }
+
+        protected virtual bool BaseRemove(TKey key, out TValue value)
+        {
+            return base.TryGetValue(key, out value) && base.Remove(key);
+        }
+
+        private bool SubRemove(TSubKey subkey, TKey key)
+        {
+            HashSet<TKey> s;
+            return this.sub.TryGetValue(subkey, out s) && s.Remove(key) && (s.Any() || this.sub.Remove(subkey));
+        }
+
+        private bool SubRemove(TSubKey subkey, out HashSet<TKey> keys)
+        {
+            return this.sub.TryGetValue(subkey, out keys) && this.sub.Remove(subkey);
+        }
+
+        public bool Remove(TSubKey subkey)
+        {
+            HashSet<TKey> s;
+            return this.sub.TryGetValue(subkey, out s) && s.All(base.Remove) && this.sub.Remove(subkey);
+        }
+
+        public bool Remove(TSubKey subkey, out IEnumerable<KeyValuePair<TKey, TValue>> elements)
+        {
+            HashSet<TKey> s;
+            if (this.SubRemove(subkey, out s))
+            {
+                elements = s.SelectMany(key =>
+                {
+                    TValue value;
+                    return this.BaseRemove(key, out value) ? new KeyValuePair<TKey, TValue>[] { new KeyValuePair<TKey, TValue>(key, value) } : emptyKVArray;
+                });
+                return true;
+            }
+            elements = null;
+            return false;
+        }
+
+        public bool TryGetValue(TSubKey subkey, out IEnumerable<KeyValuePair<TKey, TValue>> elements)
+        {
+            HashSet<TKey> s;
+            if (this.sub.TryGetValue(subkey, out s))
+            {
+                elements = s.SelectMany(key =>
+                {
+                    TValue value;
+                    return base.TryGetValue(key, out value) ? new KeyValuePair<TKey, TValue>[] { new KeyValuePair<TKey, TValue>(key, value) } : emptyKVArray;
+                });
+                return true;
+            }
+            elements = null;
+            return false;
+        }
+
+        public TValue GetValueOrDefault(TKey key)
+        {
+            TValue value;
+            return base.TryGetValue(key, out value) ? value : default(TValue);
+        }
+
+        public IEnumerable<KeyValuePair<TKey, TValue>> GetValueOrEmpty(TSubKey subkey)
+        {
+            IEnumerable<KeyValuePair<TKey, TValue>> elements;
+            return this.TryGetValue(subkey, out elements) ? elements : emptyKVArray;
+        }
+
+        public int SubCount { get { return this.sub.Count; } }
+
+        public Dictionary<TSubKey, HashSet<TKey>>.KeyCollection SubKeys { get { return this.sub.Keys; } }
     }
 
-    public IEnumerable<KeyValuePair<TKey, TValue>> GetValueOrEmpty(TSubKey2 subkey2)
+    public class SubKeyDictionary<TKey, TSubKey1, TSubKey2, TValue> : SubKeyDictionary<TKey, TSubKey1, TValue>
     {
-      IEnumerable<KeyValuePair<TKey, TValue>> elements;
-      return this.TryGetValue(subkey2, out elements) ? elements : emptyKVArray;
+        private readonly Dictionary<TSubKey2, HashSet<TKey>> sub2;
+        private readonly Func<TKey, TSubKey2> proj2;
+
+        public SubKeyDictionary(Func<TKey, TSubKey1> projection1, Func<TKey, TSubKey2> projection2)
+          : base(projection1)
+        {
+            proj2 = projection2;
+            sub2 = new Dictionary<TSubKey2, HashSet<TKey>>();
+        }
+
+        public override void Add(TKey key, TValue value)
+        {
+            base.Add(key, value);
+            this.SubAdd(proj2(key), key);
+        }
+
+        private void SubAdd(TSubKey2 subkey2, TKey key)
+        {
+            HashSet<TKey> s;
+            if (sub2.TryGetValue(subkey2, out s))
+                s.Add(key);
+            else
+                sub2[subkey2] = new HashSet<TKey> { key };
+        }
+
+        public override void Clear()
+        {
+            base.Clear();
+            sub2.Clear();
+        }
+
+        public bool ContainsKey(TSubKey2 subkey2)
+        {
+            return sub2.ContainsKey(subkey2);
+        }
+
+        public override bool Remove(TKey key)
+        {
+            return base.Remove(key) && this.SubRemove(proj2(key), key);
+        }
+
+        public override bool Remove(TKey key, out TValue value)
+        {
+            return base.TryGetValue(key, out value) && this.Remove(key);
+        }
+
+        protected override bool BaseRemove(TKey key, out TValue value)
+        {
+            return base.TryGetValue(key, out value) && base.Remove(key);
+        }
+
+        private bool SubRemove(TSubKey2 subkey2, TKey key)
+        {
+            HashSet<TKey> s;
+            return sub2.TryGetValue(subkey2, out s) && s.Remove(key) && (s.Any() || sub2.Remove(subkey2));
+        }
+
+        private bool SubRemove(TSubKey2 subkey2, out HashSet<TKey> keys)
+        {
+            return sub2.TryGetValue(subkey2, out keys) && sub2.Remove(subkey2);
+        }
+
+        public bool Remove(TSubKey2 subkey2)
+        {
+            HashSet<TKey> s;
+            return sub2.TryGetValue(subkey2, out s) && s.All(base.Remove) && sub2.Remove(subkey2);
+        }
+
+        public bool Remove(TSubKey2 subkey2, out IEnumerable<KeyValuePair<TKey, TValue>> elements)
+        {
+            HashSet<TKey> s;
+            if (this.SubRemove(subkey2, out s))
+            {
+                elements = s.SelectMany(key =>
+                {
+                    TValue value;
+                    return this.BaseRemove(key, out value) ? new KeyValuePair<TKey, TValue>[] { new KeyValuePair<TKey, TValue>(key, value) } : emptyKVArray;
+                });
+                return true;
+            }
+            elements = null;
+            return false;
+        }
+
+        public bool Remove(TSubKey1 subkey1, TSubKey2 subkey2)
+        {
+            HashSet<TKey> s1, s2;
+            if (!this.sub.TryGetValue(subkey1, out s1))
+                return false;
+            if (!sub2.TryGetValue(subkey2, out s2))
+                return false;
+            var s = s1.Intersect(s2).ToArray(); // force evaluation
+            s1.ExceptWith(s);
+            if (!s1.Any())
+                this.sub.Remove(subkey1);
+            s2.ExceptWith(s);
+            if (!s2.Any())
+                sub2.Remove(subkey2);
+            return s.All(base.BaseRemove);
+        }
+
+        public bool TryGetValue(TSubKey2 subkey2, out IEnumerable<KeyValuePair<TKey, TValue>> elements)
+        {
+            HashSet<TKey> s;
+            if (sub2.TryGetValue(subkey2, out s))
+            {
+                elements = s.SelectMany(key =>
+                {
+                    TValue value;
+                    return base.TryGetValue(key, out value) ? new KeyValuePair<TKey, TValue>[] { new KeyValuePair<TKey, TValue>(key, value) } : emptyKVArray;
+                });
+                return true;
+            }
+            elements = null;
+            return false;
+        }
+
+        public IEnumerable<KeyValuePair<TKey, TValue>> GetValueOrEmpty(TSubKey2 subkey2)
+        {
+            IEnumerable<KeyValuePair<TKey, TValue>> elements;
+            return this.TryGetValue(subkey2, out elements) ? elements : emptyKVArray;
+        }
+
+        public int Sub1Count { get { return base.SubCount; } }
+
+        public int Sub2Count { get { return sub2.Count; } }
+
+        public Dictionary<TSubKey1, HashSet<TKey>>.KeyCollection Sub1Keys { get { return base.SubKeys; } }
+
+        public Dictionary<TSubKey2, HashSet<TKey>>.KeyCollection Sub2Keys { get { return sub2.Keys; } }
     }
 
-    public int Sub1Count { get { return base.SubCount; } }
-
-    public int Sub2Count { get { return this.sub2.Count; } }
-
-    public Dictionary<TSubKey1, HashSet<TKey>>.KeyCollection Sub1Keys { get { return base.SubKeys; } }
-
-    public Dictionary<TSubKey2, HashSet<TKey>>.KeyCollection Sub2Keys { get { return this.sub2.Keys; } }
-  }
-
-  public class MultiKeyDictionary<TKey1, TKey2, TValue> : SubKeyDictionary<Pair<TKey1, TKey2>, TKey1, TKey2, TValue>
-  {
-    public MultiKeyDictionary()
-      : base(p => p.One, p => p.Two)
-    { }
-
-    public void Add(TKey1 key1, TKey2 key2, TValue value)
+    public class MultiKeyDictionary<TKey1, TKey2, TValue> : SubKeyDictionary<Pair<TKey1, TKey2>, TKey1, TKey2, TValue>
     {
-      this.Add(Pair.For(key1, key2), value);
+        public MultiKeyDictionary()
+          : base(p => p.One, p => p.Two)
+        { }
+
+        public void Add(TKey1 key1, TKey2 key2, TValue value)
+        {
+            this.Add(Pair.For(key1, key2), value);
+        }
     }
-  }
 }

--- a/Microsoft.Research/DataStructures/TimeCounter.cs
+++ b/Microsoft.Research/DataStructures/TimeCounter.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,190 +8,189 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Research.DataStructures
 {
-  /// <summary>
-  /// The class for measuring the time
-  /// </summary>
-  public class TimeCounter
-  {
-    private enum State { Stopped, Started, Paused };
-
-    private Int64 frequency;
-    private Int64 ticks;
-    private Int64 elapsed;
-    private Int64 totalElapsed;
-    private State state;
-    private bool printOverallTime = true;
-
-    [DllImport("Kernel32.dll")]
-    private static extern bool QueryPerformanceCounter(out long lpPerformanceCount);
-    [DllImport("Kernel32.dll")]
-    private static extern bool QueryPerformanceFrequency(out long lpFrequency);
-
     /// <summary>
-    /// In miliseconds
+    /// The class for measuring the time
     /// </summary>
-    private long Elapsed
+    public class TimeCounter
     {
-      get { return ToMilliseconds(this.elapsed); }
-    }
+        private enum State { Stopped, Started, Paused };
 
-    private long TotalElapsed
-    {
-      get { return ToMilliseconds(this.totalElapsed); }
-    }
+        private Int64 frequency;
+        private Int64 ticks;
+        private Int64 elapsed;
+        private Int64 totalElapsed;
+        private State state;
+        private bool printOverallTime = true;
 
-    private long ToMilliseconds(long ticks)
-    {
-      return (ticks * 1000) / this.frequency;
-    }
+        [DllImport("Kernel32.dll")]
+        private static extern bool QueryPerformanceCounter(out long lpPerformanceCount);
+        [DllImport("Kernel32.dll")]
+        private static extern bool QueryPerformanceFrequency(out long lpFrequency);
 
-    #region Getters/Setters
-    public long InSeconds
-    {
-      get
-      {
-        return ((this.Elapsed / (Int64)1000));
-      }
-    }
-
-    public long InMilliSeconds
-    {
-      get
-      {
-        return (this.Elapsed);
-      }
-    }
-
-    #endregion
-
-    #region Constructor
-    public TimeCounter()
-    {
-      this.ticks = -1;
-      this.elapsed = 0;
-      this.totalElapsed = 0;
-      this.state = State.Stopped;
-      this.printOverallTime = false;
-      if (!QueryPerformanceFrequency(out this.frequency))
-      {
-        throw new NotImplementedException("This system does not support the high precision clock of Win32");
-      }
-    }
-
-    public TimeCounter(bool printOverallTime)
-    {
-      this.ticks = -1;
-      this.elapsed = 0;
-      this.totalElapsed = 0;
-      this.state = State.Stopped;
-      this.printOverallTime = printOverallTime;
-      if (!QueryPerformanceFrequency(out this.frequency))
-      {
-        throw new NotImplementedException("This system does not support the high precision clock of Win32");
-      }
-    }
-
-    private TimeCounter(Int64 elapsed, Int64 totalElapsed, bool printOverallTime)
-    {
-      this.ticks = -1;
-      this.elapsed = elapsed;
-      this.totalElapsed = totalElapsed;
-      this.state = State.Stopped;
-      this.printOverallTime = printOverallTime;
-      if (!QueryPerformanceFrequency(out this.frequency))
-      {
-        throw new NotImplementedException("This system does not support the high precision clock of Win32");
-      }
-    }
-    #endregion
-
-    #region Start/Stop
-
-    /// <summary>
-    /// Start the performance counter
-    /// </summary>
-    public void Start()
-    {
-      if (this.state != State.Started)
-      {
-        if (this.state == State.Stopped)
+        /// <summary>
+        /// In miliseconds
+        /// </summary>
+        private long Elapsed
         {
-          this.elapsed = 0;
+            get { return ToMilliseconds(elapsed); }
         }
 
-        QueryPerformanceCounter(out this.ticks);
-        this.state = State.Started;
-      }
+        private long TotalElapsed
+        {
+            get { return ToMilliseconds(totalElapsed); }
+        }
+
+        private long ToMilliseconds(long ticks)
+        {
+            return (ticks * 1000) / frequency;
+        }
+
+        #region Getters/Setters
+        public long InSeconds
+        {
+            get
+            {
+                return ((this.Elapsed / (Int64)1000));
+            }
+        }
+
+        public long InMilliSeconds
+        {
+            get
+            {
+                return (this.Elapsed);
+            }
+        }
+
+        #endregion
+
+        #region Constructor
+        public TimeCounter()
+        {
+            ticks = -1;
+            elapsed = 0;
+            totalElapsed = 0;
+            state = State.Stopped;
+            printOverallTime = false;
+            if (!QueryPerformanceFrequency(out frequency))
+            {
+                throw new NotImplementedException("This system does not support the high precision clock of Win32");
+            }
+        }
+
+        public TimeCounter(bool printOverallTime)
+        {
+            ticks = -1;
+            elapsed = 0;
+            totalElapsed = 0;
+            state = State.Stopped;
+            this.printOverallTime = printOverallTime;
+            if (!QueryPerformanceFrequency(out frequency))
+            {
+                throw new NotImplementedException("This system does not support the high precision clock of Win32");
+            }
+        }
+
+        private TimeCounter(Int64 elapsed, Int64 totalElapsed, bool printOverallTime)
+        {
+            ticks = -1;
+            this.elapsed = elapsed;
+            this.totalElapsed = totalElapsed;
+            state = State.Stopped;
+            this.printOverallTime = printOverallTime;
+            if (!QueryPerformanceFrequency(out frequency))
+            {
+                throw new NotImplementedException("This system does not support the high precision clock of Win32");
+            }
+        }
+        #endregion
+
+        #region Start/Stop
+
+        /// <summary>
+        /// Start the performance counter
+        /// </summary>
+        public void Start()
+        {
+            if (state != State.Started)
+            {
+                if (state == State.Stopped)
+                {
+                    elapsed = 0;
+                }
+
+                QueryPerformanceCounter(out ticks);
+                state = State.Started;
+            }
+        }
+
+        public void Pause()
+        {
+            if (state == State.Started)
+            {
+                Int64 now;
+                QueryPerformanceCounter(out now);
+                elapsed += now - ticks;
+                state = State.Paused;
+            }
+        }
+
+        /// <summary>
+        /// Stop the performance counter
+        /// </summary>
+        public void Stop()
+        {
+            if (state == State.Started)
+            {
+                Int64 now;
+                QueryPerformanceCounter(out now);
+                elapsed += now - ticks;
+                totalElapsed += elapsed;
+                state = State.Stopped;
+            }
+        }
+
+        #endregion
+
+        public static TimeCounter operator +(TimeCounter p1, TimeCounter p2)
+        {
+            return new TimeCounter(p1.elapsed + p2.elapsed, p1.totalElapsed + p2.totalElapsed, p1.printOverallTime || p2.printOverallTime);
+        }
+
+        public override string ToString()
+        {
+            var elap = PrettyPrint(this.Elapsed);
+
+            if (printOverallTime)
+            {
+                var total = PrettyPrint(this.TotalElapsed);
+
+                return string.Format("{0} (so far {1})", elap, total);
+            }
+            else
+            {
+                return elap;
+            }
+        }
+
+        private static string PrettyPrint(Int64 time)
+        {
+            string elap;
+            if (time > 60000)
+            {
+                long minutes = (time / 60000);
+                long seconds = (time % 60000) / 1000;
+                elap = String.Format("{0}:{1:00}min", minutes, seconds);
+            }
+            else if (time > 1000)
+            {
+                elap = String.Format("{0:0.000}sec", (double)time / 1000);
+            }
+            else
+            {
+                elap = time + "ms";
+            }
+            return elap;
+        }
     }
-
-    public void Pause()
-    {
-      if (this.state == State.Started)
-      {
-        Int64 now;
-        QueryPerformanceCounter(out now);
-        this.elapsed += now - this.ticks;
-        this.state = State.Paused;
-      }
-    }
-
-    /// <summary>
-    /// Stop the performance counter
-    /// </summary>
-    public void Stop()
-    {
-      if (this.state == State.Started)
-      {
-        Int64 now;
-        QueryPerformanceCounter(out now);
-        this.elapsed += now - this.ticks;
-        this.totalElapsed += this.elapsed;
-        this.state = State.Stopped;
-      }
-    }
-
-    #endregion
-
-    public static TimeCounter operator +(TimeCounter p1, TimeCounter p2)
-    {
-      return new TimeCounter(p1.elapsed + p2.elapsed, p1.totalElapsed + p2.totalElapsed, p1.printOverallTime || p2.printOverallTime);
-    }
-
-    public override string ToString()
-    {      
-      var elap = PrettyPrint(this.Elapsed);
-
-      if (this.printOverallTime)
-      {
-        var total = PrettyPrint(this.TotalElapsed);
-
-        return string.Format("{0} (so far {1})", elap, total);
-      }
-      else
-      {
-        return elap;
-      }
-    }
-
-    private static string PrettyPrint(Int64 time)
-    {
-      string elap;
-      if (time > 60000)
-      {
-        long minutes = (time / 60000);
-        long seconds = (time % 60000) / 1000;
-        elap = String.Format("{0}:{1:00}min", minutes, seconds);
-      }
-      else if (time > 1000)
-      {
-        elap = String.Format("{0:0.000}sec", (double)time / 1000);
-      }
-      else
-      {
-        elap = time + "ms";
-      }
-      return elap;
-    }
-  }
-
 }

--- a/Microsoft.Research/DataStructures/TypedProperty.cs
+++ b/Microsoft.Research/DataStructures/TypedProperty.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -18,48 +7,48 @@ using System.Text;
 
 namespace Microsoft.Research.DataStructures
 {
-  public struct TypedKey<T>
-  {
-    string key;
-    public TypedKey(string key)
+    public struct TypedKey<T>
     {
-      this.key = key;
-    }
-  }
-
-  public interface ITypedProperties
-  {
-    bool Contains<T>(TypedKey<T> key);
-
-    void Add<T>(TypedKey<T> key, T value);
-
-    bool TryGetValue<T>(TypedKey<T> key, out T value);
-  }
-
-  [Serializable]
-  public class TypedProperties : ITypedProperties
-  {
-    System.Collections.Hashtable table = new System.Collections.Hashtable();
-
-    public bool Contains<T>(TypedKey<T> key)
-    {
-      return table.Contains(key);
+        private string key;
+        public TypedKey(string key)
+        {
+            this.key = key;
+        }
     }
 
-    public void Add<T>(TypedKey<T> key, T value)
+    public interface ITypedProperties
     {
-      this.table.Add(key, value);
+        bool Contains<T>(TypedKey<T> key);
+
+        void Add<T>(TypedKey<T> key, T value);
+
+        bool TryGetValue<T>(TypedKey<T> key, out T value);
     }
 
-    public bool TryGetValue<T>(TypedKey<T> key, out T value)
+    [Serializable]
+    public class TypedProperties : ITypedProperties
     {
-      object result = table[key];
-      if (result == null)
-      {
-        value = default(T); return false;
-      }
-      value = (T)result;
-      return true;
+        private System.Collections.Hashtable table = new System.Collections.Hashtable();
+
+        public bool Contains<T>(TypedKey<T> key)
+        {
+            return table.Contains(key);
+        }
+
+        public void Add<T>(TypedKey<T> key, T value)
+        {
+            table.Add(key, value);
+        }
+
+        public bool TryGetValue<T>(TypedKey<T> key, out T value)
+        {
+            object result = table[key];
+            if (result == null)
+            {
+                value = default(T); return false;
+            }
+            value = (T)result;
+            return true;
+        }
     }
-  }
 }

--- a/Microsoft.Research/DataStructures/WorkList.cs
+++ b/Microsoft.Research/DataStructures/WorkList.cs
@@ -1,179 +1,184 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Research.DataStructures {
-
-  public interface IWorkList<T> {
-    bool Add(T o);
-    bool IsEmpty { get; }
-    T Pull();
-  }
-
-  [ContractVerification(true)]
-  [ContractClass(typeof(AbstrWorkListContracts<>))]
-  public abstract class AbstrWorkList<T> : IWorkList<T> {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+namespace Microsoft.Research.DataStructures
+{
+    public interface IWorkList<T>
     {
-      Contract.Invariant(this.elems != null);
+        bool Add(T o);
+        bool IsEmpty { get; }
+        T Pull();
     }
 
-    // set of worklist members - for quick membership testing
-    protected Set<T> elems = new Set<T>();
-    // collection of worklist elements - this provides the order
-    protected abstract IEnumerable<T> coll { get; }
-
-    public bool Add(T o) {
-      if (!elems.AddQ(o)) return false;
-      this.AddInternal(o);
-      return true;
-    }
-
-    protected abstract void AddInternal(T o);
-    public virtual bool AddAll(IEnumerable<T> objs) {
-      Contract.Requires(objs != null);
-      
-      bool result = false;
-      foreach (T obj in objs)
-        if (Add(obj)) result = true;
-      return result;
-    }
-
-    public virtual bool IsEmpty {
-      get
-      {
-        Contract.Ensures(Contract.Result<bool>() == (this.Count == 0));
-
-        return elems.Count == 0;
-      }
-    }
-
-    public abstract T Pull();
-    public virtual IEnumerator<T> GetEnumerator() {
-      return coll.GetEnumerator();
-    }
-
-    public virtual int Count
+    [ContractVerification(true)]
+    [ContractClass(typeof(AbstrWorkListContracts<>))]
+    public abstract class AbstrWorkList<T> : IWorkList<T>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() == elems.Count);
-        return elems.Count;
-      }
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.elems != null);
+        }
+
+        // set of worklist members - for quick membership testing
+        protected Set<T> elems = new Set<T>();
+        // collection of worklist elements - this provides the order
+        protected abstract IEnumerable<T> coll { get; }
+
+        public bool Add(T o)
+        {
+            if (!elems.AddQ(o)) return false;
+            this.AddInternal(o);
+            return true;
+        }
+
+        protected abstract void AddInternal(T o);
+        public virtual bool AddAll(IEnumerable<T> objs)
+        {
+            Contract.Requires(objs != null);
+
+            bool result = false;
+            foreach (T obj in objs)
+                if (Add(obj)) result = true;
+            return result;
+        }
+
+        public virtual bool IsEmpty
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<bool>() == (this.Count == 0));
+
+                return elems.Count == 0;
+            }
+        }
+
+        public abstract T Pull();
+        public virtual IEnumerator<T> GetEnumerator()
+        {
+            return coll.GetEnumerator();
+        }
+
+        public virtual int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() == elems.Count);
+                return elems.Count;
+            }
+        }
     }
-  }
 
 
-  [ContractClassFor(typeof(AbstrWorkList<>))]
-  abstract class AbstrWorkListContracts<T> : AbstrWorkList<T>
-  {
-    protected override IEnumerable<T> coll
+    [ContractClassFor(typeof(AbstrWorkList<>))]
+    internal abstract class AbstrWorkListContracts<T> : AbstrWorkList<T>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<T>>() != null);
+        protected override IEnumerable<T> coll
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<T>>() != null);
 
-        throw new NotImplementedException();
-      }
+                throw new NotImplementedException();
+            }
+        }
+
+        abstract protected override void AddInternal(T o);
+
+        abstract public override T Pull();
     }
 
-    abstract protected override void AddInternal(T o);
-
-    abstract public override T Pull();
-  }
-
-  /// <summary>
-  /// Stack-based implementation of IWorkList.
-  /// </summary>
-  [ContractVerification(true)]
-  public sealed class WorkStack<T> : AbstrWorkList<T> {
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    /// <summary>
+    /// Stack-based implementation of IWorkList.
+    /// </summary>
+    [ContractVerification(true)]
+    public sealed class WorkStack<T> : AbstrWorkList<T>
     {
-      Contract.Invariant(this.stack != null);
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(stack != null);
+        }
+
+        readonly private Stack<T> stack;
+
+        protected override IEnumerable<T> coll
+        {
+            get
+            {
+                return stack;
+            }
+        }
+
+        public WorkStack()
+        {
+            stack = new Stack<T>();
+        }
+
+        protected override void AddInternal(T o)
+        {
+            stack.Push(o);
+        }
+
+        public override T Pull()
+        {
+            // F: I've added it: it is unclear why stack should not be empty at this point
+            if (stack.Count == 0)
+                throw new InvalidOperationException();
+
+            T result = stack.Pop();
+            elems.Remove(result);
+            return result;
+        }
     }
 
-    readonly private Stack<T> stack;
 
-    protected override IEnumerable<T> coll {
-      get {
-        return stack;
-      }
-    }
-
-    public WorkStack() {
-      this.stack = new Stack<T>();
-    }
-
-    protected override void AddInternal(T o) {
-      stack.Push(o);
-    }
-
-    public override T Pull() {
-      // F: I've added it: it is unclear why stack should not be empty at this point
-      if (stack.Count == 0)
-        throw new InvalidOperationException();
-
-      T result = stack.Pop();
-      elems.Remove(result);
-      return result;
-    }
-
-  }
-
-
-  /// <summary>
-  /// Queue-based implementation of IWorkList.
-  /// </summary>
-  [ContractVerification(true)]
-  public sealed class WorkList<T> : AbstrWorkList<T> {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    /// <summary>
+    /// Queue-based implementation of IWorkList.
+    /// </summary>
+    [ContractVerification(true)]
+    public sealed class WorkList<T> : AbstrWorkList<T>
     {
-      Contract.Invariant(this.queue != null);
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(queue != null);
+        }
+
+        readonly private Queue<T> queue;
+
+        protected override IEnumerable<T> coll
+        {
+            get
+            {
+                return queue;
+            }
+        }
+
+        public WorkList()
+        {
+            queue = new Queue<T>();
+        }
+
+        protected override void AddInternal(T o)
+        {
+            queue.Enqueue(o);
+        }
+
+        public override T Pull()
+        {
+            // F: I've added it: it is unclear why queue should not be empty at this point
+            if (queue.Count == 0)
+                throw new InvalidOperationException();
+
+            T o = queue.Dequeue();
+            elems.Remove(o);
+            return o;
+        }
     }
-
-    readonly private Queue<T> queue;
-
-    protected override IEnumerable<T> coll {
-      get {
-        return queue;
-      }
-    }
-
-    public WorkList() {
-      queue = new Queue<T>();
-    }
-
-    protected override void AddInternal(T o) {
-      queue.Enqueue(o);
-    }
-
-    public override T Pull() {
-      // F: I've added it: it is unclear why queue should not be empty at this point
-      if (queue.Count == 0)
-        throw new InvalidOperationException();
-
-      T o = queue.Dequeue();
-      elems.Remove(o);
-      return o;
-    }
-  }
 }


### PR DESCRIPTION
This reformat operation used dotnet/codeformatter@1d719e4e with `/rule-:FieldNames`.