### PR TITLE
Fix for: Issue #165: Sql exceptions: String or binary data would be truncated

### DIFF
--- a/Microsoft.Research/Clousot.Cache/Models/Mapping/MethodMap.cs
+++ b/Microsoft.Research/Clousot.Cache/Models/Mapping/MethodMap.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Research.CodeAnalysis.Caching.Models.Mapping
 {
     public class MethodMap : EntityTypeConfiguration<Method>
     {
+        /// <summary>
+        /// The maximum length the fully qualified method name can be. IE: Namespace.ClassName.MethodName
+        /// </summary>
+        public const int NamePropertyMaxLength = 400;
+
       [ContractVerification(false)] // Too many external unknown
         public MethodMap()
         {
@@ -34,7 +39,7 @@ namespace Microsoft.Research.CodeAnalysis.Caching.Models.Mapping
 
             this.Property(t => t.Name)
                 .IsRequired()
-                .HasMaxLength(400);
+                .HasMaxLength(NamePropertyMaxLength);
 
             this.Property(t => t.FullName)
                 .IsRequired()

--- a/Microsoft.Research/Clousot.Cache/Models/Mapping/SuggestionMap.cs
+++ b/Microsoft.Research/Clousot.Cache/Models/Mapping/SuggestionMap.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Research.CodeAnalysis.Caching.Models.Mapping
             // Properties
             this.Property(t => t.Kind)
                 .IsRequired()
-                .HasMaxLength(100);
+                .HasMaxLength(MethodMap.NamePropertyMaxLength);
 
             this.Property(t => t.Message)
                 .IsRequired();


### PR DESCRIPTION
Increases the size of the SuggestionMap.Kind string data to reflect the size of the Method Name length requirement.