### PR TITLE
Fix an apparent copy-paste bug in ValueAtReturnExpression.Equals

### DIFF
--- a/Microsoft.Research/CodeAnalysis/Expression.cs
+++ b/Microsoft.Research/CodeAnalysis/Expression.cs
@@ -3706,9 +3706,9 @@ namespace Microsoft.Research.CodeAnalysis
 
             public override bool Equals(object obj)
             {
-                OldExpression that = obj as OldExpression;
+                ValueAtReturnExpression that = obj as ValueAtReturnExpression;
                 if (that == null) return false;
-                return this.Value.Equals(that.Old);
+                return this.Value.Equals(that.Value);
             }
 
             public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)


### PR DESCRIPTION
`Equals` should compare objects of the same type `ValueAtReturnExpression`, not `OldExpression`.
I don't have a test case that would expose this, but it seems obvious.