### PR TITLE
Added supprot for default(T) expression used in contracts.

### DIFF
--- a/Foxtrot/Foxtrot/Checker/PostExtractorChecker.cs
+++ b/Foxtrot/Foxtrot/Checker/PostExtractorChecker.cs
@@ -2266,8 +2266,8 @@ namespace Microsoft.Contracts.Foxtrot
                         // F: no idea why this is != null
                         Contract.Assume(assignment.Target.Type != null);
                         if (ue.Operand is Local &&
-                            (assignment.Target.Type.IsPrimitive || assignment.Target.Type is Struct ||
-                             assignment.Target.Type.IsStructural))
+                            (assignment.Target.Type.IsPrimitive || assignment.Target.Type.IsStructural || assignment.Target.Type.IsTypeArgument ||
+                             assignment.Target.Type is Struct || assignment.Target.Type is EnumNode))
                         {
                             targetIsLocal = true;
                         }

--- a/Foxtrot/Tests/Sources/DefaultExpression.cs
+++ b/Foxtrot/Tests/Sources/DefaultExpression.cs
@@ -1,0 +1,56 @@
+// CodeContracts
+// 
+// Copyright (c) Microsoft Corporation
+// 
+// All rights reserved. 
+// 
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Diagnostics.Contracts;
+
+namespace Tests.Sources
+{
+
+    partial class TestMain
+    {
+        [ContractAbbreviator]
+        public static void NotDefault<T>(T value)
+        {
+            Contract.Requires(!EqualityComparer<T>.Default.Equals(value, default(T)));
+        }
+
+        void Test<T>()
+        {
+            Test(default(T));
+        }
+
+        void Test<T>(T value)
+        {
+            NotDefault(value);
+        }
+
+        partial void Run()
+        {
+            if (behave)
+            {
+                this.Test<object>(new object());
+            }
+            else
+            {
+                this.Test();
+            }
+        }
+
+        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Precondition;
+        public string NegativeExpectedCondition = "!EqualityComparer<T>.Default.Equals(value, default(T))";
+    }
+}

--- a/Foxtrot/Tests/TestInputs.xml
+++ b/Foxtrot/Tests/TestInputs.xml
@@ -683,6 +683,17 @@
      BinDir="false"
      Compiler="CS"
      />
+
+  <TestFile
+     Name="Foxtrot\Tests\Sources\DefaultExpression.cs"
+     CompilerOptions=""
+     FoxtrotOptions=""
+     References=""
+     ContractReferenceAssemblies="false"
+     BinDir="false"
+     Compiler="CS"
+     />
+
   <TestFile
      Name="Foxtrot\Tests\Sources\DefaultParameter.cs"
      FoxtrotOptions=""

--- a/System.Compiler/Nodes.cs
+++ b/System.Compiler/Nodes.cs
@@ -7798,6 +7798,25 @@ namespace System.Compiler{
         base.DeclaringType = value;
       }
     }
+
+    private bool isTypeArgument;
+    
+    /// <summary>
+    ///     Gets a value that indicates whether the current type node is a type argument of a generic member.
+    /// </summary>
+    public bool IsTypeArgument
+    {
+        get
+        {
+            return this.IsTypeArgument;
+        }
+    }
+    
+    public void MarkAsTypeArgument()
+    {
+        this.isTypeArgument = true;
+    }
+    
     private TypeFlags flags;
     public TypeFlags Flags{
       get{return this.flags;}
@@ -9568,6 +9587,11 @@ namespace System.Compiler{
       CC.Contract.Assume(declaringType != null || this.DeclaringType == null);
       CC.Contract.Assume(declaringType == null || this.DeclaringType == declaringType || this.DeclaringType == declaringType.Template);
       
+      for (int i = 0; i < consolidatedTemplateArguments.Count; ++i)
+      {
+          consolidatedTemplateArguments[i].MarkAsTypeArgument();
+      }
+
       var duplicator = new Duplicator(module, declaringType);
       duplicator.RecordOriginalAsTemplate = true;
       duplicator.SkipBodies = true;


### PR DESCRIPTION
I do not know how to run Foxtrot tests so it would be great if someone can take a look at DefaultExpression.cs test and confirm it is correct.
This should fix #29.