### PR TITLE
ccrewrite: properly escaping type names when serializing metadata

### DIFF
--- a/Foxtrot/Tests/FoxtrotTests10.csproj
+++ b/Foxtrot/Tests/FoxtrotTests10.csproj
@@ -142,6 +142,14 @@
       <Project>{9D404D0C-0921-4ADD-BC22-A14AAE2CA7E2}</Project>
       <Name>CRASanitizer</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\System.Compiler\System.CompilerCC.csproj">
+      <Project>{d7e16b38-3893-4eef-847f-a3be807e9546}</Project>
+      <Name>System.CompilerCC</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foxtrot\Foxtrot.Extractor.csproj">
+      <Project>{f7364559-90f5-480b-b975-c95a04e0daf6}</Project>
+      <Name>Foxtrot.Extractor</Name>
+    </ProjectReference>
     <ProjectReference Include="AssemblyWithContracts\AssemblyWithContracts.csproj">
       <Project>{8602713E-68E4-4A8F-BB6C-9AEA279E494F}</Project>
       <Name>AssemblyWithContracts</Name>

--- a/Foxtrot/Tests/Options.cs
+++ b/Foxtrot/Tests/Options.cs
@@ -47,6 +47,12 @@ namespace Tests
 
         public bool UseExe = true;
 
+        /// <summary>
+        /// If set to true, verification will include reading contracts back from the rewritten
+        /// assembly in addition to running peverify.
+        /// </summary>
+        public bool DeepVerify = false;
+
         private int instance;
 
         private TestContext TestContext;

--- a/Foxtrot/Tests/RewriterTests.cs
+++ b/Foxtrot/Tests/RewriterTests.cs
@@ -114,7 +114,8 @@ namespace Tests
         }
 
         /// <summary>
-        /// Unit test for #47 - "Could not resolve type reference" for some iterator methods in VS2015
+        /// Unit test for #47 - "Could not resolve type reference" for some iterator methods in VS2015 and
+        /// #186 - ccrewrite produces an incorrect type name in IteratorStateMachineAttribute with some generic types
         /// </summary>
         [DeploymentItem("Foxtrot\\Tests\\TestInputs.xml"), DataSource("Microsoft.VisualStudio.TestTools.DataSource.XML", "|DataDirectory|\\TestInputs.xml", "IteratorWithComplexGeneric", DataAccessMethod.Sequential)]
         [TestMethod]
@@ -125,6 +126,7 @@ namespace Tests
             // Bug with metadata reader could be reproduced only with a new mscorlib and new System.dll.
             options.BuildFramework = @".NetFramework\v4.6";
             options.ReferencesFramework = @".NetFramework\v4.6";
+            options.DeepVerify = true;
             TestDriver.BuildRewriteRun(options);
         }
 


### PR DESCRIPTION
This fixes #186.

@SergeyTeplyakov, will you be adding a unit test for this or do you want me to look into this?