### PR TITLE
Propagating build script error codes to the top level script

### DIFF
--- a/Microsoft.Research/ManagedContract.Setup/buildMSI.bat
+++ b/Microsoft.Research/ManagedContract.Setup/buildMSI.bat
@@ -2,11 +2,14 @@
 
 rem Make sure NuGet packages are restored before proceeding with the build
 ..\..\.nuget\NuGet.exe restore ..\..\CodeContracts.sln
+if errorlevel 1 exit /b 1
 
 if "%2" == "" goto nonetlabel
 
 echo Build %2 version (%1)
 msbuild buildMSI10.xml /p:CCNetLabel=%1 /p:ReleaseConfig=%2 /t:All %3
+if errorlevel 1 exit /b 1
+
 goto end
 
 :nonetlabel
@@ -14,11 +17,15 @@ if "%1" == "" goto default
 
 echo build %1 version (1.1.1.1)
 msbuild buildMSI10.xml /p:CCNetLabel=1.1.1.1 /p:ReleaseConfig=%1 /t:All 
+if errorlevel 1 exit /b 1
+
 goto end
 
 :default
 echo build debug version (1.1.1.1)
 msbuild buildMSI10.xml /p:CCNetLabel=1.1.1.1 /p:ReleaseConfig=debug /t:All
+if errorlevel 1 exit /b 1
+
 goto end
 
 

--- a/Microsoft.VisualStudio.CodeTools/CodeToolsSetup/buildMSM.bat
+++ b/Microsoft.VisualStudio.CodeTools/CodeToolsSetup/buildMSM.bat
@@ -4,6 +4,10 @@ rem Make sure NuGet packages are restored before proceeding with the build
 ..\..\.nuget\NuGet.exe restore ..\CodeTools10.sln
 if errorlevel 1 exit /b 1
 
+rem Also need to restore packages from the top-level solution before building CodeTools
+..\..\.nuget\NuGet.exe restore ..\..\CodeContracts.sln
+if errorlevel 1 exit /b 1
+
 if "%1" == "" goto default
 if "%1" == "export" goto export
 

--- a/Microsoft.VisualStudio.CodeTools/CodeToolsSetup/buildMSM.bat
+++ b/Microsoft.VisualStudio.CodeTools/CodeToolsSetup/buildMSM.bat
@@ -2,24 +2,37 @@
 
 rem Make sure NuGet packages are restored before proceeding with the build
 ..\..\.nuget\NuGet.exe restore ..\CodeTools10.sln
+if errorlevel 1 exit /b 1
 
 if "%1" == "" goto default
 if "%1" == "export" goto export
 
 msbuild buildMSM.xml /p:CCNetLabel=1.13.1.1 /p:ReleaseConfig=%1 /t:All
+if errorlevel 1 exit /b 1
 goto end
 
 :default
 msbuild buildMSM.xml /p:CCNetLabel=1.13.1.1 /p:ReleaseConfig=release /t:All
-export release
+if errorlevel 1 exit /b 1
+
+call export release
+if errorlevel 1 exit /b 1
+
 goto end
 
 :export
+
 regasm /tlb ..\ITaskManager\bin\Release\ITaskManager.dll
+if errorlevel 1 exit /b 1
+
 sd edit ..\TLB\ITaskManager.tlb
+if errorlevel 1 exit /b 1
+
 copy /y ..\ITaskManager\bin\Release\ITaskManager.tlb ..\TLB
+if errorlevel 1 exit /b 1
+
 msbuild buildMSM.xml /p:CCNetLabel=1.13.1.1 /p:ReleaseConfig=release /t:Export
-goto end
+if errorlevel 1 exit /b 1
 
 :end
-
+exit /b 0

--- a/Microsoft.VisualStudio.CodeTools/CodeToolsSetup/export.bat
+++ b/Microsoft.VisualStudio.CodeTools/CodeToolsSetup/export.bat
@@ -2,5 +2,8 @@ set release=%1
 if "%1" == "" set release=release
 
 copy /y %release%\CodeTools.msm ..\..\Microsoft.Research\ImportedCodeTools
+if errorlevel 1 exit /b 1
+
 copy /y ..\CodeToolsUpdate\bin\%release%\CodeToolsUpdate.exe ..\..\Microsoft.Research\ImportedCodeTools
+if errorlevel 1 exit /b 1
 

--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,3 @@
 @echo off
 call buildCC %1 
+if errorlevel 1 exit /b 1

--- a/buildCC.bat
+++ b/buildCC.bat
@@ -1,8 +1,5 @@
 @echo off
 
-.nuget\nuget.exe restore .nuget\packages.config -PackagesDirectory .\packages
-if errorlevel 1 goto FailedNoPop
-
 pushd Microsoft.VisualStudio.CodeTools\CodeToolsSetup
 
 call buildMSM release
@@ -29,7 +26,6 @@ exit /b 0
 
 :Failed
 popd
-:FailedNoPop
 echo .
 echo ****************************************************
 echo Build FAILED

--- a/buildCC.bat
+++ b/buildCC.bat
@@ -1,15 +1,37 @@
 @echo off
 
-cd Microsoft.VisualStudio.CodeTools\CodeToolsSetup
-call buildMSM release
-call export release
-cd ..\..
+.nuget\nuget.exe restore .nuget\packages.config -PackagesDirectory .\packages
+if errorlevel 1 goto FailedNoPop
 
-cd Microsoft.Research\ManagedContract.Setup
+pushd Microsoft.VisualStudio.CodeTools\CodeToolsSetup
+
+call buildMSM release
+if errorlevel 1 goto Failed
+
+call export release
+if errorlevel 1 goto Failed
+
+popd
+pushd Microsoft.Research\ManagedContract.Setup
+
 call buildmsi %1 devlab9ts
+if errorlevel 1 goto Failed
+
 call buildnuget %1 devlab9ts 
-cd ..\..
+if errorlevel 1 goto Failed
+
+popd
 echo .
 echo ****************************************************
 echo Done building CodeContracts version %1
 echo ****************************************************
+exit /b 0
+
+:Failed
+popd
+:FailedNoPop
+echo .
+echo ****************************************************
+echo Build FAILED
+echo ****************************************************
+exit /b 1


### PR DESCRIPTION
This is to address #167.

@sharwell, I noticed you added a NuGet package reference for the WiX toolset and updated CodeTools BuildMSM.xml to refer to the correct toolset (which is great). However, NuGet packages from the top-level nuget.config are not restored prior to building CodeTools. As a result, running buildCC on a freshly checked out copy fails.

I added a line to restore NuGet packages right at the top of buildCC.bat. Let me know if there is a better way to handle this.