### PR TITLE
Add initial AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: 1.9.10000.{build}
+os: Visual Studio 2015 RC
+init:
+- ps: git config --global core.autocrlf true
+- ps: Update-AppveyorBuild -Version "1.9.1$(Get-Date -format MMdd).$env:appveyor_build_number"
+build_script:
+- ps: ./buildCC "1.9.1$(Get-Date -format MMdd).$env:appveyor_build_number"
+test: off
+#  assemblies:
+#  - '**\ClousotCacheTests\bin\Debug\ClousotCacheTests.dll'
+#  - '**\ClousotTests\bin\Debug\ClousotTests.dll'
+#  - '**\Foxtrot\Tests\bin\Debug\FoxtrotTests.dll'
+#  - '**\Foxtrot\Tests\UnitTests\bin\Debug\UnitTests.dll'
+artifacts:
+- path: '**\ManagedContract.Setup\devlab9ts\Microsoft.Contracts.*.nupkg'
+- path: '**\ManagedContract.Setup\devlab9ts\msi\Contracts.devlab9ts.msi'
+- path: '**\ContractAdornments\Extension\bin\Devlab9\CodeContractsHelper.vsix'


### PR DESCRIPTION
* Build appears to be following the versioning scheme used by the project
* Artifacts from the build are attached to the AppVeyor output from each build
* Tests are disabled
  * The test assemblies aren't compiled by the `buildCC` command used for creating the artifacts
  * The tests fail when run without an unknown combination of command line configuration options for the test runner
  * The AppVeyor build will time out after 40 minutes, but the tests appear to take several hours before failing