### PR TITLE
Fix for #204

### DIFF
--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Utils.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Utils.cs
@@ -866,9 +866,10 @@ namespace Microsoft.Research.AbstractDomains
             Contract.Requires(left != null);
             Contract.Requires(right != null);
 
-            // the Roslyn compiler uses cgt.un for comparing references to null; while producing correct
-            // results at runtime, it doesn't match implicit non-null assumptions made by the static checker,
-            // so we detect it here and convert it to an old-style equality comparison
+            // Since there is no cne instruction, ECMA-335 §III.1.5 makes a note that cgt.un may
+            // be used instead for the specific case where the right-hand-side is null. If the
+            // right side is null, we treat the instruction as a "not equal" instruction for
+            // improved results from the static checker.
             if (decoder.IsNull(right))
                 return VisitNotEqual(left, right, original, data);
 

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Utils.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Utils.cs
@@ -866,6 +866,12 @@ namespace Microsoft.Research.AbstractDomains
             Contract.Requires(left != null);
             Contract.Requires(right != null);
 
+            // the Roslyn compiler uses cgt.un for comparing references to null; while producing correct
+            // results at runtime, it doesn't match implicit non-null assumptions made by the static checker,
+            // so we detect it here and convert it to an old-style equality comparison
+            if (decoder.IsNull(right))
+                return VisitNotEqual(left, right, original, data);
+
             return DispatchCompare(VisitLessThan_Un, right, left, original, data);
         }
 


### PR DESCRIPTION
This fixes #204.

The culprit turned out to be the IL generated by Roslyn for comparing references to null. In the old compiler, `o => o != null` results in

```
    ldarg.0
    ldnull
    ceq
    ldc.i4.0
    ceq
    ret
```

which literally translates to `(o == null) == 0`.

In Roslyn, the same code results in

```
    ldarg.1
    ldnull
    cgt.un
    ret
```

which literally translates to `o > null`. While this is a clever trick and produces shorter IL, it doesn't match implicit non-null assumptions generated by the static checker and thus results in unproven assertions.

The fix is to recognize the cases when `cgt.un` is used to compare to null and make them look like `o != null` to the static checker.