### PR TITLE
Qualify references to fields to work around CS0136 in VS2013

### DIFF
--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/ArraySegmentation.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/ArraySegmentation.cs
@@ -1761,11 +1761,11 @@ namespace Microsoft.Research.AbstractDomains
             }
 
             Contract.Assert(elements.Count >= 1);
-            Contract.Assert(limits.Count == elements.Count + 1);
+            Contract.Assert(this.limits.Count == elements.Count + 1);
 
             // Fast, syntactic search for the lower bound
             var found = false;
-            for (var i = 0; i < limits.Count - 1; i++)
+            for (var i = 0; i < this.limits.Count - 1; i++)
             {
                 if (limits[i].Contains(lowExp))
                 {
@@ -1779,7 +1779,7 @@ namespace Microsoft.Research.AbstractDomains
                 }
             }
 
-            Contract.Assert(limits.Count == elements.Count + 1);
+            Contract.Assert(this.limits.Count == elements.Count + 1);
 
             // Semantic search
             if (!found)

--- a/Microsoft.Research/CodeAnalysis/Expression.cs
+++ b/Microsoft.Research/CodeAnalysis/Expression.cs
@@ -4237,7 +4237,7 @@ namespace Microsoft.Research.CodeAnalysis
 
                     UnaryOperator op;
                     ExternalExpression arg;
-                    if (decoder.IsUnaryOperator(exp, out op, out arg))
+                    if (decoder.IsUnaryOperator(this.exp, out op, out arg))
                     {
                         var exp = BoxedExpression.For(arg, decoder);
 


### PR DESCRIPTION
Fixes #208

@gafter Do you know why we needed to do this? I can't tell if this was a spec change between 2013 and 2015, or if the old compiler had a bug that was fixed for Roslyn.