### PR TITLE
Reformat code in Foxtrot.Extractor

### DIFF
--- a/Foxtrot/Foxtrot/AssemblyResolver.cs
+++ b/Foxtrot/Foxtrot/AssemblyResolver.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,29 +11,29 @@ namespace Microsoft.Contracts.Foxtrot
 {
     public class AssemblyResolver
     {
-        public string[] EmptyExt = new[] {""};
-        public string[] DllExt = new[] {".dll", ".winmd"};
-        public string[] DllAndExeExt = new[] {".dll", ".winmd", ".exe"};
-        public string[] EmptyAndDllExt = new[] {"", ".dll", ".winmd"};
-        public string[] AllExt = new[] {"", ".dll", ".winmd", ".exe"};
+        public string[] EmptyExt = new[] { "" };
+        public string[] DllExt = new[] { ".dll", ".winmd" };
+        public string[] DllAndExeExt = new[] { ".dll", ".winmd", ".exe" };
+        public string[] EmptyAndDllExt = new[] { "", ".dll", ".winmd" };
+        public string[] AllExt = new[] { "", ".dll", ".winmd", ".exe" };
 
-        private IEnumerable<string> resolvedPaths;
-        private IEnumerable<string> libpaths;
-        
-        private bool trace;
-        private bool usePDB;
-        private bool preserveShortBranches;
-        private Action<AssemblyResolver, AssemblyNode> postLoad;
+        private IEnumerable<string> _resolvedPaths;
+        private IEnumerable<string> _libpaths;
+
+        private bool _trace;
+        private bool _usePDB;
+        private bool _preserveShortBranches;
+        private Action<AssemblyResolver, AssemblyNode> _postLoad;
 
         public AssemblyResolver(IEnumerable<string> resolvedPaths, IEnumerable<string> libpaths, bool usePDB,
             bool preserveShortBranches, bool trace, Action<AssemblyResolver, AssemblyNode> postLoad)
         {
-            this.resolvedPaths = resolvedPaths;
-            this.libpaths = libpaths;
-            this.trace = trace;
-            this.usePDB = usePDB;
-            this.preserveShortBranches = preserveShortBranches;
-            this.postLoad = postLoad;
+            _resolvedPaths = resolvedPaths;
+            _libpaths = libpaths;
+            _trace = trace;
+            _usePDB = usePDB;
+            _preserveShortBranches = preserveShortBranches;
+            _postLoad = postLoad;
         }
 
         /// <summary>
@@ -66,7 +55,7 @@ namespace Microsoft.Contracts.Foxtrot
             AssemblyNode a = null;
             try
             {
-                if (trace)
+                if (_trace)
                 {
                     LoadTracing(string.Format("Attempting to load: {0}", assemblyName));
                 }
@@ -83,9 +72,9 @@ namespace Microsoft.Contracts.Foxtrot
                 // Check user-supplied candidate paths
 
                 LoadTracing("AssemblyResolver: Attempting user-supplied candidates.");
-                if (this.resolvedPaths != null)
+                if (_resolvedPaths != null)
                 {
-                    foreach (string candidate in this.resolvedPaths)
+                    foreach (string candidate in _resolvedPaths)
                     {
                         var candidateAssemblyName = Path.GetFileNameWithoutExtension(candidate);
                         if (String.Compare(candidateAssemblyName, assemblyName, StringComparison.OrdinalIgnoreCase) != 0)
@@ -101,7 +90,7 @@ namespace Microsoft.Contracts.Foxtrot
 
                 if (a == null)
                 {
-                    if (this.resolvedPaths != null)
+                    if (_resolvedPaths != null)
                     {
                     }
                 }
@@ -113,9 +102,9 @@ namespace Microsoft.Contracts.Foxtrot
                 // Check user-supplied search directories
 
                 LoadTracing("AssemblyResolver: Attempting user-supplied directories.");
-                if (this.libpaths != null)
+                if (_libpaths != null)
                 {
-                    foreach (string dir in this.libpaths)
+                    foreach (string dir in _libpaths)
                     {
                         a = ProbeForAssemblyWithExtension(dir, assemblyName, exts);
                         if (a != null)
@@ -125,7 +114,7 @@ namespace Microsoft.Contracts.Foxtrot
 
                 if (a == null)
                 {
-                    if (this.libpaths != null)
+                    if (_libpaths != null)
                     {
                     }
                 }
@@ -140,7 +129,7 @@ namespace Microsoft.Contracts.Foxtrot
                 {
                     a = ProbeForAssemblyWithExtension(referencingModuleDirectory, assemblyName, exts);
                 }
-                
+
                 if (a == null)
                 {
                     if (referencingModuleDirectory != null)
@@ -204,7 +193,7 @@ namespace Microsoft.Contracts.Foxtrot
                     break;
                 }
             } while (!string.IsNullOrWhiteSpace(directory));
-            
+
             return null;
         }
 
@@ -212,10 +201,10 @@ namespace Microsoft.Contracts.Foxtrot
         {
             foreach (string ext in exts)
             {
-                bool tempDebugInfo = this.usePDB;
+                bool tempDebugInfo = _usePDB;
                 string fullName = Path.Combine(directory, assemblyName + ext);
-                
-                if (this.trace)
+
+                if (_trace)
                 {
                     LoadTracing(String.Format("Attempting load from {0}", fullName));
                 }
@@ -241,7 +230,7 @@ namespace Microsoft.Contracts.Foxtrot
                         }
                     }
 
-                    if (this.trace)
+                    if (_trace)
                     {
                         LoadTracing(string.Format("Resolved assembly reference '{0}' to '{1}'. (Using directory {2})",
                             assemblyName, fullName, directory));
@@ -253,7 +242,7 @@ namespace Microsoft.Contracts.Foxtrot
                         true, // doNotLockFile
                         tempDebugInfo, // getDebugInfo
                         true, // useGlobalCache
-                        this.preserveShortBranches, // preserveShortBranches
+                        _preserveShortBranches, // preserveShortBranches
                         this.PostLoadHook
                         );
 
@@ -270,12 +259,12 @@ namespace Microsoft.Contracts.Foxtrot
 
             if (!SystemTypes.IsInitialized) return;
 
-            if (this.postLoad != null) this.postLoad(this, assemblyNode);
+            if (_postLoad != null) _postLoad(this, assemblyNode);
         }
 
         private void LoadTracing(string msg)
         {
-            if (this.trace)
+            if (_trace)
             {
                 Console.WriteLine("Trace: {0}", msg);
             }
@@ -323,7 +312,7 @@ namespace Microsoft.Contracts.Foxtrot
                     if (string.IsNullOrEmpty(path.Trim())) continue;
 
                     var candidate = Path.GetFullPath(path);
-                    
+
                     if (candidate.EndsWith(@"\mscorlib.dll") && File.Exists(candidate))
                     {
                         return candidate;

--- a/Foxtrot/Foxtrot/Cache.cs
+++ b/Foxtrot/Foxtrot/Cache.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 
@@ -19,32 +8,32 @@ namespace Microsoft.Contracts.Foxtrot
     // TODO ST: consider replacing this struct by Lazy<T>
     public struct Cache<T>
     {
-        private T cache;
-        private Func<T> compute;
-        private bool initialized;
+        private T _cache;
+        private Func<T> _compute;
+        private bool _initialized;
 
         public Cache(Func<T> compute)
         {
-            this.compute = compute;
-            this.initialized = true;
-            cache = default(T);
+            _compute = compute;
+            _initialized = true;
+            _cache = default(T);
         }
 
         public bool IsInitialized
         {
-            get { return this.initialized; }
+            get { return _initialized; }
         }
 
         public T Value
         {
             get
             {
-                if (compute != null)
+                if (_compute != null)
                 {
-                    cache = compute();
-                    compute = null;
+                    _cache = _compute();
+                    _compute = null;
                 }
-                return cache;
+                return _cache;
             }
         }
     }

--- a/Foxtrot/Foxtrot/Checker/Error.cs
+++ b/Foxtrot/Foxtrot/Checker/Error.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 using System.Compiler;

--- a/Foxtrot/Foxtrot/Checker/PostExtractorChecker.cs
+++ b/Foxtrot/Foxtrot/Checker/PostExtractorChecker.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;
@@ -26,26 +15,26 @@ namespace Microsoft.Contracts.Foxtrot
     [ContractVerification(false)] // F:
     public sealed class PostExtractorChecker : Inspector
     {
-        private readonly Action<System.CodeDom.Compiler.CompilerError> m_errorHandler;
-        private readonly bool allowPreconditionsInOverrides;
-        private readonly bool explicitUserValidations;
-        private readonly bool addInterfaceWrappersWhenNeeded;
+        private readonly Action<System.CodeDom.Compiler.CompilerError> _errorHandler;
+        private readonly bool _allowPreconditionsInOverrides;
+        private readonly bool _explicitUserValidations;
+        private readonly bool _addInterfaceWrappersWhenNeeded;
 
         /// <summary>
         /// Identical to the runtime checking level option.
         /// Instrumentation level: 0=no contracts, 1=ReleaseRequires, 2=Requires, 3=Ensures, 4=Invariants. (Each increase includes the previous)
         /// </summary>
-        private readonly int runtimeCheckingLevel = 4; // all contracts
+        private readonly int _runtimeCheckingLevel = 4; // all contracts
 
-        private readonly PurityChecker purityChecker;
-        private readonly PreconditionChecker preconditionChecker;
-        private readonly PostconditionChecker postconditionChecker;
-        private readonly VisibilityChecker visibilityChecker;
-        private readonly CheckForCallsToInvariantMethods invariantCallChecker;
-        private readonly MethodBodyChecker methodBodyChecker;
-        private readonly InvariantChecker invariantChecker;
-        private readonly ContractNodes contractNodes;
-        private CurrentState currentState;
+        private readonly PurityChecker _purityChecker;
+        private readonly PreconditionChecker _preconditionChecker;
+        private readonly PostconditionChecker _postconditionChecker;
+        private readonly VisibilityChecker _visibilityChecker;
+        private readonly CheckForCallsToInvariantMethods _invariantCallChecker;
+        private readonly MethodBodyChecker _methodBodyChecker;
+        private readonly InvariantChecker _invariantChecker;
+        private readonly ContractNodes _contractNodes;
+        private CurrentState _currentState;
 
         [ContractVerification(false)] // F: todo
         private struct CurrentState
@@ -54,81 +43,81 @@ namespace Microsoft.Contracts.Foxtrot
             public readonly Method Method;
             public readonly TypeNode Type;
 
-            private Dictionary<string, object> typeSuppressed;
-            private Dictionary<string, object> methodSuppressed;
-            private Dictionary<string, object> assemblySuppressed;
+            private Dictionary<string, object> _typeSuppressed;
+            private Dictionary<string, object> _methodSuppressed;
+            private Dictionary<string, object> _assemblySuppressed;
 
             public CurrentState(AssemblyNode assembly)
             {
                 this.Assembly = assembly;
                 this.Type = null;
                 this.Method = null;
-                this.assemblySuppressed = null;
-                this.typeSuppressed = null;
-                this.methodSuppressed = null;
+                _assemblySuppressed = null;
+                _typeSuppressed = null;
+                _methodSuppressed = null;
             }
 
             private CurrentState(Method method, CurrentState oldState)
             {
                 this.Assembly = oldState.Assembly;
-                this.assemblySuppressed = oldState.assemblySuppressed;
+                _assemblySuppressed = oldState._assemblySuppressed;
                 this.Type = oldState.Type;
-                this.typeSuppressed = oldState.typeSuppressed;
+                _typeSuppressed = oldState._typeSuppressed;
                 this.Method = method;
-                this.methodSuppressed = null;
+                _methodSuppressed = null;
             }
 
             public CurrentState(TypeNode type, CurrentState oldState)
             {
                 this.Type = type;
                 this.Method = null;
-                this.typeSuppressed = null;
-                this.methodSuppressed = null;
+                _typeSuppressed = null;
+                _methodSuppressed = null;
                 this.Assembly = oldState.Assembly;
-                this.assemblySuppressed = oldState.assemblySuppressed;
+                _assemblySuppressed = oldState._assemblySuppressed;
             }
 
             public bool IsSuppressed(string errorNumber)
             {
-                if (this.Assembly != null && this.assemblySuppressed == null)
+                if (this.Assembly != null && _assemblySuppressed == null)
                 {
-                    this.assemblySuppressed = new Dictionary<string, object>();
-                    GrabSuppressAttributes(this.assemblySuppressed, this.Assembly.Attributes);
+                    _assemblySuppressed = new Dictionary<string, object>();
+                    GrabSuppressAttributes(_assemblySuppressed, this.Assembly.Attributes);
                 }
 
-                if (this.assemblySuppressed != null && this.assemblySuppressed.ContainsKey(errorNumber)) return true;
+                if (_assemblySuppressed != null && _assemblySuppressed.ContainsKey(errorNumber)) return true;
 
-                if (this.Type != null && this.typeSuppressed == null)
+                if (this.Type != null && _typeSuppressed == null)
                 {
-                    this.typeSuppressed = GrabSuppressAttributes(this.Type);
+                    _typeSuppressed = GrabSuppressAttributes(this.Type);
                 }
-                
-                if (this.typeSuppressed != null && this.typeSuppressed.ContainsKey(errorNumber)) return true;
 
-                if (this.Method != null && this.methodSuppressed == null)
+                if (_typeSuppressed != null && _typeSuppressed.ContainsKey(errorNumber)) return true;
+
+                if (this.Method != null && _methodSuppressed == null)
                 {
-                    this.methodSuppressed = GrabSuppressAttributes(this.Method);
+                    _methodSuppressed = GrabSuppressAttributes(this.Method);
                 }
-                
-                if (this.methodSuppressed != null && this.methodSuppressed.ContainsKey(errorNumber)) return true;
+
+                if (_methodSuppressed != null && _methodSuppressed.ContainsKey(errorNumber)) return true;
 
                 return false;
             }
 
-            private static readonly Identifier SuppressMessageIdentifier = Identifier.For("SuppressMessageAttribute");
+            private static readonly Identifier s_suppressMessageIdentifier = Identifier.For("SuppressMessageAttribute");
             // Should be thread-safe
 
             private static Dictionary<string, object> GrabSuppressAttributes(Method method)
             {
                 var result = new Dictionary<string, object>();
-                
+
                 GrabSuppressAttributes(result, method.Attributes);
-                
+
                 if (method.DeclaringMember != null)
                 {
                     GrabSuppressAttributes(result, method.DeclaringMember.Attributes);
                 }
-                
+
                 return result;
             }
 
@@ -153,10 +142,10 @@ namespace Microsoft.Contracts.Foxtrot
                         var attr = attributes[i];
 
                         if (attr == null) continue;
-                        
+
                         if (attr.Type == null) continue;
-                        
-                        if (attr.Type.Name.Matches(SuppressMessageIdentifier))
+
+                        if (attr.Type.Name.Matches(s_suppressMessageIdentifier))
                         {
                             if (attr.Expressions != null && attr.Expressions.Count >= 2)
                             {
@@ -165,14 +154,14 @@ namespace Microsoft.Contracts.Foxtrot
 
                                 string category = expr.Value as string;
                                 if (category != "Microsoft.Contracts") continue;
-                                
+
                                 var errorCode = attr.Expressions[1] as Literal;
                                 if (errorCode == null) continue;
-                                
+
                                 string errorCodeLit = errorCode.Value as string;
-                                
+
                                 Contract.Assume(errorCodeLit != null); // F:
-                                
+
                                 if (errorCodeLit.StartsWith("CC"))
                                 {
                                     result.Add(errorCodeLit, errorCodeLit);
@@ -198,13 +187,13 @@ namespace Microsoft.Contracts.Foxtrot
          System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic"), ContractInvariantMethod]
         private void ObjectInvariant()
         {
-            Contract.Invariant(m_errorHandler != null);
-            Contract.Invariant(purityChecker != null);
-            Contract.Invariant(invariantChecker != null);
-            Contract.Invariant(methodBodyChecker != null);
-            Contract.Invariant(visibilityChecker != null);
-            Contract.Invariant(this.invariantMethods != null);
-            Contract.Invariant(this.contractNodes != null);
+            Contract.Invariant(_errorHandler != null);
+            Contract.Invariant(_purityChecker != null);
+            Contract.Invariant(_invariantChecker != null);
+            Contract.Invariant(_methodBodyChecker != null);
+            Contract.Invariant(_visibilityChecker != null);
+            Contract.Invariant(_invariantMethods != null);
+            Contract.Invariant(_contractNodes != null);
         }
 
         [ContractVerification(true)]
@@ -217,21 +206,21 @@ namespace Microsoft.Contracts.Foxtrot
             Contract.Requires(errorHandler != null);
             Contract.Requires(usedToExtract != null);
 
-            this.m_errorHandler = errorHandler;
-            this.allowPreconditionsInOverrides = allowPreconditionsInOverrides;
-            this.explicitUserValidations = explicitUserValidations;
-            this.addInterfaceWrappersWhenNeeded = addInterfaceWrappersWhenNeeded;
-            this.runtimeCheckingLevel = runtimeCheckingLevel;
+            _errorHandler = errorHandler;
+            _allowPreconditionsInOverrides = allowPreconditionsInOverrides;
+            _explicitUserValidations = explicitUserValidations;
+            _addInterfaceWrappersWhenNeeded = addInterfaceWrappersWhenNeeded;
+            _runtimeCheckingLevel = runtimeCheckingLevel;
 
-            this.purityChecker = new PurityChecker(this.HandleError, fSharp, usedToExtract);
-            this.preconditionChecker = new PreconditionChecker(this.HandleError, usedToExtract);
-            this.postconditionChecker = new PostconditionChecker(this.HandleError, fSharp);
-            this.invariantCallChecker = new CheckForCallsToInvariantMethods(this);
-            this.methodBodyChecker = new MethodBodyChecker(this.HandleError, usedToExtract);
-            this.invariantChecker = new InvariantChecker(this.HandleError, usedToExtract);
-            this.contractNodes = usedToExtract;
-            this.visibilityChecker = new VisibilityChecker(this.HandleError, usedToExtract);
-            this.invariantMethods = new TrivialHashtable(0);
+            _purityChecker = new PurityChecker(this.HandleError, fSharp, usedToExtract);
+            _preconditionChecker = new PreconditionChecker(this.HandleError, usedToExtract);
+            _postconditionChecker = new PostconditionChecker(this.HandleError, fSharp);
+            _invariantCallChecker = new CheckForCallsToInvariantMethods(this);
+            _methodBodyChecker = new MethodBodyChecker(this.HandleError, usedToExtract);
+            _invariantChecker = new InvariantChecker(this.HandleError, usedToExtract);
+            _contractNodes = usedToExtract;
+            _visibilityChecker = new VisibilityChecker(this.HandleError, usedToExtract);
+            _invariantMethods = new TrivialHashtable(0);
         }
 
 
@@ -240,9 +229,9 @@ namespace Microsoft.Contracts.Foxtrot
         /// </summary>
         private void HandleError(CompilerError error)
         {
-            if (error.IsWarning && this.currentState.IsSuppressed(error.ErrorNumber)) return;
-            
-            this.m_errorHandler(error);
+            if (error.IsWarning && _currentState.IsSuppressed(error.ErrorNumber)) return;
+
+            _errorHandler(error);
         }
 
         /// <summary>
@@ -261,7 +250,7 @@ namespace Microsoft.Contracts.Foxtrot
             }
 
             if (current == method) return null; // no root base method
-            
+
             return current;
         }
 
@@ -272,7 +261,7 @@ namespace Microsoft.Contracts.Foxtrot
             if (t1.TemplateParameters != null)
             {
                 if (t1.TemplateParameters.Count != t2.TemplateParameters.Count) return false;
-                
+
                 for (int i = 0, n = t1.TemplateParameters.Count; i < n; i++)
                 {
                     var tn1 = t1.TemplateParameters[i];
@@ -287,16 +276,16 @@ namespace Microsoft.Contracts.Foxtrot
                     if ((tn1.Interfaces == null) != (tn2.Interfaces == null)) return false;
 
                     if (tn1.Interfaces != null && tn1.Interfaces.Count != tn2.Interfaces.Count) return false;
-                    
+
                     TypeParameter tp1 = tn1 as TypeParameter;
-                    
+
                     if (tp1 != null)
                     {
                         var tp2 = tn2 as TypeParameter;
                         if (tp2 == null) return false;
 
                         if (tp1.IsReferenceType != tp2.IsReferenceType) return false;
-                        
+
                         if (tp1.IsValueType != tp2.IsValueType) return false;
 
                         if ((tp1.TypeParameterFlags & TypeParameterFlags.DefaultConstructorConstraint) !=
@@ -311,9 +300,9 @@ namespace Microsoft.Contracts.Foxtrot
                     {
                         var cp2 = tn2 as ClassParameter;
                         if (cp2 == null) return false;
-                        
+
                         if (cp1.IsReferenceType != cp2.IsReferenceType) return false;
-                        
+
                         if (cp1.IsValueType != cp2.IsValueType) return false;
 
                         if ((cp1.TypeParameterFlags & TypeParameterFlags.DefaultConstructorConstraint) !=
@@ -496,8 +485,8 @@ namespace Microsoft.Contracts.Foxtrot
                 // F:
                 Contract.Assume(typeNode.Contract.Invariants != null);
 
-                this.purityChecker.CheckInvariants(typeNode, typeNode.Contract.Invariants);
-                this.invariantChecker.Check(typeNode);
+                _purityChecker.CheckInvariants(typeNode, typeNode.Contract.Invariants);
+                _invariantChecker.Check(typeNode);
             }
 
             // Make sure that if this class has a contractClass, that that class points back to this one
@@ -573,14 +562,14 @@ namespace Microsoft.Contracts.Foxtrot
                     {
                         Member mem = mems[i];
                         Field f = mem as Field;
-                        
+
                         if (f != null)
                         {
                             if (!f.IsPublic) continue;
 
                             //if (f.Type != field.Type) continue; // REVIEW: When it becomes possible, allow widening
                             error = false;
-                            
+
                             break;
                         }
 
@@ -588,14 +577,14 @@ namespace Microsoft.Contracts.Foxtrot
                         if (p != null)
                         {
                             Method getter = p.Getter;
-                            
+
                             if (getter == null) continue; // found by Clousot.
-                            
+
                             if (!getter.IsPublic) continue;
-                            
+
                             //if (getter.ReturnType != field.Type) continue; // REVIEW: When it becomes possible, allow widening
                             error = false;
-                            
+
                             break;
                         }
                     }
@@ -631,9 +620,9 @@ namespace Microsoft.Contracts.Foxtrot
             while (method.Template != null) method = method.Template;
 
             var declType = method.DeclaringType;
-            
+
             if (declType == null) return method;
-            
+
             if (!declType.IsAbstract) return method; // only abstract types and interfaces can have OOB
 
             // get rid of instantiations
@@ -651,18 +640,18 @@ namespace Microsoft.Contracts.Foxtrot
                     if (attr == null) continue;
 
                     if (attr.Type == null) continue;
-                    
+
                     if (attr.Type.Name == null) continue;
-                    
+
                     if (attr.Type.Name.Name != "ContractClassAttribute") continue;
 
                     if (attr.Expressions == null) return method;
-                    
+
                     Literal lit = attr.Expressions[0] as Literal;
-                    
+
                     if (lit == null) return method; // not found
                     TypeNode t = lit.Value as TypeNode;
-                    
+
                     if (t == null) return method; // not found
                     if (t.Template != null)
                     {
@@ -707,7 +696,7 @@ namespace Microsoft.Contracts.Foxtrot
                 for (int i = 0; i < method.ShallowImplicitlyImplementedInterfaceMethods.Count; i++)
                 {
                     var intfMethod = method.ShallowImplicitlyImplementedInterfaceMethods[i];
-                    
+
                     if (intfMethod != null) yield return intfMethod;
                 }
             }
@@ -717,31 +706,32 @@ namespace Microsoft.Contracts.Foxtrot
         private static bool ImplementsAnyInterfaces(Method rootMethod)
         {
             Contract.Requires(rootMethod != null);
-            
+
             if (rootMethod.ImplementedInterfaceMethods != null && rootMethod.ImplementedInterfaceMethods.Count > 0)
                 return true;
-            
+
             if (rootMethod.ImplicitlyImplementedInterfaceMethods != null &&
-                rootMethod.ImplicitlyImplementedInterfaceMethods.Count > 0) return true;
-            
+                rootMethod.ImplicitlyImplementedInterfaceMethods.Count > 0)
+                return true;
+
             return false;
         }
 
-        private readonly TrivialHashtable invariantMethods;
+        private readonly TrivialHashtable _invariantMethods;
 
         [ContractVerification(true)]
         public override void VisitMethod(Method method)
         {
             if (method == null) return;
-            
+
             // closures used from methods are visited from the method from which they are referenced
             if (HelperMethods.IsCompilerGenerated(method)) return;
 
-            var savedState = this.currentState;
+            var savedState = _currentState;
             try
             {
-                this.currentState = savedState.Derive(method);
-                if (this.contractNodes.IsObjectInvariantMethod(method))
+                _currentState = savedState.Derive(method);
+                if (_contractNodes.IsObjectInvariantMethod(method))
                 {
                     return;
                 }
@@ -801,8 +791,8 @@ namespace Microsoft.Contracts.Foxtrot
                     }
 
                     // abbreviator code must be completely visible to all callers as it is effectively inlined there.
-                    this.visibilityChecker.CheckRequires(method.Contract);
-                    this.visibilityChecker.CheckAbbreviatorEnsures(method.Contract);
+                    _visibilityChecker.CheckRequires(method.Contract);
+                    _visibilityChecker.CheckAbbreviatorEnsures(method.Contract);
 
                     return; // no further checks as we check the rest in use-site methods.
                 }
@@ -813,21 +803,21 @@ namespace Microsoft.Contracts.Foxtrot
 
                 // Check purity
 
-                this.purityChecker.Check(method);
+                _purityChecker.Check(method);
 
                 // Check Method Body
 
-                this.methodBodyChecker.Check(method);
+                _methodBodyChecker.Check(method);
 
                 SourceContext sourceContext = HelperMethods.SourceContextOfMethod(method);
-                
+
                 Method firstRootMethod = null;
 
                 var methodDeclaringType = method.DeclaringType;
 
                 Contract.Assume(methodDeclaringType != null);
-                
-                TypeNode classForWhichThisIsContractMethod = HelperMethods.IsContractTypeForSomeOtherType(methodDeclaringType, this.contractNodes);
+
+                TypeNode classForWhichThisIsContractMethod = HelperMethods.IsContractTypeForSomeOtherType(methodDeclaringType, _contractNodes);
 
                 foreach (var rootMethod in RootMethodsForRequires(method))
                 {
@@ -844,7 +834,7 @@ namespace Microsoft.Contracts.Foxtrot
                                     string.Format(
                                         "Contract class {2} cannot define contract for method {0} as its original definition is not in type {1}. Define the contract on type {3} instead.",
                                         rootMethod.FullName, classForWhichThisIsContractMethod, methodDeclaringType.FullName,
-                                        rootMethod.DeclaringType), 
+                                        rootMethod.DeclaringType),
                                     sourceContext));
 
                             continue;
@@ -856,7 +846,7 @@ namespace Microsoft.Contracts.Foxtrot
                                 new Error(1077,
                                     string.Format(
                                         "Contract class {1} cannot define contract for non-abstract method {0}. Define the contract on {0} instead.",
-                                        rootMethod.FullName, methodDeclaringType.FullName), 
+                                        rootMethod.FullName, methodDeclaringType.FullName),
                                     sourceContext));
 
                             continue;
@@ -866,7 +856,7 @@ namespace Microsoft.Contracts.Foxtrot
                         continue;
                     }
 
-                    if (!allowPreconditionsInOverrides)
+                    if (!_allowPreconditionsInOverrides)
                     {
                         // Overrides cannot add preconditions unless this is "the" contract method for an abstract method
 
@@ -876,21 +866,21 @@ namespace Microsoft.Contracts.Foxtrot
                             {
                                 if (req == null) continue;
 
-                                if (!this.explicitUserValidations || !req.IsFromValidation)
+                                if (!_explicitUserValidations || !req.IsFromValidation)
                                 {
                                     SourceContext sc = req.SourceContext;
                                     if (rootMethod.DeclaringType is Interface)
                                     {
                                         this.HandleError(
                                             new Warning(1033,
-                                                string.Format( "Method '{0}' implements interface method '{1}', thus cannot add Requires.", method.FullName, rootMethod.FullName), 
+                                                string.Format("Method '{0}' implements interface method '{1}', thus cannot add Requires.", method.FullName, rootMethod.FullName),
                                                 sc));
                                     }
                                     else
                                     {
                                         this.HandleError(
                                             new Warning(1032,
-                                                string.Format("Method '{0}' overrides '{1}', thus cannot add Requires.", method.FullName, rootMethod.FullName), 
+                                                string.Format("Method '{0}' overrides '{1}', thus cannot add Requires.", method.FullName, rootMethod.FullName),
                                                 sc));
                                     }
 
@@ -927,20 +917,20 @@ namespace Microsoft.Contracts.Foxtrot
 
                     // Check that validations are present if necessary
 
-                    if (this.explicitUserValidations && !HasValidations(method.Contract))
+                    if (_explicitUserValidations && !HasValidations(method.Contract))
                     {
                         var rootMethodContract = GetMethodWithContractFor(rootMethod).Contract;
                         if (rootMethodContract != null)
                         {
                             for (int i = 0; i < rootMethodContract.RequiresCount; i++)
                             {
-                                var req = (RequiresPlain) rootMethodContract.Requires[i];
+                                var req = (RequiresPlain)rootMethodContract.Requires[i];
                                 if (req == null) continue;
 
                                 if (!req.IsWithException) continue;
-                                
+
                                 var operation = (rootMethod.DeclaringType is Interface) ? "implements" : "overrides";
-                                
+
                                 if (req.SourceConditionText != null && req.ExceptionType.Name != null)
                                 {
                                     this.HandleError(new Warning(1055,
@@ -990,30 +980,30 @@ namespace Microsoft.Contracts.Foxtrot
 
                 // Explicit parameter validations should not use Requires<E>
 
-                if (this.explicitUserValidations && method.Contract != null)
+                if (_explicitUserValidations && method.Contract != null)
                 {
                     for (int i = 0; i < method.Contract.RequiresCount; i++)
                     {
-                        var req = (RequiresPlain) method.Contract.Requires[i];
+                        var req = (RequiresPlain)method.Contract.Requires[i];
                         if (req == null) continue;
 
                         if (req.IsFromValidation) continue;
-                        
+
                         if (!req.IsWithException) continue;
-                        
+
                         // found Requires<E>
                         this.HandleError(new Error(1058,
                             String.Format(
                                 "Method '{0}' should not have Requires<E> contract when assembly mode is set to 'Custom Parameter Validation'. Either change it to a legacy if-then-throw validation or change the assembly mode to 'Standard Contract Requires'.",
                                 method.FullName), req.SourceContext));
-                        
+
                         return; // avoid duplicate errors.
                     }
                 }
 
                 // non-user validation assembly
 
-                if (!this.explicitUserValidations && HasValidations(method.Contract))
+                if (!_explicitUserValidations && HasValidations(method.Contract))
                 {
                     if (firstRootMethod != null)
                     {
@@ -1086,7 +1076,7 @@ namespace Microsoft.Contracts.Foxtrot
             }
             finally
             {
-                this.currentState = savedState;
+                _currentState = savedState;
             }
         }
 
@@ -1097,18 +1087,18 @@ namespace Microsoft.Contracts.Foxtrot
 
         private void CheckRequires(MethodContract methodContract)
         {
-            this.preconditionChecker.CheckRequires(methodContract);
-            this.visibilityChecker.CheckRequires(methodContract);
+            _preconditionChecker.CheckRequires(methodContract);
+            _visibilityChecker.CheckRequires(methodContract);
         }
 
         private void CheckEnsures(MethodContract methodContract)
         {
-            this.postconditionChecker.CheckEnsures(methodContract);
+            _postconditionChecker.CheckEnsures(methodContract);
         }
 
         public override void VisitAssembly(AssemblyNode assembly)
         {
-            this.currentState = new CurrentState(assembly);
+            _currentState = new CurrentState(assembly);
 
             if (ContractNodes.IsAlreadyRewritten(assembly))
             {
@@ -1123,9 +1113,9 @@ namespace Microsoft.Contracts.Foxtrot
         {
             if (typeNode == null) return;
 
-            var savedState = this.currentState;
-            this.currentState = savedState.Derive(typeNode);
-            
+            var savedState = _currentState;
+            _currentState = savedState.Derive(typeNode);
+
             try
             {
                 GatherInvariantMethods(typeNode.Members);
@@ -1134,11 +1124,11 @@ namespace Microsoft.Contracts.Foxtrot
 
                 base.VisitTypeNode(typeNode);
 
-                this.invariantCallChecker.VisitMemberList(typeNode.Members);
+                _invariantCallChecker.VisitMemberList(typeNode.Members);
             }
             finally
             {
-                this.currentState = savedState;
+                _currentState = savedState;
             }
         }
 
@@ -1153,9 +1143,9 @@ namespace Microsoft.Contracts.Foxtrot
                 var method = memberList[i] as Method;
                 if (method == null) continue;
 
-                if (this.contractNodes.IsObjectInvariantMethod(method))
+                if (_contractNodes.IsObjectInvariantMethod(method))
                 {
-                    this.invariantMethods[method.UniqueKey] = method;
+                    _invariantMethods[method.UniqueKey] = method;
                 }
             }
         }
@@ -1171,9 +1161,9 @@ namespace Microsoft.Contracts.Foxtrot
         {
             if (Class == null) return;
 
-            var savedState = this.currentState;
+            var savedState = _currentState;
 
-            this.currentState = savedState.Derive(Class);
+            _currentState = savedState.Derive(Class);
 
             try
             {
@@ -1183,7 +1173,7 @@ namespace Microsoft.Contracts.Foxtrot
             }
             finally
             {
-                this.currentState = savedState;
+                _currentState = savedState;
             }
 
             base.VisitClass(Class);
@@ -1195,7 +1185,7 @@ namespace Microsoft.Contracts.Foxtrot
 
             if (Class.Interfaces == null) return;
 
-            if (this.runtimeCheckingLevel == 0) return;
+            if (_runtimeCheckingLevel == 0) return;
 
             if (!HelperMethods.ContractOption(Class, "runtime", "checking") ||
                 !HelperMethods.ContractOption(Class, "contract", "inheritance"))
@@ -1234,13 +1224,13 @@ namespace Microsoft.Contracts.Foxtrot
 
                 var contract = contractMethod.Contract;
                 if (contract == null) continue;
-                
+
                 if (contract.RequiresCount + contract.EnsuresCount == 0) continue;
 
                 // find base implementing method
                 var baseMethod = FindInheritedMethod(Class.BaseClass, intfMethod);
                 if (baseMethod == null) continue;
-                
+
                 var baseMethodImplementsInterfaceMethod = false;
                 if (baseMethod.ImplicitlyImplementedInterfaceMethods != null)
                 {
@@ -1256,9 +1246,9 @@ namespace Microsoft.Contracts.Foxtrot
 
                 if (baseMethodImplementsInterfaceMethod) continue;
 
-                if (this.runtimeCheckingLevel < 3 && contract.RequiresCount == 0) continue;
+                if (_runtimeCheckingLevel < 3 && contract.RequiresCount == 0) continue;
 
-                if (this.addInterfaceWrappersWhenNeeded)
+                if (_addInterfaceWrappersWhenNeeded)
                 {
                     AddInterfaceImplementationWrapper(Class, intfMethod, baseMethod);
                 }
@@ -1276,19 +1266,19 @@ namespace Microsoft.Contracts.Foxtrot
         private static void AddInterfaceImplementationWrapper(Class Class, Method intfMethod, Method baseMethod)
         {
             var d = new Duplicator(Class.DeclaringModule, Class);
-            
+
             d.SkipBodies = true;
 
             var copy = d.VisitMethod(baseMethod);
-            
+
             copy.Flags = MethodFlags.Private | MethodFlags.HideBySig | MethodFlags.Virtual | MethodFlags.NewSlot |
                          MethodFlags.Final;
-            
+
             copy.ImplementedInterfaceMethods = new MethodList(intfMethod);
             copy.Name = Identifier.For("InheritedInterfaceImplementationContractWrapper$" + intfMethod.Name.Name);
             copy.ClearBody();
             copy.ThisParameter.Type = Class;
-            
+
             var bodyBlock = new Block(new StatementList());
             copy.Body = new Block(new StatementList(bodyBlock));
 
@@ -1312,7 +1302,7 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 bodyBlock.Statements.Add(new Return(callExpression));
             }
-            
+
             Class.Members.Add(copy);
         }
 
@@ -1327,9 +1317,9 @@ namespace Microsoft.Contracts.Foxtrot
                 }
 
                 var candidate = baseClass.GetExactMatchingMethod(interfaceMethod);
-                
+
                 if (candidate != null) return candidate;
-            
+
                 baseClass = baseClass.BaseClass;
             }
 
@@ -1344,7 +1334,7 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 if (interfaceList[i] == intf) return true;
             }
-            
+
             return false;
         }
 
@@ -1353,7 +1343,7 @@ namespace Microsoft.Contracts.Foxtrot
             if (method == null) return false;
 
             var methodContract = method.Contract;
-            
+
             return methodContract != null && methodContract.RequiresCount > 0;
         }
 
@@ -1363,7 +1353,7 @@ namespace Microsoft.Contracts.Foxtrot
 
             return methodContract.EnsuresCount > 0 ||
                    Contract.Exists(0, methodContract.RequiresCount,
-                       i => !((RequiresPlain) methodContract.Requires[i]).IsFromValidation);
+                       i => !((RequiresPlain)methodContract.Requires[i]).IsFromValidation);
         }
 
         public void VisitForPostCheck(AssemblyNode assemblyNode)
@@ -1452,7 +1442,7 @@ namespace Microsoft.Contracts.Foxtrot
                 if (method == null) return null;
 
                 if (method.Template != null) return method.Template;
-                
+
                 return method;
             }
 
@@ -1461,7 +1451,7 @@ namespace Microsoft.Contracts.Foxtrot
                 if (memberBinding == null) return;
 
                 var method = TemplateOrMethod(memberBinding.BoundMember as Method);
-                
+
                 if (usedToExtract.IsInvariantMethod(method))
                 {
                     // indicates invariant use inside a method not marked by ObjectInvariantAttribute
@@ -1469,11 +1459,11 @@ namespace Microsoft.Contracts.Foxtrot
                     Contract.Assume(this.CurrentMethod != null);
 
                     var containingMethodName = this.CurrentMethod.FullName;
-                    
+
                     this.errorHandler(new Error(1022,
                         string.Format("Bad use of method 'Contract.Invariant' in method body '{0}'",
                             containingMethodName), lastSC));
-                    
+
                     return;
                 }
 
@@ -1493,18 +1483,18 @@ namespace Microsoft.Contracts.Foxtrot
             [ContractInvariantMethod]
             private void ObjectInvariant()
             {
-                Contract.Invariant(this.parent != null);
+                Contract.Invariant(_parent != null);
             }
 
-            private readonly PostExtractorChecker parent;
+            private readonly PostExtractorChecker _parent;
 
             public CheckForCallsToInvariantMethods(PostExtractorChecker parent)
             {
                 Contract.Requires(parent != null);
-                this.parent = parent;
+                _parent = parent;
             }
 
-            private SourceContext lastSC;
+            private SourceContext _lastSC;
 
             public override void VisitStatementList(StatementList statements)
             {
@@ -1515,9 +1505,9 @@ namespace Microsoft.Contracts.Foxtrot
                     var st = statements[i];
                     if (st != null && st.SourceContext.IsValid)
                     {
-                        lastSC = st.SourceContext;
+                        _lastSC = st.SourceContext;
                     }
-                    
+
                     this.Visit(st);
                 }
             }
@@ -1540,12 +1530,12 @@ namespace Microsoft.Contracts.Foxtrot
 
                 var m = mb.BoundMember as Method;
                 if (m == null) return;
-                
+
                 Method invMethod = this.InvariantMethods[m.UniqueKey] as Method;
                 if (invMethod != null)
                 {
-                    this.parent.HandleError(new Error(1042,
-                        "Explicit use of invariant method '" + invMethod.FullName + "' is not allowed.", this.lastSC));
+                    _parent.HandleError(new Error(1042,
+                        "Explicit use of invariant method '" + invMethod.FullName + "' is not allowed.", _lastSC));
                 }
             }
 
@@ -1557,8 +1547,8 @@ namespace Microsoft.Contracts.Foxtrot
                     Contract.Ensures(Contract.Result<TrivialHashtable>() != null);
 
                     // F:
-                    Contract.Assume(this.parent.invariantMethods != null);
-                    return this.parent.invariantMethods;
+                    Contract.Assume(_parent._invariantMethods != null);
+                    return _parent._invariantMethods;
                 }
             }
         }
@@ -1590,29 +1580,29 @@ namespace Microsoft.Contracts.Foxtrot
         [ContractVerification(true)]
         internal class PreconditionChecker : BasicChecker
         {
-            private bool hasError;
+            private bool _hasError;
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")
             ]
             public bool HasError
             {
-                get { return hasError; }
+                get { return _hasError; }
             }
 
-            private Requires current;
+            private Requires _current;
 
             private Requires Current
             {
                 get
                 {
                     // F: this.current may be null (e.g. after the constructor)          
-                    return this.current;
+                    return _current;
                 }
                 set
                 {
                     // F:
                     Contract.Requires(value != null);
-                    this.current = value;
+                    _current = value;
                     this.lastSC = value.SourceContext;
                 }
             }
@@ -1630,7 +1620,7 @@ namespace Microsoft.Contracts.Foxtrot
                 // F:
                 Contract.Requires(message != null);
 
-                this.hasError = true;
+                _hasError = true;
 
                 this.errorHandler(new Error(1011, message, this.CurrentSourceContext));
 
@@ -1658,10 +1648,10 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 if (req == null) return;
 
-                this.hasError = false;
-                
+                _hasError = false;
+
                 this.Current = req;
-                
+
                 this.Visit(req);
             }
 
@@ -1670,10 +1660,10 @@ namespace Microsoft.Contracts.Foxtrot
                 if (contract == null) return;
 
                 this.CurrentMethod = contract.DeclaringMethod;
-                
+
                 var requiresList = contract.Requires;
                 if (requiresList == null) return;
-                
+
                 foreach (var req in requiresList)
                 {
                     CheckPrecondition(req);
@@ -1687,17 +1677,17 @@ namespace Microsoft.Contracts.Foxtrot
             /// <summary>
             /// Parent instance.
             /// </summary>
-            private bool fSharp;
+            private bool _fSharp;
 
-            private bool checkingExceptionalPostcondition;
-            private Action<CompilerError> errorHandler;
+            private bool _checkingExceptionalPostcondition;
+            private Action<CompilerError> _errorHandler;
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic"),
              System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
             [ContractInvariantMethod]
             private void ObjectInvariant()
             {
-                Contract.Invariant(this.errorHandler != null);
+                Contract.Invariant(_errorHandler != null);
             }
 
             private MethodContractElement Current { get; set; }
@@ -1712,10 +1702,10 @@ namespace Microsoft.Contracts.Foxtrot
                 // F:
                 Contract.Requires(message != null);
 
-                this.errorHandler(new Error(number, message, this.CurrentSourceContext));
+                _errorHandler(new Error(number, message, this.CurrentSourceContext));
                 if (this.Current.DefSite.IsValid)
                 {
-                    this.errorHandler(new Warning(0, "  location related to previous warning.", this.Current.DefSite));
+                    _errorHandler(new Warning(0, "  location related to previous warning.", this.Current.DefSite));
                 }
             }
 
@@ -1723,8 +1713,8 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 Contract.Requires(errorHandler != null);
 
-                this.errorHandler = errorHandler;
-                this.fSharp = fSharp;
+                _errorHandler = errorHandler;
+                _fSharp = fSharp;
             }
 
             public override void VisitOldExpression(OldExpression oldExpression)
@@ -1734,7 +1724,7 @@ namespace Microsoft.Contracts.Foxtrot
                 // Make sure the argument to Old() isn't just a literal.
                 if (oldExpression.expression is Literal)
                     this.HandleError(1000, "Literal expression in Old expression.");
-                
+
                 base.VisitOldExpression(oldExpression);
             }
 
@@ -1743,7 +1733,7 @@ namespace Microsoft.Contracts.Foxtrot
                 if (returnValue == null) return;
 
                 var type = returnValue.Type;
-                
+
                 if (type == null) return;
 
                 CheckProperUseOfReturnValueHelper(type);
@@ -1751,7 +1741,7 @@ namespace Microsoft.Contracts.Foxtrot
 
             private void CheckProperUseOfReturnValueHelper(TypeNode type)
             {
-                if (this.checkingExceptionalPostcondition)
+                if (_checkingExceptionalPostcondition)
                 {
                     Method method = this.CurrentMethod;
                     this.HandleError(1001,
@@ -1762,7 +1752,7 @@ namespace Microsoft.Contracts.Foxtrot
                     // Make sure the type of result matches the type of the method.
                     //Method method = GetLastNode<Method>();
                     Method method = this.CurrentMethod;
-                    if (!this.fSharp && type != method.ReturnType &&
+                    if (!_fSharp && type != method.ReturnType &&
                         !method.ReturnType.IsAssignableTo(type, this.CurrentSubstitution))
                     {
                         this.HandleError(1002,
@@ -1774,13 +1764,13 @@ namespace Microsoft.Contracts.Foxtrot
 
             public override void VisitEnsuresExceptional(EnsuresExceptional exceptional)
             {
-                this.checkingExceptionalPostcondition = true;
+                _checkingExceptionalPostcondition = true;
                 base.VisitEnsuresExceptional(exceptional);
             }
 
             public override void VisitEnsuresNormal(EnsuresNormal normal)
             {
-                this.checkingExceptionalPostcondition = false;
+                _checkingExceptionalPostcondition = false;
                 base.VisitEnsuresNormal(normal);
             }
 
@@ -1808,7 +1798,7 @@ namespace Microsoft.Contracts.Foxtrot
                     var ens = contract.ModelEnsures[i];
                     CheckPostcondition(ens);
                 }
-                
+
                 for (int i = 0; i < contract.AsyncEnsuresCount; i++)
                 {
                     var ens = contract.AsyncEnsures[i];
@@ -1829,21 +1819,21 @@ namespace Microsoft.Contracts.Foxtrot
             [ContractInvariantMethod]
             private void ObjectInvariant()
             {
-                Contract.Invariant(this.visibilityHelper != null);
-                Contract.Invariant(this.errorHandler != null);
+                Contract.Invariant(_visibilityHelper != null);
+                Contract.Invariant(_errorHandler != null);
             }
 
-            private readonly Action<CompilerError> errorHandler;
-            private readonly ContractNodes contractNodes;
+            private readonly Action<CompilerError> _errorHandler;
+            private readonly ContractNodes _contractNodes;
 
-            private readonly VisibilityHelper visibilityHelper = new VisibilityHelper();
+            private readonly VisibilityHelper _visibilityHelper = new VisibilityHelper();
 
             public VisibilityChecker(Action<CompilerError> errorHandler, ContractNodes usedToExtract)
             {
                 Contract.Requires(errorHandler != null);
 
-                this.errorHandler = errorHandler;
-                this.contractNodes = usedToExtract;
+                _errorHandler = errorHandler;
+                _contractNodes = usedToExtract;
             }
 
             private void HandleError(Method method, int number, string message, MethodContractElement contract)
@@ -1851,10 +1841,10 @@ namespace Microsoft.Contracts.Foxtrot
                 Contract.Requires(contract != null);
                 Contract.Requires(message != null); // F:
 
-                this.errorHandler(new Error(number, message, contract.SourceContext));
+                _errorHandler(new Error(number, message, contract.SourceContext));
                 if (contract.DefSite.IsValid)
                 {
-                    this.errorHandler(new Warning(0, "  location related to previous warning.", contract.DefSite));
+                    _errorHandler(new Warning(0, "  location related to previous warning.", contract.DefSite));
                 }
             }
 
@@ -1866,7 +1856,7 @@ namespace Microsoft.Contracts.Foxtrot
 
                 CheckRequiresPlain(method, requires as RequiresPlain);
 
-                var nonVisible = this.visibilityHelper.AsVisibleAs(requires.Condition, method);
+                var nonVisible = _visibilityHelper.AsVisibleAs(requires.Condition, method);
                 if (nonVisible != null)
                 {
                     string message = "Member '" + nonVisible.FullName +
@@ -1893,7 +1883,7 @@ namespace Microsoft.Contracts.Foxtrot
                                 "Exception type {0} in Requires<E> has less visibility than enclosing method {1}",
                                 plain.ExceptionType.FullName, method.FullName);
 
-                        this.errorHandler(new Error(1037, msg, plain.SourceContext));
+                        _errorHandler(new Error(1037, msg, plain.SourceContext));
                     }
                 }
             }
@@ -1907,7 +1897,7 @@ namespace Microsoft.Contracts.Foxtrot
 
                 CheckEnsuresExceptional(method, ensures as EnsuresExceptional);
 
-                var nonVisible = this.visibilityHelper.AsVisibleAs(ensures.PostCondition, method);
+                var nonVisible = _visibilityHelper.AsVisibleAs(ensures.PostCondition, method);
                 if (nonVisible != null)
                 {
                     string message = "Member '" + nonVisible.FullName +
@@ -1933,7 +1923,7 @@ namespace Microsoft.Contracts.Foxtrot
                                 "Exception type {0} in EnsuresOnThrow<E> has less visibility than enclosing method {1}",
                                 ensuresExceptional.Type.FullName, method.FullName);
 
-                        this.errorHandler(new Error(1037, msg, ensuresExceptional.SourceContext));
+                        _errorHandler(new Error(1037, msg, ensuresExceptional.SourceContext));
                     }
                 }
             }
@@ -1967,11 +1957,11 @@ namespace Microsoft.Contracts.Foxtrot
 
                 if (!method.IsVirtual) return method;
 
-                var origType = HelperMethods.IsContractTypeForSomeOtherTypeUnspecialized(method.DeclaringType, this.contractNodes);
+                var origType = HelperMethods.IsContractTypeForSomeOtherTypeUnspecialized(method.DeclaringType, _contractNodes);
                 if (origType == null) return method;
 
                 var result = HelperMethods.FindImplementedMethodUnspecialized(origType, method);
-                
+
                 Contract.Assert(result != null);
 
                 /*
@@ -1992,14 +1982,14 @@ namespace Microsoft.Contracts.Foxtrot
             internal void CheckAbbreviatorEnsures(MethodContract methodContract)
             {
                 if (methodContract == null) return;
-                
+
                 for (int i = 0; i < methodContract.EnsuresCount; i++)
                 {
                     var ens = methodContract.Ensures[i];
 
                     Contract.Assume(ens != null);
                     Contract.Assume(methodContract.DeclaringMethod != null); // F:
-                    
+
                     this.CheckEnsures(methodContract.DeclaringMethod, ens);
                 }
 
@@ -2027,20 +2017,20 @@ namespace Microsoft.Contracts.Foxtrot
             [ContractInvariantMethod]
             private void ObjectInvariant()
             {
-                Contract.Invariant(this.errorHandler != null);
-                Contract.Invariant(this.contractNodes != null);
+                Contract.Invariant(_errorHandler != null);
+                Contract.Invariant(_contractNodes != null);
             }
 
             /// <summary>
             /// Error handler
             /// </summary>
-            private readonly Action<System.CodeDom.Compiler.CompilerError> errorHandler;
+            private readonly Action<System.CodeDom.Compiler.CompilerError> _errorHandler;
 
-            private readonly bool fSharp = false;
-            private readonly ContractNodes contractNodes;
+            private readonly bool _fSharp = false;
+            private readonly ContractNodes _contractNodes;
 
-            private SourceContext lastSourceContext;
-            private bool assignmentFound;
+            private SourceContext _lastSourceContext;
+            private bool _assignmentFound;
 
             /// <summary>
             /// Creates a new instance of this class.
@@ -2051,34 +2041,34 @@ namespace Microsoft.Contracts.Foxtrot
                 Contract.Requires(errorHandler != null);
                 Contract.Requires(contractNodes != null);
 
-                this.errorHandler = errorHandler;
-                this.fSharp = fSharp;
-                this.contractNodes = contractNodes;
+                _errorHandler = errorHandler;
+                _fSharp = fSharp;
+                _contractNodes = contractNodes;
             }
 
             public void CheckInvariants(TypeNode t, InvariantList invariants)
             {
                 Contract.Requires(invariants != null);
 
-                this.assignmentFound = false;
+                _assignmentFound = false;
                 foreach (var i in invariants)
                 {
                     if (i == null) continue;
 
-                    this.lastSourceContext = i.SourceContext;
+                    _lastSourceContext = i.SourceContext;
                     this.CurrentMethod = i;
-                    
+
                     this.Visit(i);
-                    
+
                     Contract.Assume(this.CurrentMethod != null);
-                    
-                    if (this.assignmentFound)
+
+                    if (_assignmentFound)
                     {
-                        this.errorHandler(
+                        _errorHandler(
                             new Error(1003,
-                                "Malformed contract. Found Invariant after assignment in method '" + this.CurrentMethod.FullName + "'.", 
+                                "Malformed contract. Found Invariant after assignment in method '" + this.CurrentMethod.FullName + "'.",
                                 i.SourceContext));
-                        
+
                         break;
                     }
                 }
@@ -2092,67 +2082,67 @@ namespace Microsoft.Contracts.Foxtrot
                 if (currentMethod.Contract == null) return;
 
                 this.CurrentMethod = currentMethod;
-                this.assignmentFound = false;
+                _assignmentFound = false;
                 bool errorIssued = false;
-                
+
                 for (int i = 0; i < currentMethod.Contract.RequiresCount; i++)
                 {
                     var req = currentMethod.Contract.Requires[i];
                     if (req == null) continue;
 
-                    this.lastSourceContext = req.SourceContext;
-                    
+                    _lastSourceContext = req.SourceContext;
+
                     this.Visit(req);
-                    
-                    if (this.assignmentFound)
+
+                    if (_assignmentFound)
                     {
                         errorIssued = true;
-                        
-                        this.errorHandler(new Error(1004,
+
+                        _errorHandler(new Error(1004,
                             "Malformed contract. Found Requires after assignment in method '"
                             + currentMethod.FullName + "'.", req.SourceContext));
-                        
+
                         break;
                     }
                 }
 
                 if (errorIssued) return;
-                
+
                 for (int i = 0; i < currentMethod.Contract.EnsuresCount; i++)
                 {
                     var ens = currentMethod.Contract.Ensures[i];
                     if (ens == null) continue;
 
-                    this.lastSourceContext = ens.SourceContext;
+                    _lastSourceContext = ens.SourceContext;
                     this.Visit(ens);
-                    
-                    if (this.assignmentFound)
+
+                    if (_assignmentFound)
                     {
                         errorIssued = true;
-                        
-                        this.errorHandler(new Error(1005,
+
+                        _errorHandler(new Error(1005,
                             "Malformed contract. Found Ensures after assignment in method '"
                             + currentMethod.FullName + "'.", ens.SourceContext));
-                        
+
                         break;
                     }
                 }
 
                 if (errorIssued) return;
-                
+
                 for (int i = 0; i < currentMethod.Contract.AsyncEnsuresCount; i++)
                 {
                     var ens = currentMethod.Contract.AsyncEnsures[i];
                     if (ens == null) continue;
-                    
-                    this.lastSourceContext = ens.SourceContext;
-                    
+
+                    _lastSourceContext = ens.SourceContext;
+
                     this.Visit(ens);
-                    
-                    if (this.assignmentFound)
+
+                    if (_assignmentFound)
                     {
                         errorIssued = true;
-                        this.errorHandler(new Error(1005,
+                        _errorHandler(new Error(1005,
                             "Malformed contract. Found Ensures after assignment in method '"
                             + currentMethod.FullName + "'.", ens.SourceContext));
                         break;
@@ -2160,25 +2150,25 @@ namespace Microsoft.Contracts.Foxtrot
                 }
 
                 if (errorIssued) return;
-                
+
                 for (int i = 0; i < currentMethod.Contract.ModelEnsuresCount; i++)
                 {
                     var ens = currentMethod.Contract.ModelEnsures[i];
-                    
+
                     if (ens == null) continue;
-                    
-                    this.lastSourceContext = ens.SourceContext;
+
+                    _lastSourceContext = ens.SourceContext;
 
                     this.Visit(ens);
 
-                    if (this.assignmentFound)
+                    if (_assignmentFound)
                     {
                         errorIssued = true;
-                        
-                        this.errorHandler(new Error(1005,
+
+                        _errorHandler(new Error(1005,
                             "Malformed contract. Found Ensures after assignment in method '"
                             + currentMethod.FullName + "'.", ens.SourceContext));
-                        
+
                         break;
                     }
                 }
@@ -2240,13 +2230,13 @@ namespace Microsoft.Contracts.Foxtrot
                 // Skip compiler-generated code.
                 // Since we only visit contract regions, any assignment to state is not allowed.
                 bool targetIsLocal = false;
-                
+
                 if (assignment.Target is Local) targetIsLocal = true;
-                
+
                 Indexer idxr = assignment.Target as Indexer;
                 if (idxr != null && idxr.Object is Local)
                     targetIsLocal = true;
-                
+
                 // Assignments to locals that are structs show up as address deference
                 AddressDereference addressDereference = assignment.Target as AddressDereference;
                 if (addressDereference != null)
@@ -2267,7 +2257,7 @@ namespace Microsoft.Contracts.Foxtrot
 
                 if (!IsAnonymousDelegateConstruction(assignment) && !targetIsLocal)
                 {
-                    this.assignmentFound = true;
+                    _assignmentFound = true;
                     //this.errorHandler(new Error("Detected assignment in a pure region in method '"
                     //  + this.currentMethod.FullName + "'.", assignment.SourceContext));
                 }
@@ -2288,19 +2278,19 @@ namespace Microsoft.Contracts.Foxtrot
                 MemberBinding binding = call.Callee as MemberBinding;
                 Method method = binding != null ? binding.BoundMember as Method : null;
 
-                bool pure = this.contractNodes.IsPure(method);
+                bool pure = _contractNodes.IsPure(method);
 
                 // F: For some reason the code below relies on method != null, and hence to binding call.Callee <: MemberBinding
                 Contract.Assume(method != null);
 
-                if (!this.fSharp && !pure && method != this.contractNodes.AssumeMethod)
+                if (!_fSharp && !pure && method != _contractNodes.AssumeMethod)
                 {
                     // F:
                     Contract.Assume(this.CurrentMethod != null);
 
-                    this.errorHandler(new Warning(1036,
+                    _errorHandler(new Warning(1036,
                         "Detected call to method '" + method.FullName + "' without [Pure] in contracts of method '" +
-                        this.CurrentMethod.FullName + "'.", this.lastSourceContext));
+                        this.CurrentMethod.FullName + "'.", _lastSourceContext));
                 }
 
                 // make sure we now assume this method is pure for the rest of the analysis
@@ -2309,12 +2299,12 @@ namespace Microsoft.Contracts.Foxtrot
                     var template = method;
 
                     while (template.Template != null) template = template.Template;
-                    
+
                     if (template.Contract == null)
                     {
                         template.Contract = new MethodContract(template);
                     }
-                    
+
                     template.Contract.IsPure = true;
                 }
 
@@ -2329,7 +2319,7 @@ namespace Microsoft.Contracts.Foxtrot
                 switch (expression.NodeType)
                 {
                     case NodeType.Dup:
-                        seenDup = true;
+                        _seenDup = true;
                         break;
 
                     case NodeType.Arglist:
@@ -2350,35 +2340,35 @@ namespace Microsoft.Contracts.Foxtrot
                 }
             }
 
-            private bool seenDup;
+            private bool _seenDup;
 
             public override void VisitEnsuresExceptional(EnsuresExceptional exceptional)
             {
-                seenDup = false;
+                _seenDup = false;
                 base.VisitEnsuresExceptional(exceptional);
             }
 
             public override void VisitEnsuresNormal(EnsuresNormal normal)
             {
-                seenDup = false;
+                _seenDup = false;
                 base.VisitEnsuresNormal(normal);
             }
 
             public override void VisitInvariant(Invariant invariant)
             {
-                seenDup = false;
+                _seenDup = false;
                 base.VisitInvariant(invariant);
             }
 
             public override void VisitRequiresOtherwise(RequiresOtherwise otherwise)
             {
-                seenDup = false;
+                _seenDup = false;
                 base.VisitRequiresOtherwise(otherwise);
             }
 
             public override void VisitRequiresPlain(RequiresPlain plain)
             {
-                seenDup = false;
+                _seenDup = false;
                 base.VisitRequiresPlain(plain);
             }
 
@@ -2388,11 +2378,11 @@ namespace Microsoft.Contracts.Foxtrot
 
                 // MaF: this is too strict. Some C# code patterns use Dup and pop in a branch to avoid loading a memory location twice.
                 // we now emit the error only if there was no prior dup
-                if (!seenDup)
+                if (!_seenDup)
                 {
-                    this.errorHandler(new Warning(1069,
+                    _errorHandler(new Warning(1069,
                         "Detected expression statement evaluated for potential side-effect in contracts of method '" +
-                        this.CurrentMethod.FullName + "'.", this.lastSourceContext));
+                        this.CurrentMethod.FullName + "'.", _lastSourceContext));
                 }
             }
 
@@ -2412,7 +2402,7 @@ namespace Microsoft.Contracts.Foxtrot
             public override void VisitStatementList(StatementList statements)
             {
                 if (statements == null) return;
-                
+
                 for (int i = 0; i < statements.Count; i++)
                 {
                     var stmt = statements[i];
@@ -2420,7 +2410,7 @@ namespace Microsoft.Contracts.Foxtrot
 
                     if (stmt.SourceContext.IsValid)
                     {
-                        lastSourceContext = stmt.SourceContext;
+                        _lastSourceContext = stmt.SourceContext;
                     }
                     this.Visit(stmt);
                 }

--- a/Foxtrot/Foxtrot/Checker/VisibilityHelper.cs
+++ b/Foxtrot/Foxtrot/Checker/VisibilityHelper.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 using System.Diagnostics.Contracts;
@@ -23,18 +12,18 @@ namespace Microsoft.Contracts.Foxtrot
     [ContractVerification(true)]
     internal class VisibilityHelper : InspectorIncludingClosures
     {
-        private Member memberInErrorFound;
+        private Member _memberInErrorFound;
 
         /// <summary>
         /// The visibility of things is checked to be as visible as this member.
         /// </summary>
-        private Member AsThisMember;
+        private Member _asThisMember;
 
         private void ReInitialize(Method asThisMember)
         {
             this.CurrentMethod = asThisMember;
-            memberInErrorFound = null;
-            this.AsThisMember = asThisMember;
+            _memberInErrorFound = null;
+            _asThisMember = asThisMember;
         }
 
         /// <summary>
@@ -54,15 +43,15 @@ namespace Microsoft.Contracts.Foxtrot
                 {
                     specPublic = IsSpecPublic(f);
                 }
-                
+
                 if (!specPublic && !HelperMethods.IsCompilerGenerated(mem))
                 {
                     // F: It seems there is some type-state like invariant here justifying why this.AsThisMemeber != null
-                    Contract.Assume(this.AsThisMember != null);
-                    
-                    if (!HelperMethods.IsReferenceAsVisibleAs(mem, this.AsThisMember))
+                    Contract.Assume(_asThisMember != null);
+
+                    if (!HelperMethods.IsReferenceAsVisibleAs(mem, _asThisMember))
                     {
-                        this.memberInErrorFound = mem;
+                        _memberInErrorFound = mem;
                         return;
                     }
                 }
@@ -94,7 +83,7 @@ namespace Microsoft.Contracts.Foxtrot
         {
             this.ReInitialize(method);
             this.VisitExpression(expr);
-            return this.memberInErrorFound;
+            return _memberInErrorFound;
         }
     }
 }

--- a/Foxtrot/Foxtrot/Checker/Warning.cs
+++ b/Foxtrot/Foxtrot/Checker/Warning.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 using System.Diagnostics.Contracts;

--- a/Foxtrot/Foxtrot/CodeInspector.cs
+++ b/Foxtrot/Foxtrot/CodeInspector.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
 using System.Compiler;
@@ -28,7 +17,7 @@ namespace Microsoft.Contracts.Foxtrot
         {
             CodeInspector ifrv = new CodeInspector(
                 ContractNodes.RuntimeIgnoredAttributeName, contractNodes, referencingType, skipQuantifiers);
-            
+
             ifrv.Visit(node);
 
             return ifrv.foundAttribute;
@@ -37,9 +26,9 @@ namespace Microsoft.Contracts.Foxtrot
         public static bool UsesModel(Node node, ContractNodes contractNodes)
         {
             CodeInspector ifrv = new CodeInspector(ContractNodes.ModelAttributeName, contractNodes, null, false);
-            
+
             ifrv.Visit(node);
-            
+
             return ifrv.foundAttribute;
         }
 
@@ -48,24 +37,24 @@ namespace Microsoft.Contracts.Foxtrot
         /// </summary>
         public bool foundAttribute;
 
-        private readonly Identifier attributeToFind;
-        private readonly ContractNodes contractNodes;
-        private readonly bool skipQuantifiers;
-        private readonly Stack<TypeNode> referencingType;
-        private bool generatedMethodContainsInvisibleMemberReference;
+        private readonly Identifier _attributeToFind;
+        private readonly ContractNodes _contractNodes;
+        private readonly bool _skipQuantifiers;
+        private readonly Stack<TypeNode> _referencingType;
+        private bool _generatedMethodContainsInvisibleMemberReference;
 
         private CodeInspector(Identifier attributeToFind, ContractNodes contractNodes, TypeNode referencingType, bool skipQuantifiers)
         {
             this.foundAttribute = false;
-            
-            this.attributeToFind = attributeToFind;
-            this.contractNodes = contractNodes;
-            this.skipQuantifiers = skipQuantifiers;
-            this.referencingType = new Stack<TypeNode>();
+
+            _attributeToFind = attributeToFind;
+            _contractNodes = contractNodes;
+            _skipQuantifiers = skipQuantifiers;
+            _referencingType = new Stack<TypeNode>();
 
             if (referencingType != null)
             {
-                this.referencingType.Push(referencingType);
+                _referencingType.Push(referencingType);
             }
         }
 
@@ -73,16 +62,16 @@ namespace Microsoft.Contracts.Foxtrot
         {
             if (memberBinding.BoundMember != null)
             {
-                if (HelperMethods.HasAttribute(memberBinding.BoundMember.Attributes, this.attributeToFind))
+                if (HelperMethods.HasAttribute(memberBinding.BoundMember.Attributes, _attributeToFind))
                 {
                     this.foundAttribute = true;
                     return;
                 }
 
-                if (referencingType.Count > 0 &&
-                    !HelperMethods.IsVisibleFrom(memberBinding.BoundMember, this.referencingType.Peek()))
+                if (_referencingType.Count > 0 &&
+                    !HelperMethods.IsVisibleFrom(memberBinding.BoundMember, _referencingType.Peek()))
                 {
-                    this.generatedMethodContainsInvisibleMemberReference = true;
+                    _generatedMethodContainsInvisibleMemberReference = true;
                     this.foundAttribute = true;
                     return;
                 }
@@ -96,11 +85,11 @@ namespace Microsoft.Contracts.Foxtrot
                         return;
                     }
 
-                    if (this.skipQuantifiers &&
-                        (this.contractNodes.IsForallMethod(referencedMethod) ||
-                         this.contractNodes.IsGenericForallMethod(referencedMethod) ||
-                         this.contractNodes.IsExistsMethod(referencedMethod) ||
-                         this.contractNodes.IsGenericExistsMethod(referencedMethod))
+                    if (_skipQuantifiers &&
+                        (_contractNodes.IsForallMethod(referencedMethod) ||
+                         _contractNodes.IsGenericForallMethod(referencedMethod) ||
+                         _contractNodes.IsExistsMethod(referencedMethod) ||
+                         _contractNodes.IsGenericExistsMethod(referencedMethod))
                         )
                     {
                         this.foundAttribute = true;
@@ -108,8 +97,8 @@ namespace Microsoft.Contracts.Foxtrot
                     }
 
                     // check if we deal with a contract method on an interface/abstract method that is annotated
-                    var origType = HelperMethods.IsContractTypeForSomeOtherTypeUnspecialized(referencedMethod.DeclaringType, this.contractNodes);
-                    
+                    var origType = HelperMethods.IsContractTypeForSomeOtherTypeUnspecialized(referencedMethod.DeclaringType, _contractNodes);
+
                     if (origType != null)
                     {
                         var origMethod = HelperMethods.FindImplementedMethodSpecialized(origType, referencedMethod);
@@ -132,7 +121,7 @@ namespace Microsoft.Contracts.Foxtrot
                 // look for attribute on property
                 if (referencedMethod.IsPropertyGetter && referencedMethod.DeclaringMember != null)
                 {
-                    if (HelperMethods.HasAttribute(referencedMethod.DeclaringMember.Attributes, this.attributeToFind))
+                    if (HelperMethods.HasAttribute(referencedMethod.DeclaringMember.Attributes, _attributeToFind))
                     {
                         return true;
                     }
@@ -152,25 +141,25 @@ namespace Microsoft.Contracts.Foxtrot
 
                 MemberBinding mb = ue.Operand as MemberBinding;
                 if (mb == null) goto JustVisit;
-                
+
                 Method m = mb.BoundMember as Method;
-                
+
                 if (HelperMethods.IsCompilerGenerated(m))
                 {
-                    bool savedInvisibleMemberRef = this.generatedMethodContainsInvisibleMemberReference;
+                    bool savedInvisibleMemberRef = _generatedMethodContainsInvisibleMemberReference;
                     try
                     {
-                        this.generatedMethodContainsInvisibleMemberReference = false;
-                        
+                        _generatedMethodContainsInvisibleMemberReference = false;
+
                         var unspecedM = HelperMethods.Unspecialize(m);
                         var unspecedT = unspecedM.DeclaringType;
-                        
+
                         Contract.Assert(unspecedT.Template == null);
-                        
-                        this.referencingType.Push(unspecedT);
+
+                        _referencingType.Push(unspecedT);
                         this.VisitBlock(unspecedM.Body);
-                        
-                        if (this.generatedMethodContainsInvisibleMemberReference)
+
+                        if (_generatedMethodContainsInvisibleMemberReference)
                         {
                             // remove method (and all containing closure methods)
                             savedInvisibleMemberRef = true;
@@ -186,14 +175,14 @@ namespace Microsoft.Contracts.Foxtrot
                     }
                     finally
                     {
-                        this.generatedMethodContainsInvisibleMemberReference = savedInvisibleMemberRef;
-                        this.referencingType.Pop();
+                        _generatedMethodContainsInvisibleMemberReference = savedInvisibleMemberRef;
+                        _referencingType.Pop();
                     }
                 }
             }
 
-            JustVisit:
-            
+        JustVisit:
+
             base.VisitConstruct(cons);
         }
     }

--- a/Foxtrot/Foxtrot/ContractBlocks.cs
+++ b/Foxtrot/Foxtrot/ContractBlocks.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 

--- a/Foxtrot/Foxtrot/ContractNodes.cs
+++ b/Foxtrot/Foxtrot/ContractNodes.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Compiler;
@@ -50,9 +39,9 @@ namespace Microsoft.Contracts.Foxtrot
 
         public static readonly Identifier ContractClassName = Identifier.For("Contract");
         public static readonly Identifier ContractInternalNamespace = Identifier.For("System.Runtime.CompilerServices");
-        
+
         //public static readonly Identifier ContractInternalNamespace = Identifier.For("System.Diagnostics.Contracts.Internal");
-        
+
         public static readonly Identifier RaiseContractFailedEventName = Identifier.For("RaiseContractFailedEvent");
         public static readonly Identifier TriggerFailureName = Identifier.For("TriggerFailure");
         public static readonly Identifier ReportFailureName = Identifier.For("ReportFailure");
@@ -92,67 +81,100 @@ namespace Microsoft.Contracts.Foxtrot
 
         // Fields that represent methods, attributes, and types in the contract library
 
-        [RepresentationFor("System.Diagnostics.Contracts.PureAttribute")] public readonly Class /*?*/ PureAttribute;
+        [RepresentationFor("System.Diagnostics.Contracts.PureAttribute")]
+        public readonly Class /*?*/ PureAttribute;
 
-        [RepresentationFor("System.Diagnostics.Contracts.ContractInvariantMethodAttribute")] public readonly Class /*?*/ InvariantMethodAttribute;
+        [RepresentationFor("System.Diagnostics.Contracts.ContractInvariantMethodAttribute")]
+        public readonly Class /*?*/ InvariantMethodAttribute;
 
-        [RepresentationFor("System.Diagnostics.Contracts.ContractClassAttribute")] internal readonly Class /*?*/ ContractClassAttribute;
+        [RepresentationFor("System.Diagnostics.Contracts.ContractClassAttribute")]
+        internal readonly Class /*?*/ ContractClassAttribute;
 
-        [RepresentationFor("System.Diagnostics.Contracts.ContractClassForAttribute")] internal readonly Class /*?*/ ContractClassForAttribute;
+        [RepresentationFor("System.Diagnostics.Contracts.ContractClassForAttribute")]
+        internal readonly Class /*?*/ ContractClassForAttribute;
 
-        [RepresentationFor("System.Diagnostics.Contracts.ContractVerificationAttribute")] public readonly Class /*?*/ VerifyAttribute;
+        [RepresentationFor("System.Diagnostics.Contracts.ContractVerificationAttribute")]
+        public readonly Class /*?*/ VerifyAttribute;
 
-        [RepresentationFor("System.Diagnostics.Contracts.ContractPublicPropertyNameAttribute")] internal readonly Class /*?*/ SpecPublicAttribute;
+        [RepresentationFor("System.Diagnostics.Contracts.ContractPublicPropertyNameAttribute")]
+        internal readonly Class /*?*/ SpecPublicAttribute;
 
-        [RepresentationFor("System.Diagnostics.Contracts.ContractReferenceAssemblyAttribute", false)] public readonly Class /*?*/ ReferenceAssemblyAttribute;
+        [RepresentationFor("System.Diagnostics.Contracts.ContractReferenceAssemblyAttribute", false)]
+        public readonly Class /*?*/ ReferenceAssemblyAttribute;
 
-        [RepresentationFor("System.Diagnostics.Contracts.ContractRuntimeIgnoredAttribute")] public readonly Class /*?*/ IgnoreAtRuntimeAttribute;
+        [RepresentationFor("System.Diagnostics.Contracts.ContractRuntimeIgnoredAttribute")]
+        public readonly Class /*?*/ IgnoreAtRuntimeAttribute;
 
-        [RepresentationFor("System.Diagnostics.Contracts.ContractClass")] public readonly Class /*?*/ ContractClass;
+        [RepresentationFor("System.Diagnostics.Contracts.ContractClass")]
+        public readonly Class /*?*/ ContractClass;
 
-        [RepresentationFor("System.Diagnostics.Contracts.Internal.ContractHelper", false)] public readonly Class /*?*/ ContractHelperClass;
+        [RepresentationFor("System.Diagnostics.Contracts.Internal.ContractHelper", false)]
+        public readonly Class /*?*/ ContractHelperClass;
 
-        [RepresentationFor("System.Diagnostics.Contracts.ContractFailureKind")] public readonly EnumNode /*?*/ ContractFailureKind;
+        [RepresentationFor("System.Diagnostics.Contracts.ContractFailureKind")]
+        public readonly EnumNode /*?*/ ContractFailureKind;
 
-        [RepresentationFor("Contract.Assert(bool)")] public readonly Method /*?*/ AssertMethod;
-        [RepresentationFor("Contract.Assert(bool, string)")] public readonly Method /*?*/ AssertWithMsgMethod;
-        [RepresentationFor("Contract.Assume(bool b)")] public readonly Method /*?*/ AssumeMethod;
-        [RepresentationFor("Contract.Assume(bool b, string)")] public readonly Method /*?*/ AssumeWithMsgMethod;
+        [RepresentationFor("Contract.Assert(bool)")]
+        public readonly Method /*?*/ AssertMethod;
+        [RepresentationFor("Contract.Assert(bool, string)")]
+        public readonly Method /*?*/ AssertWithMsgMethod;
+        [RepresentationFor("Contract.Assume(bool b)")]
+        public readonly Method /*?*/ AssumeMethod;
+        [RepresentationFor("Contract.Assume(bool b, string)")]
+        public readonly Method /*?*/ AssumeWithMsgMethod;
 
-        [RepresentationFor("Contract.Requires(bool)")] public readonly Method /*?*/ RequiresMethod;
-        [RepresentationFor("Contract.Requires(bool,string)")] public readonly Method /*?*/ RequiresWithMsgMethod;
+        [RepresentationFor("Contract.Requires(bool)")]
+        public readonly Method /*?*/ RequiresMethod;
+        [RepresentationFor("Contract.Requires(bool,string)")]
+        public readonly Method /*?*/ RequiresWithMsgMethod;
 
-        [RepresentationFor("Contract.Requires<TException>(bool)", false)] public readonly Method /*?*/ RequiresExceptionMethod;
+        [RepresentationFor("Contract.Requires<TException>(bool)", false)]
+        public readonly Method /*?*/ RequiresExceptionMethod;
 
-        [RepresentationFor("Contract.Requires<TException>(bool,string)", false)] public readonly Method /*?*/ RequiresExceptionWithMsgMethod;
+        [RepresentationFor("Contract.Requires<TException>(bool,string)", false)]
+        public readonly Method /*?*/ RequiresExceptionWithMsgMethod;
 
-        [RepresentationFor("Contract.Ensures(bool)")] public readonly Method /*?*/ EnsuresMethod;
-        [RepresentationFor("Contract.Ensures(bool,string)")] public readonly Method /*?*/ EnsuresWithMsgMethod;
-        [RepresentationFor("Contract.EnsuresOnThrow<T>(bool)")] public readonly Method /*?*/ EnsuresOnThrowTemplate;
+        [RepresentationFor("Contract.Ensures(bool)")]
+        public readonly Method /*?*/ EnsuresMethod;
+        [RepresentationFor("Contract.Ensures(bool,string)")]
+        public readonly Method /*?*/ EnsuresWithMsgMethod;
+        [RepresentationFor("Contract.EnsuresOnThrow<T>(bool)")]
+        public readonly Method /*?*/ EnsuresOnThrowTemplate;
 
-        [RepresentationFor("Contract.EnsuresOnThrow<T>(bool,string)")] public readonly Method /*?*/ EnsuresOnThrowWithMsgTemplate;
+        [RepresentationFor("Contract.EnsuresOnThrow<T>(bool,string)")]
+        public readonly Method /*?*/ EnsuresOnThrowWithMsgTemplate;
 
-        [RepresentationFor("Contract.Invariant(bool)")] public readonly Method /*?*/ InvariantMethod;
-        [RepresentationFor("Contract.Invariant(bool,msg)")] public readonly Method /*?*/ InvariantWithMsgMethod;
+        [RepresentationFor("Contract.Invariant(bool)")]
+        public readonly Method /*?*/ InvariantMethod;
+        [RepresentationFor("Contract.Invariant(bool,msg)")]
+        public readonly Method /*?*/ InvariantWithMsgMethod;
 
-        [RepresentationFor("Contract.Result<T>()")] private readonly Method /*?*/ ResultTemplate;
-        [RepresentationFor("Contract.ValueAtReturn<T>(out T t)")] private readonly Method /*?*/ ParameterTemplate;
-        [RepresentationFor("Contract.OldValue<T>(T t)")] private readonly Method /*?*/ OldTemplate;
+        [RepresentationFor("Contract.Result<T>()")]
+        private readonly Method /*?*/ _resultTemplate;
+        [RepresentationFor("Contract.ValueAtReturn<T>(out T t)")]
+        private readonly Method /*?*/ _parameterTemplate;
+        [RepresentationFor("Contract.OldValue<T>(T t)")]
+        private readonly Method /*?*/ _oldTemplate;
 
-        [RepresentationFor("Contract.ForAll(int lo, int hi, Predicate<int> P)", false)] private readonly Method /*?*/ ForAllTemplate;
+        [RepresentationFor("Contract.ForAll(int lo, int hi, Predicate<int> P)", false)]
+        private readonly Method /*?*/ _forAllTemplate;
 
-        [RepresentationFor("Contract.ForAll<T>(IEnumerable<T> collection, Predicate<int> P)", false)] private readonly Method /*?*/ ForAllGenericTemplate;
+        [RepresentationFor("Contract.ForAll<T>(IEnumerable<T> collection, Predicate<int> P)", false)]
+        private readonly Method /*?*/ _forAllGenericTemplate;
 
-        [RepresentationFor("Contract.Exists(int lo, int hi, Predicate<int> P)", false)] private readonly Method /*?*/ ExistsTemplate;
+        [RepresentationFor("Contract.Exists(int lo, int hi, Predicate<int> P)", false)]
+        private readonly Method /*?*/ _existsTemplate;
 
-        [RepresentationFor("Contract.Exists<T>(IEnumerable<T> collection, Predicate<int> P)", false)] private readonly Method /*?*/ ExistsGenericTemplate;
+        [RepresentationFor("Contract.Exists<T>(IEnumerable<T> collection, Predicate<int> P)", false)]
+        private readonly Method /*?*/ _existsGenericTemplate;
 
-        [RepresentationFor("Contract.EndContractBlock()")] public readonly Method /*?*/ EndContract;
+        [RepresentationFor("Contract.EndContractBlock()")]
+        public readonly Method /*?*/ EndContract;
 
-        [RepresentationFor("ContractHelper.RaiseContractFailedEvent(ContractFailureKind failureKind, String userProvidedMessage, String condition, Exception originalException)", false)] 
+        [RepresentationFor("ContractHelper.RaiseContractFailedEvent(ContractFailureKind failureKind, String userProvidedMessage, String condition, Exception originalException)", false)]
         public readonly Method /*?*/ RaiseFailedEventMethod;
 
-        [RepresentationFor( "ContractHelper.ShowFailure(ContractFailureKind failureKind, String displayMessage, String userProvidedMessage, String condition, Exception originalException)", false)] 
+        [RepresentationFor("ContractHelper.ShowFailure(ContractFailureKind failureKind, String displayMessage, String userProvidedMessage, String condition, Exception originalException)", false)]
         public readonly Method /*?*/ TriggerFailureMethod;
 
         /// <summary>
@@ -177,11 +199,11 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 throw new InvalidOperationException(message);
             }
-            
+
             var error = new CompilerError(assembly.Location, 0, 0, "", message);
-            
+
             error.IsWarning = true;
-            
+
             ErrorFound(error);
         }
 
@@ -191,7 +213,7 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 throw new InvalidOperationException(message);
             }
-            
+
             ErrorFound(new System.CodeDom.Compiler.CompilerError(assembly.Location, 0, 0, "", message));
         }
 
@@ -274,7 +296,7 @@ namespace Microsoft.Contracts.Foxtrot
             }
 
             EnsuresMethod = ContractClass.GetMethod(Identifier.For("Ensures"), SystemTypes.Boolean);
-            
+
             EnsuresWithMsgMethod = ContractClass.GetMethod(Identifier.For("Ensures"), SystemTypes.Boolean, SystemTypes.String);
             EnsuresOnThrowTemplate = ContractClass.GetMethod(Identifier.For("EnsuresOnThrow"), SystemTypes.Boolean);
             EnsuresOnThrowWithMsgTemplate = ContractClass.GetMethod(Identifier.For("EnsuresOnThrow"), SystemTypes.Boolean, SystemTypes.String);
@@ -288,7 +310,7 @@ namespace Microsoft.Contracts.Foxtrot
             AssumeMethod = ContractClass.GetMethod(Identifier.For("Assume"), SystemTypes.Boolean);
             AssumeWithMsgMethod = ContractClass.GetMethod(Identifier.For("Assume"), SystemTypes.Boolean, SystemTypes.String);
 
-            ResultTemplate = ContractClass.GetMethod(ResultName);
+            _resultTemplate = ContractClass.GetMethod(ResultName);
 
             TypeNode GenericPredicate = SystemTypes.SystemAssembly.GetType(
                 Identifier.For("System"),
@@ -296,10 +318,10 @@ namespace Microsoft.Contracts.Foxtrot
 
             if (GenericPredicate != null)
             {
-                ForAllGenericTemplate = ContractClass.GetMethod(ForallName, SystemTypes.GenericIEnumerable, GenericPredicate);
-                ExistsGenericTemplate = ContractClass.GetMethod(ExistsName, SystemTypes.GenericIEnumerable, GenericPredicate);
+                _forAllGenericTemplate = ContractClass.GetMethod(ForallName, SystemTypes.GenericIEnumerable, GenericPredicate);
+                _existsGenericTemplate = ContractClass.GetMethod(ExistsName, SystemTypes.GenericIEnumerable, GenericPredicate);
 
-                if (ForAllGenericTemplate == null)
+                if (_forAllGenericTemplate == null)
                 {
                     // The problem might be that we are in the pre 4.0 scenario and using an out-of-band contract for mscorlib
                     // in which case the contract library is defined in that out-of-band contract assembly.
@@ -315,16 +337,16 @@ namespace Microsoft.Contracts.Foxtrot
                             assemblyContainingContractClass.GetType(Identifier.For("System.Collections.Generic"),
                                 Identifier.For("IEnumerable" + TargetPlatform.GenericTypeNamesMangleChar + "1"));
 
-                        ForAllGenericTemplate = ContractClass.GetMethod(Identifier.For("ForAll"), genericIEnum, GenericPredicate);
-                        ExistsGenericTemplate = ContractClass.GetMethod(Identifier.For("Exists"), genericIEnum, GenericPredicate);
+                        _forAllGenericTemplate = ContractClass.GetMethod(Identifier.For("ForAll"), genericIEnum, GenericPredicate);
+                        _existsGenericTemplate = ContractClass.GetMethod(Identifier.For("Exists"), genericIEnum, GenericPredicate);
                     }
                 }
 
                 TypeNode PredicateOfInt = GenericPredicate.GetTemplateInstance(ContractClass, SystemTypes.Int32);
                 if (PredicateOfInt != null)
                 {
-                    ForAllTemplate = ContractClass.GetMethod(Identifier.For("ForAll"), SystemTypes.Int32, SystemTypes.Int32, PredicateOfInt);
-                    ExistsTemplate = ContractClass.GetMethod(Identifier.For("Exists"), SystemTypes.Int32, SystemTypes.Int32, PredicateOfInt);
+                    _forAllTemplate = ContractClass.GetMethod(Identifier.For("ForAll"), SystemTypes.Int32, SystemTypes.Int32, PredicateOfInt);
+                    _existsTemplate = ContractClass.GetMethod(Identifier.For("Exists"), SystemTypes.Int32, SystemTypes.Int32, PredicateOfInt);
                 }
             }
 
@@ -336,7 +358,7 @@ namespace Microsoft.Contracts.Foxtrot
                     Reference reference = method.Parameters[0].Type as Reference;
                     if (reference != null && reference.ElementType.IsTemplateParameter)
                     {
-                        ParameterTemplate = method;
+                        _parameterTemplate = method;
                         break;
                     }
                 }
@@ -347,7 +369,7 @@ namespace Microsoft.Contracts.Foxtrot
                 Method method = member as Method;
                 if (method != null && method.Parameters.Count == 1 && method.Parameters[0].Type.IsTemplateParameter)
                 {
-                    OldTemplate = method;
+                    _oldTemplate = method;
                     break;
                 }
             }
@@ -389,14 +411,14 @@ namespace Microsoft.Contracts.Foxtrot
 
             // Check that every field in this class has been set
 
-            foreach (System.Reflection.FieldInfo field in typeof (ContractNodes).GetFields())
+            foreach (System.Reflection.FieldInfo field in typeof(ContractNodes).GetFields())
             {
                 if (field.GetValue(this) == null)
                 {
                     string sig = null;
                     bool required = false;
 
-                    object[] cas = field.GetCustomAttributes(typeof (RepresentationFor), false);
+                    object[] cas = field.GetCustomAttributes(typeof(RepresentationFor), false);
                     for (int i = 0, n = cas.Length; i < n; i++)
                     {
                         // should be exactly one
@@ -410,7 +432,7 @@ namespace Microsoft.Contracts.Foxtrot
                     }
 
                     if (!required) continue;
-                    
+
                     string msg = "Could not find contract node for '" + field.Name + "'";
                     if (sig != null)
                         msg = "Could not find the method/type '" + sig + "'";
@@ -421,10 +443,10 @@ namespace Microsoft.Contracts.Foxtrot
                     }
 
                     Module dm = ContractClass.DeclaringModule;
-                    
+
                     ClearFields();
                     CallErrorFound(dm, msg);
-                    
+
                     return;
                 }
             }
@@ -439,7 +461,7 @@ namespace Microsoft.Contracts.Foxtrot
                 )
             {
                 Module dm = ContractClass.DeclaringModule;
-                
+
                 ClearFields();
                 CallErrorFound(dm, "The enum ContractFailureKind must have the values 'Assert', 'Assume', 'Invariant', 'Postcondition', and 'Precondition'.");
             }
@@ -451,9 +473,9 @@ namespace Microsoft.Contracts.Foxtrot
         /// </summary>
         private void ClearFields()
         {
-            foreach (System.Reflection.FieldInfo field in typeof (ContractNodes).GetFields())
+            foreach (System.Reflection.FieldInfo field in typeof(ContractNodes).GetFields())
             {
-                object[] cas = field.GetCustomAttributes(typeof (RepresentationFor), false);
+                object[] cas = field.GetCustomAttributes(typeof(RepresentationFor), false);
                 if (cas != null && cas.Length == 1)
                 {
                     field.SetValue(this, null);
@@ -486,7 +508,7 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 return m;
             }
-            
+
             return null;
         }
 
@@ -498,7 +520,7 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 return true;
             }
-            
+
             return false;
         }
 
@@ -616,7 +638,7 @@ namespace Microsoft.Contracts.Foxtrot
 
                 return mc.Operands[0];
             }
-            
+
             return null;
         }
 
@@ -736,7 +758,8 @@ namespace Microsoft.Contracts.Foxtrot
             if (AreAnyPure(method.ImplicitlyImplementedInterfaceMethods)) return true;
 
             if (IsForallMethod(method) || IsGenericForallMethod(method) || IsExistsMethod(method) ||
-                IsGenericExistsMethod(method)) return true;
+                IsGenericExistsMethod(method))
+                return true;
 
             if (IsFuncOrPredicate(method)) return true;
 
@@ -762,7 +785,7 @@ namespace Microsoft.Contracts.Foxtrot
                 method = method.Template;
             }
 
-            if (method == ResultTemplate) return true;
+            if (method == _resultTemplate) return true;
 
             // by name matching
             return method.MatchesContractByName(ResultName);
@@ -777,7 +800,7 @@ namespace Microsoft.Contracts.Foxtrot
                 method = method.Template;
             }
 
-            if (method == OldTemplate) return true;
+            if (method == _oldTemplate) return true;
 
             // by name matching
             return method.MatchesContractByName(OldName);
@@ -792,7 +815,7 @@ namespace Microsoft.Contracts.Foxtrot
                 method = method.Template;
             }
 
-            if (method == ParameterTemplate) return true;
+            if (method == _parameterTemplate) return true;
 
             // by name matching
             return method.MatchesContractByName(ValueAtReturnName);
@@ -807,7 +830,7 @@ namespace Microsoft.Contracts.Foxtrot
                 method = method.Template;
             }
 
-            if (method == ForAllTemplate) return true;
+            if (method == _forAllTemplate) return true;
 
             // by name matching
             if (method.TemplateParameters != null && method.TemplateParameters.Count > 0) return false;
@@ -824,7 +847,7 @@ namespace Microsoft.Contracts.Foxtrot
                 method = method.Template;
             }
 
-            if (method == ForAllGenericTemplate) return true;
+            if (method == _forAllGenericTemplate) return true;
 
             // by name matching
             if (method.TemplateParameters == null || method.TemplateParameters.Count != 1) return false;
@@ -835,12 +858,12 @@ namespace Microsoft.Contracts.Foxtrot
 
         public Method GetForAllTemplate
         {
-            get { return this.ForAllTemplate; }
+            get { return _forAllTemplate; }
         }
 
         public Method GetForAllGenericTemplate
         {
-            get { return this.ForAllGenericTemplate; }
+            get { return _forAllGenericTemplate; }
         }
 
         public bool IsExistsMethod(Method method)
@@ -852,7 +875,7 @@ namespace Microsoft.Contracts.Foxtrot
                 method = method.Template;
             }
 
-            if (method == ExistsTemplate) return true;
+            if (method == _existsTemplate) return true;
 
             // by name matching
             if (method.TemplateParameters != null && method.TemplateParameters.Count > 0) return false;
@@ -869,7 +892,7 @@ namespace Microsoft.Contracts.Foxtrot
                 method = method.Template;
             }
 
-            if (method == ExistsGenericTemplate) return true;
+            if (method == _existsGenericTemplate) return true;
 
             // by name matching
             if (method.TemplateParameters == null || method.TemplateParameters.Count != 1) return false;
@@ -879,12 +902,12 @@ namespace Microsoft.Contracts.Foxtrot
 
         public Method GetExistsTemplate
         {
-            get { return this.ExistsTemplate; }
+            get { return _existsTemplate; }
         }
 
         public Method GetExistsGenericTemplate
         {
-            get { return this.ExistsGenericTemplate; }
+            get { return _existsGenericTemplate; }
         }
 
         [Pure]

--- a/Foxtrot/Foxtrot/Documentation/ContractAssumeAssertStatement.cs
+++ b/Foxtrot/Foxtrot/Documentation/ContractAssumeAssertStatement.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 

--- a/Foxtrot/Foxtrot/Documentation/GenerateDocumentationFromPDB.cs
+++ b/Foxtrot/Foxtrot/Documentation/GenerateDocumentationFromPDB.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Compiler;
@@ -25,10 +14,10 @@ namespace Microsoft.Contracts.Foxtrot
 {
     public class GenerateDocumentationFromPDB : Inspector
     {
-        private int tabWidth;
-        private int tabStops;
-        private bool writeOutput;
-        private ContractNodes contracts;
+        private int _tabWidth;
+        private int _tabStops;
+        private bool _writeOutput;
+        private ContractNodes _contracts;
 
         public GenerateDocumentationFromPDB(ContractNodes contracts) : this(contracts, 2, false)
         {
@@ -36,16 +25,16 @@ namespace Microsoft.Contracts.Foxtrot
 
         public GenerateDocumentationFromPDB(ContractNodes contracts, int tabWidth, bool writeOutput)
         {
-            this.contracts = contracts;
-            this.tabWidth = tabWidth;
-            this.tabStops = 0;
-            this.writeOutput = writeOutput;
+            _contracts = contracts;
+            _tabWidth = tabWidth;
+            _tabStops = 0;
+            _writeOutput = writeOutput;
         }
 
         private void Indent()
         {
             string s = "";
-            s = s.PadLeft(tabStops*tabWidth);
+            s = s.PadLeft(_tabStops * _tabWidth);
             Console.Write(s);
         }
 
@@ -170,7 +159,7 @@ namespace Microsoft.Contracts.Foxtrot
                 if (!skip)
                 {
                     bStart = aEnd + 2;
-                    
+
                     while (Char.IsWhiteSpace(predicate[aEnd - 1]))
                         aEnd--;
 
@@ -196,12 +185,12 @@ namespace Microsoft.Contracts.Foxtrot
         // These aren't operators like + per se, but ones that will cause evaluation order to possibly change,
         // or alter the semantics of what might be in a predicate.
         // @TODO: Consider adding '~'
-        private static readonly string[] Operators = new string[]
+        private static readonly string[] s_operators = new string[]
         {"==", "!=", "=", "<", ">", "(", ")", "//", "/*", "*/"};
 
         private static bool ContainsNoOperators(string s, int start, int end)
         {
-            foreach (string op in Operators)
+            foreach (string op in s_operators)
             {
                 if (s.IndexOf(op) >= 0)
                 {
@@ -228,7 +217,7 @@ namespace Microsoft.Contracts.Foxtrot
         // Recognize only SIMPLE method calls, like "System.string.Equals("", "")".
         private static bool IsSimpleFunctionCall(string s, int start, int end)
         {
-            char[] badChars = {'+', '-', '*', '/', '~', '<', '=', '>', ';', '?', ':'};
+            char[] badChars = { '+', '-', '*', '/', '~', '<', '=', '>', ';', '?', ':' };
 
             int parenCount = 0;
             int index = start;
@@ -475,7 +464,7 @@ namespace Microsoft.Contracts.Foxtrot
                 else
                 {
                     if (text[i] == ',' && angleCount == 0 && parenCount == 0) return i;
-                    
+
                     if (text[i] == ')') parenCount++;
                     else if (text[i] == '(') parenCount--;
                     else if (text[i] == '>') angleCount++;
@@ -549,21 +538,21 @@ namespace Microsoft.Contracts.Foxtrot
 
         private struct DocSlice
         {
-            private SourceDocument doc;
-            private int startLine;
-            private int startColumn;
-            private int endLine;
-            private int count;
+            private SourceDocument _doc;
+            private int _startLine;
+            private int _startColumn;
+            private int _endLine;
+            private int _count;
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic"),
              System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
             [ContractInvariantMethod]
             private void ObjectInvariant()
             {
-                Contract.Invariant(this.doc != null);
-                Contract.Invariant(this.startLine > 0);
-                Contract.Invariant(this.startColumn >= 0);
-                Contract.Invariant(this.count >= 0);
+                Contract.Invariant(_doc != null);
+                Contract.Invariant(_startLine > 0);
+                Contract.Invariant(_startColumn >= 0);
+                Contract.Invariant(_count >= 0);
             }
 
             public DocSlice(SourceDocument doc, int startLine, int startColumn, int endLine)
@@ -571,11 +560,11 @@ namespace Microsoft.Contracts.Foxtrot
                 Contract.Requires(doc != null);
                 Contract.Requires(startLine > 0);
 
-                this.doc = doc;
-                this.startColumn = startColumn;
-                this.startLine = startLine;
-                this.endLine = endLine;
-                this.count = 0;
+                _doc = doc;
+                _startColumn = startColumn;
+                _startLine = startLine;
+                _endLine = endLine;
+                _count = 0;
 
                 // compute count
                 int i = startLine;
@@ -585,15 +574,15 @@ namespace Microsoft.Contracts.Foxtrot
                     string s = doc[i];
                     if (s == null) return;
 
-                    count += s.Length;
+                    _count += s.Length;
                     i++;
                 }
 
-                count -= startColumn;
-                if (count < 0)
+                _count -= startColumn;
+                if (_count < 0)
                 {
                     // problem. indicates source/pdb are out of date w.r.t each other
-                    count = 0;
+                    _count = 0;
                 }
             }
 
@@ -602,7 +591,7 @@ namespace Microsoft.Contracts.Foxtrot
                 get
                 {
                     Contract.Ensures(Contract.Result<int>() >= 0);
-                    return this.count;
+                    return _count;
                 }
             }
 
@@ -614,12 +603,12 @@ namespace Microsoft.Contracts.Foxtrot
                     Contract.Requires(column < Length);
 
                     int skipped = 0;
-                    int i = startLine;
-                    column += this.startColumn; // adjust
+                    int i = _startLine;
+                    column += _startColumn; // adjust
 
-                    while (i <= endLine)
+                    while (i <= _endLine)
                     {
-                        string s = doc[i];
+                        string s = _doc[i];
 
                         if (s == null)
                         {
@@ -644,13 +633,13 @@ namespace Microsoft.Contracts.Foxtrot
                 Contract.Requires(startIndex + length <= Length);
 
                 int skipped = 0;
-                int i = startLine;
+                int i = _startLine;
                 StringBuilder sb = null; // lazily create
-                startIndex += this.startColumn; // skip to column
+                startIndex += _startColumn; // skip to column
 
-                while (i <= endLine)
+                while (i <= _endLine)
                 {
-                    string s = doc[i];
+                    string s = _doc[i];
                     if (s == null)
                     {
                         throw new InvalidOperationException();
@@ -722,8 +711,8 @@ namespace Microsoft.Contracts.Foxtrot
 
         private class SourceDocument
         {
-            private TextReader tr;
-            private List<string> lines;
+            private TextReader _tr;
+            private List<string> _lines;
 
             public SourceDocument(string fileName)
             {
@@ -733,7 +722,7 @@ namespace Microsoft.Contracts.Foxtrot
                 }
                 try
                 {
-                    tr = File.OpenText(fileName);
+                    _tr = File.OpenText(fileName);
                 }
                 catch
                 {
@@ -752,9 +741,9 @@ namespace Microsoft.Contracts.Foxtrot
 
                     EnsureRead(line);
 
-                    if (lines != null && lines.Count > line)
+                    if (_lines != null && _lines.Count > line)
                     {
-                        return lines[line];
+                        return _lines[line];
                     }
 
                     return null;
@@ -763,26 +752,26 @@ namespace Microsoft.Contracts.Foxtrot
 
             private void EnsureRead(int line)
             {
-                if (tr == null) return;
+                if (_tr == null) return;
 
-                if (lines == null) lines = new List<string>();
+                if (_lines == null) _lines = new List<string>();
                 try
                 {
-                    while (lines.Count <= line)
+                    while (_lines.Count <= line)
                     {
-                        var linestring = tr.ReadLine();
+                        var linestring = _tr.ReadLine();
                         if (linestring == null)
                         {
-                            tr = null;
+                            _tr = null;
                             break;
                         }
 
-                        lines.Add(linestring);
+                        _lines.Add(linestring);
                     }
                 }
                 catch
                 {
-                    tr = null;
+                    _tr = null;
                 }
             }
         }
@@ -796,16 +785,16 @@ namespace Microsoft.Contracts.Foxtrot
             if (sourceName == null) return null;
 
             SourceDocument result;
-            if (!sourceTexts.TryGetValue(sourceName, out result))
+            if (!_sourceTexts.TryGetValue(sourceName, out result))
             {
                 result = new SourceDocument(sourceName);
-                sourceTexts.Add(sourceName, result);
+                _sourceTexts.Add(sourceName, result);
             }
 
             return result;
         }
 
-        private Dictionary<string, SourceDocument> sourceTexts = new Dictionary<string, SourceDocument>();
+        private Dictionary<string, SourceDocument> _sourceTexts = new Dictionary<string, SourceDocument>();
 
         private string GetSource(string prefix, SourceContext sctx)
         {
@@ -842,17 +831,17 @@ namespace Microsoft.Contracts.Foxtrot
         {
             if (typeNode == null) return;
 
-            if (writeOutput)
+            if (_writeOutput)
             {
                 Indent();
                 Console.WriteLine(typeNode.FullName);
-                this.tabStops++;
+                _tabStops++;
             }
 
             base.VisitTypeNode(typeNode);
-            if (writeOutput)
+            if (_writeOutput)
             {
-                this.tabStops--;
+                _tabStops--;
             }
         }
 
@@ -863,12 +852,12 @@ namespace Microsoft.Contracts.Foxtrot
             string source = GetSource("Contract.Invariant", sctx);
             if (source == null)
             {
-                if (writeOutput) Console.WriteLine("<error generating documentation>");
+                if (_writeOutput) Console.WriteLine("<error generating documentation>");
             }
             else
             {
                 invariant.SourceConditionText = new Literal(source, SystemTypes.String);
-                if (writeOutput)
+                if (_writeOutput)
                 {
                     Indent();
                     Console.WriteLine("{0}", source);
@@ -881,13 +870,13 @@ namespace Microsoft.Contracts.Foxtrot
         {
             if (method == null) return;
 
-            if (this.contracts != null && contracts.IsObjectInvariantMethod(method)) return;
+            if (_contracts != null && _contracts.IsObjectInvariantMethod(method)) return;
 
-            if (writeOutput)
+            if (_writeOutput)
             {
                 Indent();
                 Console.WriteLine(method.FullName);
-                this.tabStops++;
+                _tabStops++;
             }
 
             base.VisitMethod(method);
@@ -898,9 +887,9 @@ namespace Microsoft.Contracts.Foxtrot
                 this.VisitRequiresList(method.Contract.Validations);
             }
 
-            if (writeOutput)
+            if (_writeOutput)
             {
-                this.tabStops--;
+                _tabStops--;
             }
         }
 
@@ -910,7 +899,7 @@ namespace Microsoft.Contracts.Foxtrot
             string source = GetSource("if", ContextForTextExtraction(otherwise), out isVB, true);
             if (source == null)
             {
-                if (writeOutput) Console.WriteLine("<error generating documentation>");
+                if (_writeOutput) Console.WriteLine("<error generating documentation>");
             }
             else
             {
@@ -931,7 +920,7 @@ namespace Microsoft.Contracts.Foxtrot
                         otherwise.SourceConditionText = new Literal(source, SystemTypes.String);
                     }
 
-                    if (writeOutput)
+                    if (_writeOutput)
                     {
                         Indent();
                         if (negatedCondition != null)
@@ -981,12 +970,12 @@ namespace Microsoft.Contracts.Foxtrot
             string source = GetSource("Contract.Requires", ContextForTextExtraction(plain));
             if (source == null)
             {
-                if (writeOutput) Console.WriteLine("<error generating documentation>");
+                if (_writeOutput) Console.WriteLine("<error generating documentation>");
             }
             else
             {
                 plain.SourceConditionText = new Literal(source, SystemTypes.String);
-                if (writeOutput)
+                if (_writeOutput)
                 {
                     Indent();
                     Console.WriteLine("{0}", source);
@@ -1002,12 +991,12 @@ namespace Microsoft.Contracts.Foxtrot
             string source = GetSource("Contract.Ensures", ContextForTextExtraction(normal));
             if (source == null)
             {
-                if (writeOutput) Console.WriteLine("<error generating documentation>");
+                if (_writeOutput) Console.WriteLine("<error generating documentation>");
             }
             else
             {
                 normal.SourceConditionText = new Literal(source, SystemTypes.String);
-                if (writeOutput)
+                if (_writeOutput)
                 {
                     Indent();
                     Console.WriteLine("{0}", source);
@@ -1022,12 +1011,12 @@ namespace Microsoft.Contracts.Foxtrot
             string source = GetSource("Contract.Ensures", ContextForTextExtraction(exceptional));
             if (source == null)
             {
-                if (writeOutput) Console.WriteLine("<error generating documentation>");
+                if (_writeOutput) Console.WriteLine("<error generating documentation>");
             }
             else
             {
                 exceptional.SourceConditionText = new Literal(source, SystemTypes.String);
-                if (writeOutput)
+                if (_writeOutput)
                 {
                     Indent();
                     Console.WriteLine("{0}", source);
@@ -1058,8 +1047,8 @@ namespace Microsoft.Contracts.Foxtrot
 
             if (m == null) goto done;
 
-            if (m != contracts.AssertMethod && m != contracts.AssumeMethod
-                && m != contracts.AssertWithMsgMethod && m != contracts.AssumeWithMsgMethod)
+            if (m != _contracts.AssertMethod && m != _contracts.AssumeMethod
+                && m != _contracts.AssertWithMsgMethod && m != _contracts.AssumeWithMsgMethod)
             {
                 goto done;
             }
@@ -1068,7 +1057,7 @@ namespace Microsoft.Contracts.Foxtrot
             string source = GetSource("Contract.Assert", sctx);
             if (source == null)
             {
-                if (writeOutput) Console.WriteLine("<error generating documentation>");
+                if (_writeOutput) Console.WriteLine("<error generating documentation>");
             }
             else
             {
@@ -1076,7 +1065,7 @@ namespace Microsoft.Contracts.Foxtrot
             }
 
         done:
-            
+
             this.VisitExpressionStatement(statement);
             return statement;
         }

--- a/Foxtrot/Foxtrot/Extraction/AbbreviationDuplicator.cs
+++ b/Foxtrot/Foxtrot/Extraction/AbbreviationDuplicator.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Compiler;
@@ -24,53 +13,53 @@ namespace Microsoft.Contracts.Foxtrot
     /// </summary>
     internal class AbbreviationDuplicator : DuplicatorForContractsAndClosures
     {
-        private ExpressionList actuals;
-        private Expression targetObject;
-        private Method abbreviation;
-        private TrivialHashtable localsInActuals;
+        private ExpressionList _actuals;
+        private Expression _targetObject;
+        private Method _abbreviation;
+        private TrivialHashtable _localsInActuals;
 
         public AbbreviationDuplicator(Method sourceMethod, Method targetMethod, ContractNodes contractNodes,
             Method abbreviation, Expression targetObject, ExpressionList actuals)
             : base(targetMethod.DeclaringType.DeclaringModule, sourceMethod, targetMethod, contractNodes, false)
         {
-            this.targetObject = targetObject;
-            this.abbreviation = abbreviation;
-            this.actuals = actuals;
+            _targetObject = targetObject;
+            _abbreviation = abbreviation;
+            _actuals = actuals;
 
-            this.localsInActuals = new TrivialHashtable();
+            _localsInActuals = new TrivialHashtable();
 
             PopulateLocalsInActuals();
         }
 
         private void PopulateLocalsInActuals()
         {
-            var finder = new FindLocalsInActuals(this.localsInActuals);
+            var finder = new FindLocalsInActuals(_localsInActuals);
 
-            finder.VisitExpression(this.targetObject);
-            finder.VisitExpressionList(this.actuals);
+            finder.VisitExpression(_targetObject);
+            finder.VisitExpressionList(_actuals);
         }
 
         private class FindLocalsInActuals : Inspector
         {
-            private TrivialHashtable localsFound;
+            private TrivialHashtable _localsFound;
 
             public FindLocalsInActuals(TrivialHashtable target)
             {
-                this.localsFound = target;
+                _localsFound = target;
             }
 
             public override void VisitLocal(Local local)
             {
                 if (local == null) return;
 
-                this.localsFound[local.UniqueKey] = local;
+                _localsFound[local.UniqueKey] = local;
             }
         }
 
         public override Expression VisitThis(This This)
         {
-            if (This.DeclaringMethod == abbreviation)
-                return (Expression) this.Visit(this.targetObject);
+            if (This.DeclaringMethod == _abbreviation)
+                return (Expression)this.Visit(_targetObject);
 
             if (This.DeclaringMethod == this.targetMethod)
                 // important lower case. Upper case is Duplicator's target method
@@ -83,13 +72,13 @@ namespace Microsoft.Contracts.Foxtrot
         {
             if (parameter == null) return null;
 
-            if (parameter.DeclaringMethod == abbreviation)
+            if (parameter.DeclaringMethod == _abbreviation)
             {
                 var argIndex = parameter.ParameterListIndex;
 
-                if (argIndex >= actuals.Count) throw new InvalidOperationException("bad parameter/actual list");
+                if (argIndex >= _actuals.Count) throw new InvalidOperationException("bad parameter/actual list");
 
-                return (Expression) this.Visit(actuals[argIndex]);
+                return (Expression)this.Visit(_actuals[argIndex]);
             }
 
             if (parameter.DeclaringMethod == this.targetMethod)
@@ -105,7 +94,7 @@ namespace Microsoft.Contracts.Foxtrot
         {
             if (local == null) return null;
 
-            if (this.localsInActuals[local.UniqueKey] != null) return local; // don't copy
+            if (_localsInActuals[local.UniqueKey] != null) return local; // don't copy
 
             return base.VisitLocal(local);
         }
@@ -163,7 +152,7 @@ namespace Microsoft.Contracts.Foxtrot
         {
             var result = base.VisitRequiresPlain(plain);
 
-            result.UserMessage = (Expression) Visit(result.UserMessage);
+            result.UserMessage = (Expression)Visit(result.UserMessage);
 
             return result;
         }
@@ -172,7 +161,7 @@ namespace Microsoft.Contracts.Foxtrot
         {
             var result = base.VisitEnsuresExceptional(exceptional);
 
-            result.UserMessage = (Expression) Visit(result.UserMessage);
+            result.UserMessage = (Expression)Visit(result.UserMessage);
 
             return result;
         }
@@ -181,7 +170,7 @@ namespace Microsoft.Contracts.Foxtrot
         {
             var result = base.VisitEnsuresNormal(normal);
 
-            result.UserMessage = (Expression) Visit(result.UserMessage);
+            result.UserMessage = (Expression)Visit(result.UserMessage);
 
             return result;
         }

--- a/Foxtrot/Foxtrot/Extraction/AsyncContractDuplicator.cs
+++ b/Foxtrot/Foxtrot/Extraction/AsyncContractDuplicator.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 
@@ -18,17 +7,17 @@ namespace Microsoft.Contracts.Foxtrot
 {
     internal class AsyncContractDuplicator : Duplicator
     {
-        private TypeNode parentType;
+        private TypeNode _parentType;
 
         public AsyncContractDuplicator(TypeNode parentType, Module module)
             : base(module, parentType)
         {
-            this.parentType = parentType;
+            _parentType = parentType;
         }
 
         public override Expression VisitLocal(Local local)
         {
-            if (HelperMethods.IsClosureType(this.parentType, local.Type))
+            if (HelperMethods.IsClosureType(_parentType, local.Type))
             {
                 // don't copy local as we need to share this closure local
                 return local;

--- a/Foxtrot/Foxtrot/Extraction/AsyncReturnValueQuery.cs
+++ b/Foxtrot/Foxtrot/Extraction/AsyncReturnValueQuery.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 
@@ -18,15 +7,15 @@ namespace Microsoft.Contracts.Foxtrot
 {
     internal class AsyncReturnValueQuery : InspectorIncludingClosures
     {
-        private bool foundReturnValueTaskResult;
-        private ContractNodes contractNodes;
-        private TypeNode actualResultType;
+        private bool _foundReturnValueTaskResult;
+        private ContractNodes _contractNodes;
+        private TypeNode _actualResultType;
 
         public AsyncReturnValueQuery(ContractNodes contractNodes, Method currentMethod, TypeNode actualResultType)
         {
-            this.contractNodes = contractNodes;
+            _contractNodes = contractNodes;
             this.CurrentMethod = currentMethod;
-            this.actualResultType = actualResultType;
+            _actualResultType = actualResultType;
         }
 
         /// <summary>
@@ -39,7 +28,7 @@ namespace Microsoft.Contracts.Foxtrot
 
             v.Visit(node);
 
-            return v.foundReturnValueTaskResult;
+            return v._foundReturnValueTaskResult;
         }
 
         public override void VisitMethodCall(MethodCall call)
@@ -65,9 +54,9 @@ namespace Microsoft.Contracts.Foxtrot
                         if (calledMethod2 != null)
                         {
                             Method template2 = calledMethod2.Template;
-                            if (contractNodes.IsResultMethod(template2))
+                            if (_contractNodes.IsResultMethod(template2))
                             {
-                                this.foundReturnValueTaskResult = true;
+                                _foundReturnValueTaskResult = true;
                                 //return new ReturnValue(calledMethod.DeclaringType.TemplateArguments[0]);
                                 return;
                             }
@@ -76,12 +65,12 @@ namespace Microsoft.Contracts.Foxtrot
                 }
             }
 
-            if (this.actualResultType != null && contractNodes.IsResultMethod(template) &&
-                calledMethod.ReturnType == this.actualResultType)
+            if (_actualResultType != null && _contractNodes.IsResultMethod(template) &&
+                calledMethod.ReturnType == _actualResultType)
             {
                 // using Contract.Result<T>() in a Task<T> returning method, this is a shorthand for
                 // Contract.Result<Task<T>>().Result
-                this.foundReturnValueTaskResult = true;
+                _foundReturnValueTaskResult = true;
                 return;
             }
 

--- a/Foxtrot/Foxtrot/Extraction/CheckLocals.cs
+++ b/Foxtrot/Foxtrot/Extraction/CheckLocals.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 
@@ -26,11 +15,11 @@ namespace Microsoft.Contracts.Foxtrot
     internal class CheckLocals : Inspector
     {
         internal Local reUseOfExistingLocal = null;
-        private GatherLocals gatherLocals;
+        private GatherLocals _gatherLocals;
 
         public CheckLocals(GatherLocals gatherLocals)
         {
-            this.gatherLocals = gatherLocals;
+            _gatherLocals = gatherLocals;
         }
 
         /// <summary>
@@ -42,7 +31,7 @@ namespace Microsoft.Contracts.Foxtrot
         /// <returns></returns>
         public override void VisitLocal(Local local)
         {
-            if (gatherLocals.Locals[local.UniqueKey] != null)
+            if (_gatherLocals.Locals[local.UniqueKey] != null)
             {
                 if (local.Name != null && local.Name.Name.StartsWith("VB$CG$"))
                 {

--- a/Foxtrot/Foxtrot/Extraction/ClousotExtractor.cs
+++ b/Foxtrot/Foxtrot/Extraction/ClousotExtractor.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Compiler;
@@ -50,10 +39,10 @@ namespace Microsoft.Contracts.Foxtrot
 
         protected override Statement ExtraAssumeFalseOnThrow()
         {
-            return 
+            return
                 new ExpressionStatement(
                     new MethodCall(
-                        new MemberBinding(null, this.contractNodes.AssumeMethod), new ExpressionList(Literal.False), 
+                        new MemberBinding(null, this.contractNodes.AssumeMethod), new ExpressionList(Literal.False),
                         NodeType.Call));
         }
 
@@ -94,7 +83,7 @@ namespace Microsoft.Contracts.Foxtrot
             }
         }
 
-        private bool insideInvariant;
+        private bool _insideInvariant;
 
 #if true // ExtractorVisitor now does this
 
@@ -140,7 +129,7 @@ namespace Microsoft.Contracts.Foxtrot
                         return new ReturnValue(calledMethod.ReturnType, call.SourceContext);
                     }
                 }
-                else if (insideInvariant &&
+                else if (_insideInvariant &&
                          contractNodes.IsInvariantMethod(calledMethod))
                 {
                     Expression condition = call.Operands[0];
@@ -155,7 +144,7 @@ namespace Microsoft.Contracts.Foxtrot
 
         public override Invariant VisitInvariant(Invariant invariant)
         {
-            this.insideInvariant = true;
+            _insideInvariant = true;
 
             try
             {
@@ -163,7 +152,7 @@ namespace Microsoft.Contracts.Foxtrot
             }
             finally
             {
-                this.insideInvariant = false;
+                _insideInvariant = false;
             }
         }
 

--- a/Foxtrot/Foxtrot/Extraction/CountPopExpressions.cs
+++ b/Foxtrot/Foxtrot/Extraction/CountPopExpressions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 

--- a/Foxtrot/Foxtrot/Extraction/Extractor.cs
+++ b/Foxtrot/Foxtrot/Extraction/Extractor.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 // needed for defining exception .ctors
@@ -168,11 +157,11 @@ namespace Microsoft.Contracts.Foxtrot
                     {
                         return contracts;
                     }
-                    
+
                     string nameOfAssemblyContainingContracts = assemblyContractsLiveIn.Name;
-                    
+
                     Contract.Assume(assemblyToVisit.AssemblyReferences != null);
-                    
+
                     foreach (var ar in assemblyToVisit.AssemblyReferences)
                     {
                         Contract.Assume(ar != null);

--- a/Foxtrot/Foxtrot/Extraction/ExtractorException.cs
+++ b/Foxtrot/Foxtrot/Extraction/ExtractorException.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Runtime.Serialization;

--- a/Foxtrot/Foxtrot/Extraction/ExtractorExtensions.cs
+++ b/Foxtrot/Foxtrot/Extraction/ExtractorExtensions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 
@@ -24,12 +13,12 @@ namespace Microsoft.Contracts.Foxtrot
             {
                 // nested type
                 var parent = typeNode.DeclaringType.FindShadow(shadowAssembly);
-                
+
                 if (parent == null) return null;
-                
+
                 return parent.GetNestedType(typeNode.Name);
             }
-            
+
             // namespace type
             return shadowAssembly.GetType(typeNode.Namespace, typeNode.Name);
         }
@@ -189,7 +178,7 @@ namespace Microsoft.Contracts.Foxtrot
 
             // recurse structurally. For now, we cheat and just use the string names
             if (type.IsStructurallyEquivalentTo(that)) return true;
-            
+
             return type.FullName == that.FullName;
         }
     }

--- a/Foxtrot/Foxtrot/Extraction/FilterForRuntime.cs
+++ b/Foxtrot/Foxtrot/Extraction/FilterForRuntime.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 
@@ -21,13 +10,15 @@ namespace Microsoft.Contracts.Foxtrot
     /// </summary>
     internal class FilterForRuntime : StandardVisitor
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields")] private ContractNodes contractNodes;
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields")] private ContractNodes targetContractNodes;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields")]
+        private ContractNodes _contractNodes;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields")]
+        private ContractNodes _targetContractNodes;
 
         public FilterForRuntime(ContractNodes contractNodes, ContractNodes targetContractNodes)
         {
-            this.contractNodes = contractNodes;
-            this.targetContractNodes = targetContractNodes;
+            _contractNodes = contractNodes;
+            _targetContractNodes = targetContractNodes;
         }
 
         public override AttributeNode VisitAttributeNode(AttributeNode attribute)
@@ -51,7 +42,7 @@ namespace Microsoft.Contracts.Foxtrot
                         return attribute;
                     default:
                         return null;
-                    // Don't propagate any other attributes from System.Diagnostics.Contracts, they might be types defined only in mscorlib.contracts.dll
+                        // Don't propagate any other attributes from System.Diagnostics.Contracts, they might be types defined only in mscorlib.contracts.dll
                 }
             }
 

--- a/Foxtrot/Foxtrot/Extraction/FindLocals.cs
+++ b/Foxtrot/Foxtrot/Extraction/FindLocals.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 using Microsoft.Research.DataStructures;
@@ -19,7 +8,7 @@ namespace Microsoft.Contracts.Foxtrot
 {
     internal class FindLocals : Inspector
     {
-        private Set<Local> locals = new Set<Local>();
+        private Set<Local> _locals = new Set<Local>();
 
         private FindLocals()
         {
@@ -29,12 +18,12 @@ namespace Microsoft.Contracts.Foxtrot
         {
             var n = new FindLocals();
             n.Visit(e);
-            return n.locals;
+            return n._locals;
         }
 
         public override void VisitLocal(Local local)
         {
-            this.locals.Add(local);
+            _locals.Add(local);
         }
     }
 }

--- a/Foxtrot/Foxtrot/Extraction/ForwardingDuplicator.cs
+++ b/Foxtrot/Foxtrot/Extraction/ForwardingDuplicator.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 using System.Diagnostics;
@@ -55,14 +44,14 @@ namespace Microsoft.Contracts.Foxtrot
     [ContractVerification(true)]
     internal class ForwardingDuplicator : Duplicator
     {
-        private readonly ContractNodes contractNodes;
-        private readonly ContractNodes targetContractNodes;
+        private readonly ContractNodes _contractNodes;
+        private readonly ContractNodes _targetContractNodes;
 
         public ForwardingDuplicator(Module /*!*/ module, TypeNode type, ContractNodes contractNodes,
             ContractNodes targetContractNodes) : base(module, type)
         {
-            this.contractNodes = contractNodes;
-            this.targetContractNodes = targetContractNodes;
+            _contractNodes = contractNodes;
+            _targetContractNodes = targetContractNodes;
         }
 
         /// <summary>
@@ -170,24 +159,24 @@ namespace Microsoft.Contracts.Foxtrot
             var result = base.VisitMemberBinding(memberBinding);
 
             memberBinding = result as MemberBinding;
-            if (this.targetContractNodes != null && memberBinding != null && memberBinding.TargetObject == null)
+            if (_targetContractNodes != null && memberBinding != null && memberBinding.TargetObject == null)
             {
                 // all methods are static
                 Method method = memberBinding.BoundMember as Method;
                 if (method == null) return memberBinding;
 
-                Contract.Assume(this.contractNodes != null);
+                Contract.Assume(_contractNodes != null);
 
                 if (method.Template == null)
                 {
-                    if (contractNodes.IsExistsMethod(method))
+                    if (_contractNodes.IsExistsMethod(method))
                     {
-                        return new MemberBinding(null, targetContractNodes.GetExistsTemplate);
+                        return new MemberBinding(null, _targetContractNodes.GetExistsTemplate);
                     }
-                    
-                    if (contractNodes.IsForallMethod(method))
+
+                    if (_contractNodes.IsForallMethod(method))
                     {
-                        return new MemberBinding(null, targetContractNodes.GetForAllTemplate);
+                        return new MemberBinding(null, _targetContractNodes.GetForAllTemplate);
                     }
                 }
                 else
@@ -196,24 +185,24 @@ namespace Microsoft.Contracts.Foxtrot
                     Method template = method.Template;
                     var templateArgs = method.TemplateArguments;
 
-                    if (contractNodes.IsGenericForallMethod(template))
+                    if (_contractNodes.IsGenericForallMethod(template))
                     {
                         Contract.Assume(templateArgs != null);
-                        Contract.Assume(targetContractNodes.GetForAllGenericTemplate != null);
+                        Contract.Assume(_targetContractNodes.GetForAllGenericTemplate != null);
 
                         return new MemberBinding(null,
-                            targetContractNodes.GetForAllGenericTemplate.GetTemplateInstance(
-                                targetContractNodes.GetForAllGenericTemplate.DeclaringType, templateArgs[0]));
+                            _targetContractNodes.GetForAllGenericTemplate.GetTemplateInstance(
+                                _targetContractNodes.GetForAllGenericTemplate.DeclaringType, templateArgs[0]));
                     }
-                    
-                    if (contractNodes.IsGenericExistsMethod(template))
+
+                    if (_contractNodes.IsGenericExistsMethod(template))
                     {
                         Contract.Assume(templateArgs != null);
-                        Contract.Assume(targetContractNodes.GetExistsGenericTemplate != null);
+                        Contract.Assume(_targetContractNodes.GetExistsGenericTemplate != null);
 
                         return new MemberBinding(null,
-                            targetContractNodes.GetExistsGenericTemplate.GetTemplateInstance(
-                                targetContractNodes.GetExistsGenericTemplate.DeclaringType, templateArgs[0]));
+                            _targetContractNodes.GetExistsGenericTemplate.GetTemplateInstance(
+                                _targetContractNodes.GetExistsGenericTemplate.DeclaringType, templateArgs[0]));
                     }
                 }
             }
@@ -228,64 +217,64 @@ namespace Microsoft.Contracts.Foxtrot
 
             if (attribute == null) return null;
 
-            if (this.targetContractNodes == null) return attribute;
+            if (_targetContractNodes == null) return attribute;
 
-            if (attribute.Type == this.contractNodes.ContractClassAttribute)
+            if (attribute.Type == _contractNodes.ContractClassAttribute)
             {
                 return
                     new AttributeNode(
                         new MemberBinding(null,
-                            this.targetContractNodes.ContractClassAttribute.GetConstructor(SystemTypes.Type)),
+                            _targetContractNodes.ContractClassAttribute.GetConstructor(SystemTypes.Type)),
                         attribute.Expressions);
             }
-            
-            if (attribute.Type == this.contractNodes.ContractClassForAttribute)
+
+            if (attribute.Type == _contractNodes.ContractClassForAttribute)
             {
                 return
                     new AttributeNode(
                         new MemberBinding(null,
-                            this.targetContractNodes.ContractClassForAttribute.GetConstructor(SystemTypes.Type)),
+                            _targetContractNodes.ContractClassForAttribute.GetConstructor(SystemTypes.Type)),
                         attribute.Expressions);
             }
-            
-            if (attribute.Type == this.contractNodes.IgnoreAtRuntimeAttribute)
+
+            if (attribute.Type == _contractNodes.IgnoreAtRuntimeAttribute)
             {
                 return
                     new AttributeNode(
-                        new MemberBinding(null, this.targetContractNodes.IgnoreAtRuntimeAttribute.GetConstructor()),
+                        new MemberBinding(null, _targetContractNodes.IgnoreAtRuntimeAttribute.GetConstructor()),
                         null);
             }
-            
-            if (attribute.Type == this.contractNodes.InvariantMethodAttribute)
+
+            if (attribute.Type == _contractNodes.InvariantMethodAttribute)
             {
                 return
                     new AttributeNode(
-                        new MemberBinding(null, this.targetContractNodes.InvariantMethodAttribute.GetConstructor()),
+                        new MemberBinding(null, _targetContractNodes.InvariantMethodAttribute.GetConstructor()),
                         null);
             }
-            
-            if (attribute.Type == this.contractNodes.PureAttribute)
+
+            if (attribute.Type == _contractNodes.PureAttribute)
             {
                 return
-                    new AttributeNode(new MemberBinding(null, this.targetContractNodes.PureAttribute.GetConstructor()),
+                    new AttributeNode(new MemberBinding(null, _targetContractNodes.PureAttribute.GetConstructor()),
                         null);
             }
-            
-            if (attribute.Type == this.contractNodes.SpecPublicAttribute)
+
+            if (attribute.Type == _contractNodes.SpecPublicAttribute)
             {
                 return
                     new AttributeNode(
                         new MemberBinding(null,
-                            this.targetContractNodes.SpecPublicAttribute.GetConstructor(SystemTypes.String)),
+                            _targetContractNodes.SpecPublicAttribute.GetConstructor(SystemTypes.String)),
                         attribute.Expressions);
             }
-            
-            if (attribute.Type == this.contractNodes.VerifyAttribute)
+
+            if (attribute.Type == _contractNodes.VerifyAttribute)
             {
                 return
                     new AttributeNode(
                         new MemberBinding(null,
-                            this.targetContractNodes.VerifyAttribute.GetConstructor(SystemTypes.Boolean)),
+                            _targetContractNodes.VerifyAttribute.GetConstructor(SystemTypes.Boolean)),
                         attribute.Expressions);
             }
 

--- a/Foxtrot/Foxtrot/Extraction/GatherLocals.cs
+++ b/Foxtrot/Foxtrot/Extraction/GatherLocals.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 
@@ -25,7 +14,7 @@ namespace Microsoft.Contracts.Foxtrot
     /// </summary>
     internal sealed class GatherLocals : Inspector
     {
-        private Local exemptResultLocal;
+        private Local _exemptResultLocal;
         public TrivialHashtable Locals = new TrivialHashtable();
 
         /// <summary>
@@ -33,7 +22,7 @@ namespace Microsoft.Contracts.Foxtrot
         /// </summary>
         private bool IsLocalExempt(Local local)
         {
-            if (local == exemptResultLocal) return true;
+            if (local == _exemptResultLocal) return true;
 
             bool strict = false;
 
@@ -47,7 +36,7 @@ namespace Microsoft.Contracts.Foxtrot
 
             return HelperMethods.IsCompilerGenerated(localType)
                    || local.Name.Name == "_preConditionHolds"
-                // introduced by extractor itself for legacy pre-conditions
+                   // introduced by extractor itself for legacy pre-conditions
                    || (strict
                        ? (LocalNameIsExempt(local.Name.Name))
                        : (HelperMethods.IsDelegateType(localType)
@@ -78,7 +67,7 @@ namespace Microsoft.Contracts.Foxtrot
         {
             if (assignment.Target is Local && IsResultExpression(assignment.Source))
             {
-                exemptResultLocal = (Local) assignment.Target;
+                _exemptResultLocal = (Local)assignment.Target;
             }
 
             base.VisitAssignmentStatement(assignment);

--- a/Foxtrot/Foxtrot/Extraction/LookForBadStuff.cs
+++ b/Foxtrot/Foxtrot/Extraction/LookForBadStuff.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 
@@ -18,13 +7,13 @@ namespace Microsoft.Contracts.Foxtrot
 {
     internal sealed class LookForBadStuff : Inspector
     {
-        private ContractNodes contractNodes;
+        private ContractNodes _contractNodes;
         internal Statement ReturnStatement;
         internal bool BadStuffFound = false;
 
         internal LookForBadStuff(ContractNodes contractNodes)
         {
-            this.contractNodes = contractNodes;
+            _contractNodes = contractNodes;
         }
 
         public override void VisitReturn(Return Return)
@@ -37,10 +26,10 @@ namespace Microsoft.Contracts.Foxtrot
         {
             Method methodCall = HelperMethods.IsMethodCall(statement);
 
-            if (methodCall == this.contractNodes.AssertMethod ||
-                methodCall == this.contractNodes.AssertWithMsgMethod ||
-                methodCall == this.contractNodes.AssumeMethod ||
-                methodCall == this.contractNodes.AssumeWithMsgMethod)
+            if (methodCall == _contractNodes.AssertMethod ||
+                methodCall == _contractNodes.AssertWithMsgMethod ||
+                methodCall == _contractNodes.AssumeMethod ||
+                methodCall == _contractNodes.AssumeWithMsgMethod)
             {
                 this.BadStuffFound = true;
             }

--- a/Foxtrot/Foxtrot/Extraction/ReplaceBranchTarget.cs
+++ b/Foxtrot/Foxtrot/Extraction/ReplaceBranchTarget.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 
@@ -40,22 +29,22 @@ namespace Microsoft.Contracts.Foxtrot
     /// </summary>
     internal sealed class ReplaceBranchTarget : Inspector
     {
-        private Block branchTargetToReplace;
-        private Block newBranchTarget;
+        private Block _branchTargetToReplace;
+        private Block _newBranchTarget;
 
         public ReplaceBranchTarget(Block blockToReplace, Block newTarget)
         {
-            branchTargetToReplace = blockToReplace;
-            newBranchTarget = newTarget;
+            _branchTargetToReplace = blockToReplace;
+            _newBranchTarget = newTarget;
         }
 
         public override void VisitBranch(Branch branch)
         {
             if (branch == null || branch.Target == null) return;
 
-            if (branch.Target == branchTargetToReplace)
+            if (branch.Target == _branchTargetToReplace)
             {
-                branch.Target = this.newBranchTarget;
+                branch.Target = _newBranchTarget;
                 return;
             }
 

--- a/Foxtrot/Foxtrot/Extraction/ScrubContractClass.cs
+++ b/Foxtrot/Foxtrot/Extraction/ScrubContractClass.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Compiler;
 using System.Diagnostics.Contracts;
@@ -29,13 +18,13 @@ namespace Microsoft.Contracts.Foxtrot
     /// </summary>
     internal sealed class ScrubContractClass : InspectorIncludingClosures
     {
-        private Class contractClass;
-        private TypeNode abstractClass;
-        private ExtractorVisitor parent;
+        private Class _contractClass;
+        private TypeNode _abstractClass;
+        private ExtractorVisitor _parent;
 
         private TypeNode OriginalType
         {
-            get { return this.abstractClass; }
+            get { return _abstractClass; }
         }
 
         public ScrubContractClass(ExtractorVisitor parent, Class contractClass, TypeNode originalType)
@@ -43,21 +32,21 @@ namespace Microsoft.Contracts.Foxtrot
             Contract.Requires(TypeNode.IsCompleteTemplate(contractClass));
             Contract.Requires(TypeNode.IsCompleteTemplate(originalType));
 
-            this.parent = parent;
-            this.contractClass = contractClass;
-            this.abstractClass = originalType;
+            _parent = parent;
+            _contractClass = contractClass;
+            _abstractClass = originalType;
         }
 
-        private Method currentMethod;
+        private Method _currentMethod;
 
         public override void VisitMethod(Method method)
         {
-            this.currentMethod = method;
-            this.currentSourceContext = default(SourceContext);
+            _currentMethod = method;
+            _currentSourceContext = default(SourceContext);
             base.VisitMethod(method);
         }
 
-        private SourceContext currentSourceContext;
+        private SourceContext _currentSourceContext;
 
         public override void VisitStatementList(StatementList statements)
         {
@@ -70,7 +59,7 @@ namespace Microsoft.Contracts.Foxtrot
 
                 if (stmt.SourceContext.IsValid)
                 {
-                    this.currentSourceContext = stmt.SourceContext;
+                    _currentSourceContext = stmt.SourceContext;
                 }
 
                 this.Visit(stmt);
@@ -89,13 +78,13 @@ namespace Microsoft.Contracts.Foxtrot
             Contract.Assume(member.DeclaringType != null, "top-level types should not be memberbound");
 
             var declaringType = HelperMethods.Unspecialize(member.DeclaringType);
-            if (declaringType == contractClass)
+            if (declaringType == _contractClass)
             {
                 // must reroute
                 Method method = member as Method;
                 if (method != null)
                 {
-                    if (HelperMethods.IsClosureMethod(this.contractClass, HelperMethods.Unspecialize(method))) return;
+                    if (HelperMethods.IsClosureMethod(_contractClass, HelperMethods.Unspecialize(method))) return;
 
                     var template = method.Template;
 
@@ -120,10 +109,10 @@ namespace Microsoft.Contracts.Foxtrot
                     }
 
                     // couldn't find target: must issue error
-                    parent.HandleError(this.currentMethod, 1075,
+                    _parent.HandleError(_currentMethod, 1075,
                         string.Format(
                             "Contract class '{0}' references member '{1}' which is not part of the abstract class/interface being annotated.",
-                            this.contractClass.FullName, member.FullName), currentSourceContext);
+                            _contractClass.FullName, member.FullName), _currentSourceContext);
                 }
             }
         }
@@ -134,7 +123,7 @@ namespace Microsoft.Contracts.Foxtrot
 
             var type = HelperMethods.Unspecialize(field.Type);
 
-            if (type == contractClass)
+            if (type == _contractClass)
             {
                 if (field.Type.TemplateArguments != null)
                 {
@@ -160,7 +149,7 @@ namespace Microsoft.Contracts.Foxtrot
             var memberBinding = call.Callee as MemberBinding;
             if (memberBinding == null) return;
 
-            Method method = (Method) memberBinding.BoundMember;
+            Method method = (Method)memberBinding.BoundMember;
             var dt = method.DeclaringType;
             if (dt is Interface)
             {

--- a/Foxtrot/Foxtrot/Extraction/VisitorIncludingClosures.cs
+++ b/Foxtrot/Foxtrot/Extraction/VisitorIncludingClosures.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
 using System.Compiler;
@@ -19,14 +8,14 @@ namespace Microsoft.Contracts.Foxtrot
 {
     internal class VisitorIncludingClosures : StandardVisitor
     {
-        private Method currentMethod;
+        private Method _currentMethod;
 
         protected Method CurrentMethod
         {
-            get { return this.currentMethod; }
+            get { return _currentMethod; }
             set
             {
-                this.currentMethod = value;
+                _currentMethod = value;
 
                 if (value != null)
                 {
@@ -100,25 +89,25 @@ namespace Microsoft.Contracts.Foxtrot
                 }
             }
 
-            JustVisit:
-            
+        JustVisit:
+
             return base.VisitConstruct(cons);
         }
 
-        private Stack<Method> delegates = new Stack<Method>();
+        private Stack<Method> _delegates = new Stack<Method>();
 
         public virtual void VisitAnonymousDelegate(Method method)
         {
             if (method == null) return;
 
-            delegates.Push(method);
+            _delegates.Push(method);
             try
             {
                 this.VisitBlock(method.Body);
             }
             finally
             {
-                delegates.Pop();
+                _delegates.Pop();
             }
         }
     }

--- a/Foxtrot/Foxtrot/Properties/AssemblyInfo.cs
+++ b/Foxtrot/Foxtrot/Properties/AssemblyInfo.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
This reformat operation used dotnet/codeformatter@1d719e4e with the default settings.