### PR TITLE
Update the UnitTests project to use xUnit.net

### DIFF
--- a/Foxtrot/Tests/UnitTests/GenericsTest.cs
+++ b/Foxtrot/Tests/UnitTests/GenericsTest.cs
@@ -15,286 +15,231 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics.Contracts;
 using CodeUnderTest;
+using Xunit;
 
 namespace Tests {
   /// <summary>
   /// Summary description for GenericsTest
   /// </summary>
-  [TestClass]
-  public class GenericsTest : DisableAssertUI {
-    public GenericsTest()
+  public class GenericsTest : DisableAssertUI, IClassFixture<GenericsTest.GenericsTestFixture> {
+    public GenericsTest(GenericsTestFixture testFixture)
     {
-      //
-      // TODO: Add constructor logic here
-      //
     }
 
-    private TestContext testContextInstance;
-
-    /// <summary>
-    ///Gets or sets the test context which provides
-    ///information about and functionality for the current test run.
-    ///</summary>
-    public TestContext TestContext
+    public class GenericsTestFixture
     {
-      get
+      public GenericsTestFixture()
       {
-        return testContextInstance;
-      }
-      set
-      {
-        testContextInstance = value;
-      }
-    }
-
-    #region Additional test attributes
-    //
-    // You can use the following additional attributes as you write your tests:
-    //
-    // Use ClassInitialize to run code before running the first test in the class
-    [ClassInitialize()]
-    public static void MyClassInitialize(TestContext testContext)
-    {
-      object[] attrs = typeof(RewrittenInheritanceBase).Assembly.GetCustomAttributes(true);
-      bool found = false;
-      foreach (var a in attrs)
-      {
-        Attribute attr = a as Attribute;
-        if (attr == null) continue;
-        Type ty = attr.TypeId as Type;
-        if (ty == null) continue;
-        if (ty.FullName == "System.Diagnostics.Contracts.RuntimeContractsAttribute")
+        object[] attrs = typeof(RewrittenInheritanceBase).Assembly.GetCustomAttributes(true);
+        bool found = false;
+        foreach (var a in attrs)
         {
-          found = true;
-          break;
+          Attribute attr = a as Attribute;
+          if (attr == null) continue;
+          Type ty = attr.TypeId as Type;
+          if (ty == null) continue;
+          if (ty.FullName == "System.Diagnostics.Contracts.RuntimeContractsAttribute")
+          {
+            found = true;
+            break;
+          }
         }
+        Assert.True(found, "This assembly must have been rewritten before running these tests.  This is usually done in the post build script of the test project.");
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.  This is usually done in the post build script of the test project.");
     }
-    //
-    // Use ClassCleanup to run code after all tests in a class have run
-    // [ClassCleanup()]
-    // public static void MyClassCleanup() { }
-    //
-    // Use TestInitialize to run code before running each test 
-    // [TestInitialize()]
-    // public void MyTestInitialize() { }
-    //
-    // Use TestCleanup to run code after each test has run
-    // [TestCleanup()]
-    // public void MyTestCleanup() { }
-    //
-    #endregion
 
     #region NonGenericExplicitImplementation
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericExplicitImplementationPositive()
     {
       IGenericInterface<string> j = new NonGenericExplicitImpl();
       j.M("abcd", true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericExplicitImplementationPreNegative()
     {
       IGenericInterface<string> j = new NonGenericExplicitImpl();
-      j.M(null, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => j.M(null, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericExplicitImplementationPostNegative()
     {
       IGenericInterface<string> j = new NonGenericExplicitImpl();
-      j.M("abcd", false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.M("abcd", false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericExplicitImplementationClosurePostPositive()
     {
       IGenericInterface<string> j = new NonGenericExplicitImpl();
       string[] x = new string[] { "abcd", "defg" };
       j.WithStaticClosure(x, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericExplicitImplementationClosurePostNegative()
     {
       IGenericInterface<string> j = new NonGenericExplicitImpl();
       string[] x = new string[] { "abcd", "defg" };
-      j.WithStaticClosure(x, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.WithStaticClosure(x, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericExplicitImplementationClosure2PostPositive()
     {
       IGenericInterface<string> j = new NonGenericExplicitImpl();
       string[] x = new string[] { "abcd", "defg" };
       j.WithClosureObject(x, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericExplicitImplementationClosure2PostNegative()
     {
       IGenericInterface<string> j = new NonGenericExplicitImpl();
       string[] x = new string[] { "abcd", "defg" };
-      j.WithClosureObject(x, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.WithClosureObject(x, false));
     }
     #endregion NonGenericExplicitImplementation
     #region NonGenericImplicitImplementation
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericImplicitImplementationPositive()
     {
       IGenericInterface<string> j = new NonGenericImplicitImpl();
       j.M("abcd", true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericImplicitImplementationPreNegative()
     {
       IGenericInterface<string> j = new NonGenericImplicitImpl();
-      j.M(null, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => j.M(null, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericImplicitImplementationPostNegative()
     {
       IGenericInterface<string> j = new NonGenericImplicitImpl();
-      j.M("abcd", false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.M("abcd", false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericImplicitImplementationClosurePostPositive()
     {
       IGenericInterface<string> j = new NonGenericImplicitImpl();
       string[] x = new string[] { "abcd", "defg" };
       j.WithStaticClosure(x, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericImplicitImplementationClosurePostNegative()
     {
       IGenericInterface<string> j = new NonGenericImplicitImpl();
       string[] x = new string[] { "abcd", "defg" };
-      j.WithStaticClosure(x, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.WithStaticClosure(x, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericImplicitImplementationClosure2PostPositive()
     {
       IGenericInterface<string> j = new NonGenericImplicitImpl();
       string[] x = new string[] { "abcd", "defg" };
       j.WithClosureObject(x, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NonGenericImplicitImplementationClosure2PostNegative()
     {
       IGenericInterface<string> j = new NonGenericImplicitImpl();
       string[] x = new string[] { "abcd", "defg" };
-      j.WithClosureObject(x, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.WithClosureObject(x, false));
     }
     #endregion NonGenericImplicitImplementation
     #region GenericExplicitImplementation
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericExplicitImplementationPositive()
     {
       IGenericInterface<string> j = new GenericExplicitImpl<string>();
       j.M("abcd", true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericExplicitImplementationPreNegative()
     {
       IGenericInterface<string> j = new GenericExplicitImpl<string>();
-      j.M(null, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => j.M(null, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericExplicitImplementationPostNegative()
     {
       IGenericInterface<string> j = new GenericExplicitImpl<string>();
-      j.M("abcd", false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.M("abcd", false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericExplicitImplementationClosurePostPositive()
     {
       IGenericInterface<string> j = new GenericExplicitImpl<string>();
       string[] x = new string[] { "abcd", "defg" };
       j.WithStaticClosure(x, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericExplicitImplementationClosurePostNegative()
     {
       IGenericInterface<string> j = new GenericExplicitImpl<string>();
       string[] x = new string[] { "abcd", "defg" };
-      j.WithStaticClosure(x, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.WithStaticClosure(x, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericExplicitImplementationClosure2PostPositive()
     {
       IGenericInterface<string> j = new GenericExplicitImpl<string>();
       string[] x = new string[] { "abcd", "defg" };
       j.WithClosureObject(x, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericExplicitImplementationClosure2PostNegative()
     {
       IGenericInterface<string> j = new GenericExplicitImpl<string>();
       string[] x = new string[] { "abcd", "defg" };
-      j.WithClosureObject(x, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.WithClosureObject(x, false));
     }
     #endregion GenericExplicitImplementation
     #region GenericImplicitImplementation
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericImplicitImplementationPositive()
     {
       IGenericInterface<string> j = new GenericImplicitImpl<string>();
       j.M("abcd", true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericImplicitImplementationPreNegative()
     {
       IGenericInterface<string> j = new GenericImplicitImpl<string>();
-      j.M(null, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => j.M(null, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericImplicitImplementationPostNegative()
     {
       IGenericInterface<string> j = new GenericImplicitImpl<string>();
-      j.M("abcd", false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.M("abcd", false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericImplicitImplementationClosurePostPositive()
     {
       IGenericInterface<string> j = new GenericImplicitImpl<string>();
       string[] x = new string[] { "abcd", "defg" };
       j.WithStaticClosure(x, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericImplicitImplementationClosurePostNegative()
     {
       IGenericInterface<string> j = new GenericImplicitImpl<string>();
       string[] x = new string[] { "abcd", "defg" };
-      j.WithStaticClosure(x, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.WithStaticClosure(x, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericImplicitImplementationClosure2PostPositive()
     {
       IGenericInterface<string> j = new GenericImplicitImpl<string>();
       string[] x = new string[] { "abcd", "defg" };
       j.WithClosureObject(x, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void GenericImplicitImplementationClosure2PostNegative()
     {
       IGenericInterface<string> j = new GenericImplicitImpl<string>();
       string[] x = new string[] { "abcd", "defg" };
-      j.WithClosureObject(x, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.WithClosureObject(x, false));
     }
     #endregion GenericImplicitImplementation
   }

--- a/Foxtrot/Tests/UnitTests/ManualInheritanceChains.cs
+++ b/Foxtrot/Tests/UnitTests/ManualInheritanceChains.cs
@@ -16,66 +16,65 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Diagnostics.Contracts;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Tests;
 using CodeUnderTest;
+using Xunit;
 
 namespace ManualInheritanceChain
 {
-  [TestClass]
   public class TestClass : DisableAssertUI
   {
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestBasePositive()
     {
       new BaseOfChain().Test(1);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel1Positive()
     {
       new Level1().Test(1);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Positive1()
     {
       new Level3().Test(1);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Positive2()
     {
       new Level3().Test("foo");
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Positive3()
     {
       bool result = new Level3().TestIsNonEmpty("foo");
-      Assert.IsTrue(result);
+      Assert.True(result);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Positive4()
     {
       bool result = new Level3().TestIsNonEmpty("");
-      Assert.IsFalse(result);
+      Assert.False(result);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Positive1()
     {
       new Level4().Test(1);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Positive2()
     {
       new Level4().Test("foo");
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestBaseNegative()
     {
       try
@@ -84,13 +83,13 @@ namespace ManualInheritanceChain
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
+        Assert.Equal("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel1Negative()
     {
       try
@@ -99,13 +98,13 @@ namespace ManualInheritanceChain
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
+        Assert.Equal("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Negative1()
     {
       try
@@ -114,13 +113,13 @@ namespace ManualInheritanceChain
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
+        Assert.Equal("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Negative2()
     {
       try
@@ -129,13 +128,13 @@ namespace ManualInheritanceChain
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("Precondition failed: s != null", a.Message);
+        Assert.Equal("Precondition failed: s != null", a.Message);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Negative3()
     {
       try
@@ -144,13 +143,13 @@ namespace ManualInheritanceChain
       }
       catch (TestRewriterMethods.PreconditionException p)
       {
-        Assert.AreEqual("s != null", p.Condition);
+        Assert.Equal("s != null", p.Condition);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Negative1()
     {
       try
@@ -159,13 +158,13 @@ namespace ManualInheritanceChain
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
+        Assert.Equal("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Negative2()
     {
       try
@@ -174,7 +173,7 @@ namespace ManualInheritanceChain
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("Precondition failed: s != null", a.Message);
+        Assert.Equal("Precondition failed: s != null", a.Message);
         return;
       }
       throw new Exception();
@@ -186,78 +185,77 @@ namespace ManualInheritanceChain
 
 namespace ManualInheritanceChainWithHelpers
 {
-  [TestClass]
   public class TestClass : DisableAssertUI
   {
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestBasePositive()
     {
       new ManualInheritanceChain.BaseOfChain().Test(1);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel1Positive1()
     {
       new Level1().Test(1);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel1Positive2()
     {
       new Level1().TestDouble(1);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Positive1()
     {
       new Level3().Test(1);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Positive2()
     {
       new Level3().Test("foo");
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Positive3()
     {
       bool result = new Level3().TestIsNonEmpty("foo");
-      Assert.IsTrue(result);
+      Assert.True(result);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Positive4()
     {
       bool result = new Level3().TestIsNonEmpty("");
-      Assert.IsFalse(result);
+      Assert.False(result);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Positive5()
     {
       new Level3().TestDouble(0);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Positive1()
     {
       new Level4().Test(1);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Positive2()
     {
       new Level4().Test("foo");
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Positive3()
     {
       new Level4().TestDouble(0);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestBaseNegative()
     {
       try
@@ -266,13 +264,13 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
+        Assert.Equal("Precondition failed: x > 0: x must be positive\r\nParameter name: x must be positive", a.Message);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel1Negative1()
     {
       try
@@ -281,13 +279,13 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("x must be positive", a.ParamName);
+        Assert.Equal("x must be positive", a.ParamName);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel1Negative2()
     {
       try
@@ -296,13 +294,13 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (ArgumentOutOfRangeException a)
       {
-        Assert.AreEqual("d", a.ParamName);
+        Assert.Equal("d", a.ParamName);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Negative1()
     {
       try
@@ -311,13 +309,13 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("x must be positive", a.ParamName);
+        Assert.Equal("x must be positive", a.ParamName);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Negative2()
     {
       try
@@ -326,13 +324,13 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("s", a.ParamName);
+        Assert.Equal("s", a.ParamName);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Negative3()
     {
       try
@@ -341,13 +339,13 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (TestRewriterMethods.PreconditionException p)
       {
-        Assert.AreEqual("s != null", p.Condition);
+        Assert.Equal("s != null", p.Condition);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel3Negative4()
     {
       try
@@ -356,13 +354,13 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (ArgumentOutOfRangeException p)
       {
-        Assert.AreEqual("d", p.ParamName);
+        Assert.Equal("d", p.ParamName);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Negative1()
     {
       try
@@ -371,13 +369,13 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (ArgumentException a)
       {
-        Assert.AreEqual("x must be positive", a.ParamName);
+        Assert.Equal("x must be positive", a.ParamName);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Negative2()
     {
       try
@@ -386,13 +384,13 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (ArgumentNullException a)
       {
-        Assert.AreEqual("s", a.ParamName);
+        Assert.Equal("s", a.ParamName);
         return;
       }
       throw new Exception();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestLevel4Negative3()
     {
       try
@@ -401,7 +399,7 @@ namespace ManualInheritanceChainWithHelpers
       }
       catch (ArgumentOutOfRangeException p)
       {
-        Assert.AreEqual("d", p.ParamName);
+        Assert.Equal("d", p.ParamName);
         return;
       }
       throw new Exception();

--- a/Foxtrot/Tests/UnitTests/OutOfBandTest.cs
+++ b/Foxtrot/Tests/UnitTests/OutOfBandTest.cs
@@ -12,8 +12,6 @@
 // 
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 using System;
 using System.Text;
 using System.Collections.Generic;
@@ -25,26 +23,25 @@ using System.Reflection;
 using Microsoft.CSharp;
 using OutOfBand;
 using SubtypeWithoutContracts;
+using Xunit;
 
 namespace Tests {
-  [TestClass()]
   public class OutOfBandTest : DisableAssertUI {
 
     #region Tests
 
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveOutOfBandInc()
     {
       new OutOfBand.C().Inc(3);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOutOfBandInc()
     {
-      new OutOfBand.C().Inc(27);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new OutOfBand.C().Inc(27));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOutOfBandInc2()
     {
       try
@@ -56,10 +53,10 @@ namespace Tests {
         // Since we are not running asmmeta on OutOfBand.Contracts and we use call-site-requires
         // we don't get the string here.
         // Assert.AreEqual("y >= 0", p.Condition);
-        Assert.AreEqual("y must be non-negative", p.User);
+        Assert.Equal("y must be non-negative", p.User);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOutOfBandInc3()
     {
       try
@@ -71,76 +68,70 @@ namespace Tests {
         // Since we are not running asmmeta on OutOfBand.Contracts and we use call-site-requires
         // we don't get the string here.
         // Assert.AreEqual("y == 3", p.Condition);
-        Assert.AreEqual(null, p.User);
+        Assert.Equal(null, p.User);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveOutOfBandInvariant()
     {
       new OutOfBand.C();
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.InvariantException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOutOfBandInvariant()
     {
-      new OutOfBand.C(false);
+      Assert.Throws<TestRewriterMethods.InvariantException>(() => new OutOfBand.C(false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveOutOfBandRequires()
     {
       var c = new OutOfBand.C();
       var foo = new OutOfBand.Foo(1);
       c.FooMethodTakingTypeFromSameAssembly(foo);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOutOfBandRequires1()
     {
       var c = new OutOfBand.C();
-      c.FooMethodTakingTypeFromSameAssembly(null);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => c.FooMethodTakingTypeFromSameAssembly(null));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOutOfBandRequires2()
     {
       var c = new OutOfBand.C();
       var foo = new OutOfBand.Foo(-1);
-      c.FooMethodTakingTypeFromSameAssembly(foo);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => c.FooMethodTakingTypeFromSameAssembly(foo));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveOutOfBandRequiresWithException()
     {
       var c = new OutOfBand.C();
       c.TestRequiresWithException(1);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(IndexOutOfRangeException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOutOfBandRequiresWithException1()
     {
       var c = new OutOfBand.C();
-      c.TestRequiresWithException(-1);
+      Assert.Throws<IndexOutOfRangeException>(() => c.TestRequiresWithException(-1));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOutOfBandRequiresWithException2()
     {
       var c = new OutOfBand.C();
-      c.TestRequiresWithException(10);
+      Assert.Throws<ArgumentOutOfRangeException>(() => c.TestRequiresWithException(10));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInheritedOOBInvariant()
     {
       var c = new DerivedOutOfBandC();
       c.ViolateBaseInvariant(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.InvariantException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInheritedOOBInvariant()
     {
       var c = new DerivedOutOfBandC();
-      c.ViolateBaseInvariant(false);
+      Assert.Throws<TestRewriterMethods.InvariantException>(() => c.ViolateBaseInvariant(false));
     }
     #endregion Tests
   }

--- a/Foxtrot/Tests/UnitTests/Properties/AssemblyInfo.cs
+++ b/Foxtrot/Tests/UnitTests/Properties/AssemblyInfo.cs
@@ -15,6 +15,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -47,3 +48,8 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// This test library manipulates static state during many of the tests. It was not a problem for MSTest (which never
+// parallelizes test execution), but the default behavior for xUnit.net caused test failures. This attribute disables
+// all test parallelization so tests run reliably.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]

--- a/Foxtrot/Tests/UnitTests/RewrittenContractTest.cs
+++ b/Foxtrot/Tests/UnitTests/RewrittenContractTest.cs
@@ -13,7 +13,6 @@
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #define CONTRACTS_PRECONDITIONS
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using System;
 using System.IO;
@@ -23,11 +22,12 @@ using System.Diagnostics;
 using System.Diagnostics.Contracts;
 //using System.Windows.Forms;
 using CodeUnderTest;
-
+using Xunit;
+using Xunit.Abstractions;
+using System.Reflection;
 
 namespace Tests {
 
-  [TestClass]
   public class RewriteCodeUnderTestBeforeRunningUnitTests : DisableAssertUI {
 
     static void ErrorDataReceived(object sender, DataReceivedEventArgs e)
@@ -50,25 +50,24 @@ namespace Tests {
       i.CreateNoWindow = true;
       i.WorkingDirectory = cwd;
       i.ErrorDialog = false;
+      StringBuilder result = new StringBuilder();
       using (Process p = Process.Start(i))
       {
-        p.OutputDataReceived += new DataReceivedEventHandler(OutputDataReceived);
-        p.ErrorDataReceived += new DataReceivedEventHandler(ErrorDataReceived);
+        p.OutputDataReceived += (sender, e) => result.AppendLine(e.Data);
+        p.ErrorDataReceived += (sender, e) => result.AppendLine(e.Data);
         p.BeginOutputReadLine();
         p.BeginErrorReadLine();
 
-        Assert.IsTrue(p.WaitForExit(200000), String.Format("{0} timed out", i.FileName));
+        Assert.True(p.WaitForExit(200000), String.Format("{0} timed out", i.FileName));
         if (p.ExitCode != 0)
         {
-          Assert.AreEqual(0, p.ExitCode, "{0} returned an errorcode of {1}.", i.FileName, p.ExitCode);
+          Assert.True(false, string.Format("{0} returned an errorcode of {1} (expected 0).\n\n{2}", i.FileName, p.ExitCode, result.ToString()));
         }
         return p.ExitCode;
       }
     }
 
-
-    [AssemblyInitialize]
-    public static void AssembyInitialize(TestContext context)
+    public RewriteCodeUnderTestBeforeRunningUnitTests()
     {
         //
         // VERY IMPORTANT!! Do NOT do anything that caused any type from CodeUnderTest.dll to be loaded
@@ -82,37 +81,62 @@ namespace Tests {
         int x;
         const string AsmMetaExe = @"Microsoft.Research\ImportedCCI2\AsmMeta.exe";
 
-        var deploymentDir = context.TestDeploymentDir;
+        var deploymentDir = @"..\..\..\..\..\TestResults\Out\Deploy";
 
         var testResultPosition = deploymentDir.IndexOf(@"TestResults");
         
-        Assert.IsTrue(testResultPosition != -1, 
+        Assert.True(testResultPosition != -1, 
             string.Format("Can't find the TestResults directory!!! Current deployment directory is '{0}'", deploymentDir));
         
         var testDirRoot = deploymentDir.Substring(0, testResultPosition);
 
-        Assert.IsTrue(!string.IsNullOrEmpty(testDirRoot), "I was expecting the extraction of a valid dir");
+        Assert.True(!string.IsNullOrEmpty(testDirRoot), "I was expecting the extraction of a valid dir");
 
         var RootDirectory = Path.GetFullPath(testDirRoot);
 
         var foxtrotPath = SelectFoxtrot(RootDirectory, deploymentDir);
 
-      Assert.IsTrue(File.Exists("OutOfBand.dll"));
+      Assert.True(File.Exists("OutOfBand.dll"));
       var tool = Path.GetFullPath(Path.Combine(RootDirectory, AsmMetaExe));
 
-      Assert.IsTrue(File.Exists(tool), string.Format("The tool {0} does not exists!!!!", tool));
+      Assert.True(File.Exists(tool), string.Format("The tool {0} does not exists!!!!", tool));
 
       var refAssemblies = @"..\..\..\Microsoft.Research\Imported\ReferenceAssemblies\v3.5";
       
-    Assert.IsTrue(Directory.Exists(refAssemblies),
+    Assert.True(Directory.Exists(Path.Combine(deploymentDir, refAssemblies)),
           string.Format("Can't find reference assembly folder at {0}", Path.Combine(deploymentDir, refAssemblies)));
 
-      Assert.IsTrue(File.Exists(tool), string.Format("The tool {0} does not exists!!!!", tool));
+      Assert.True(File.Exists(tool), string.Format("The tool {0} does not exists!!!!", tool));
+
+      Directory.CreateDirectory(deploymentDir);
+      File.Delete(Path.Combine(deploymentDir, "OutOfBand.dll"));
+      File.Delete(Path.Combine(deploymentDir, "OutOfBand.pdb"));
+      File.Delete(Path.Combine(deploymentDir, "CodeUnderTest.dll"));
+      File.Delete(Path.Combine(deploymentDir, "CodeUnderTest.pdb"));
+      File.Delete(Path.Combine(deploymentDir, "RewriterMethods.dll"));
+      File.Delete(Path.Combine(deploymentDir, "RewriterMethods.pdb"));
+      File.Delete(Path.Combine(deploymentDir, "BaseClassWithContracts.dll"));
+      File.Delete(Path.Combine(deploymentDir, "BaseClassWithContracts.pdb"));
+      File.Delete(Path.Combine(deploymentDir, "SubtypeWithoutContracts.dll"));
+      File.Delete(Path.Combine(deploymentDir, "SubtypeWithoutContracts.pdb"));
+
+      File.Move("OutOfBand.dll", Path.Combine(deploymentDir, "OutOfBand.dll"));
+      File.Move("OutOfBand.pdb", Path.Combine(deploymentDir, "OutOfBand.pdb"));
+      File.Move("CodeUnderTest.dll", Path.Combine(deploymentDir, "CodeUnderTest.dll"));
+      File.Move("CodeUnderTest.pdb", Path.Combine(deploymentDir, "CodeUnderTest.pdb"));
+      File.Move("RewriterMethods.dll", Path.Combine(deploymentDir, "RewriterMethods.dll"));
+      File.Move("RewriterMethods.pdb", Path.Combine(deploymentDir, "RewriterMethods.pdb"));
+      File.Move("BaseClassWithContracts.dll", Path.Combine(deploymentDir, "BaseClassWithContracts.dll"));
+      File.Move("BaseClassWithContracts.pdb", Path.Combine(deploymentDir, "BaseClassWithContracts.pdb"));
+      File.Move("SubtypeWithoutContracts.dll", Path.Combine(deploymentDir, "SubtypeWithoutContracts.dll"));
+      File.Move("SubtypeWithoutContracts.pdb", Path.Combine(deploymentDir, "SubtypeWithoutContracts.pdb"));
+
+      File.Copy("Microsoft.Contracts.dll", Path.Combine(deploymentDir, "Microsoft.Contracts.dll"), true);
 
       x = RunProcess(deploymentDir, tool, string.Format(@"/libpaths:{0} OutOfBand.dll", refAssemblies));
 
-      Assert.AreEqual(0, x, "AsmMeta failed on OutOfBand.dll");
-      Assert.IsTrue(File.Exists("OutOfBand.Contracts.dll"), "AsmMeta must have failed to produce a reference assembly for OutOfBand.dll");
+      Assert.True(x == 0, "AsmMeta failed on OutOfBand.dll");
+      Assert.True(File.Exists(Path.Combine(deploymentDir, "OutOfBand.Contracts.dll")), "AsmMeta must have failed to produce a reference assembly for OutOfBand.dll");
 
       string codeUnderTest = "CodeUnderTest.dll";
 #if LEGACY
@@ -127,28 +151,52 @@ namespace Tests {
         x = RunProcess(deploymentDir, foxtrotPath, String.Format("/useGAC /assemblyMode={0} /rewrite /rw:RewriterMethods.dll,TestRewriterMethods /nobox /callsiterequires /throwonfailure=false {1}", explicitValidation, codeUnderTest));
       }
 
-      var peVerify = Path.GetFullPath(Path.Combine(RootDirectory, @"Microsoft.Research\Imported\tools\.NetFramework\v4.0\peverify.exe"));
-      Assert.IsTrue(File.Exists(peVerify), string.Format("Can't find peVerifiy: {0} ", peVerify));
+      var peVerify = Path.GetFullPath(Path.Combine(RootDirectory, @"Microsoft.Research\Imported\tools\v3.5\peverify.exe"));
+      Assert.True(File.Exists(peVerify), string.Format("Can't find peVerifiy: {0} ", peVerify));
 
       x = RunProcess(deploymentDir, peVerify, "/unique " + codeUnderTest);
-      Assert.AreEqual(0, x, "Peverify failed on " + codeUnderTest);
+      Assert.True(x == 0, "Peverify failed on " + codeUnderTest);
 
       x = RunProcess(deploymentDir, foxtrotPath, "/rewrite /assemblyMode=standard /rw:RewriterMethods.dll,TestRewriterMethods /nobox /throwonfailure /contracts:OutOfBand.Contracts.dll /autoRef:- OutOfBand.dll");
-      Assert.AreEqual(0, x, "Rewriter failed on OutOfBand.dll");
+      Assert.True(x == 0, "Rewriter failed on OutOfBand.dll");
 
       x = RunProcess(deploymentDir, peVerify, "/unique OutOfBand.dll");
-      Assert.AreEqual(0, x, "Peverify failed on OutOfBand.dll");
+      Assert.True(x == 0, "Peverify failed on OutOfBand.dll");
 
       x = RunProcess(deploymentDir, Path.GetFullPath(Path.Combine(RootDirectory, AsmMetaExe)), @"/libpaths:..\..\..\Microsoft.Research\Imported\ReferenceAssemblies\v3.5 BaseClassWithContracts.dll");
-      Assert.AreEqual(0, x, "AsmMeta failed on BaseClassWithContracts.dll");
+      Assert.True(x == 0, "AsmMeta failed on BaseClassWithContracts.dll");
 
-      Assert.IsTrue(File.Exists("SubtypeWithoutContracts.dll"));
+      Assert.True(File.Exists(Path.Combine(deploymentDir, "SubtypeWithoutContracts.dll")));
       x = RunProcess(deploymentDir, foxtrotPath, "/rewrite /rw:RewriterMethods.dll,TestRewriterMethods /nobox /throwonfailure SubtypeWithoutContracts.dll");
-      Assert.AreEqual(0, x, "Rewriter failed on SubtypeWithoutContracts.dll");
+      Assert.True(x == 0, "Rewriter failed on SubtypeWithoutContracts.dll");
 
       x = RunProcess(deploymentDir, peVerify, "/unique SubtypeWithoutContracts.dll");
-      Assert.AreEqual(0, x, "Peverify failed on SubtypeWithoutContracts.dll");
+      Assert.True(x == 0, "Peverify failed on SubtypeWithoutContracts.dll");
 
+      AppDomain.CurrentDomain.AssemblyResolve +=
+        (sender, e) =>
+        {
+          switch (e.Name)
+          {
+          case "BaseClassWithContracts, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null":
+            return Assembly.LoadFrom(Path.Combine(deploymentDir, "BaseClassWithContracts.dll"));
+
+          case "CodeUnderTest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null":
+            return Assembly.LoadFrom(Path.Combine(deploymentDir, "CodeUnderTest.dll"));
+
+          case "OutOfBand, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null":
+            return Assembly.LoadFrom(Path.Combine(deploymentDir, "OutOfBand.dll"));
+
+          case "RewriterMethods, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null":
+            return Assembly.LoadFrom(Path.Combine(deploymentDir, "RewriterMethods.dll"));
+
+          case "SubtypeWithoutContracts, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null":
+            return Assembly.LoadFrom(Path.Combine(deploymentDir, "SubtypeWithoutContracts.dll"));
+
+          default:
+            return null;
+          }
+        };
     }
 
     static readonly string[] DeployedForRunningFoxtrotFromDeployment = new string[] { "Foxtrot.exe", "DataStructures.dll", "System.Compiler.dll" };
@@ -164,8 +212,8 @@ namespace Tests {
       }
     }
 
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+#if false
+    public RewriteCodeUnderTestBeforeRunningUnitTests() {
       object[] attrs = typeof(CodeUnderTest.RewrittenContractTest).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -178,10 +226,17 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
+#endif
   }
 
+  [CollectionDefinition("unittests")]
+  public class AssemblyCollection : ICollectionFixture<RewriteCodeUnderTestBeforeRunningUnitTests>
+  {
+  }
+
+  [Collection("unittests")]
   public class DisableAssertUI {
     static DisableAssertUI() {
       for (int i = 0; i < System.Diagnostics.Debug.Listeners.Count; i++) {
@@ -191,471 +246,504 @@ namespace Tests {
     }
   }
 
-  [TestClass]
   public class RewrittenContractTest : DisableAssertUI {
     #region Tests
 
-    [TestInitialize]
-    public void TestInitialize() {
+    public RewrittenContractTest() {
       TestRewriterMethods.FailureCount = 0;
     }
 
-    /// <summary>
-    /// Checks that RaiseContractFailedEvent hook is called even on legacy requires methods.
-    /// </summary>
-    [TestCleanup]
-    public void TestCleanup() {
-      int expectedFailures = this.TestContext.TestName.StartsWith("Positive") ? 0 : 1;
-      Assert.AreEqual(expectedFailures, TestRewriterMethods.FailureCount);
-    }
-
-    public TestContext TestContext {
-      get;
-      set;
-    }
-
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveAssertTest() {
       new CodeUnderTest.RewrittenContractTest().AssertsTrue(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAssertTest() {
       try {
         new CodeUnderTest.RewrittenContractTest().AssertsTrue(false);
         throw new Exception();
       } catch (TestRewriterMethods.AssertException e) {
-        Assert.AreEqual("mustBeTrue", e.Condition);
+        Assert.Equal("mustBeTrue", e.Condition);
       }
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveAssumeTest() {
       new CodeUnderTest.RewrittenContractTest().AssumesTrue(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAssumeTest() {
       try {
         new CodeUnderTest.RewrittenContractTest().AssumesTrue(false);
         throw new Exception();
       } catch (TestRewriterMethods.AssumeException e) {
-        Assert.AreEqual("mustBeTrue", e.Condition);
+        Assert.Equal("mustBeTrue", e.Condition);
       }
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveRequiresTest() {
       new CodeUnderTest.RewrittenContractTest().RequiresTrue(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeRequiresTest() {
-      new CodeUnderTest.RewrittenContractTest().RequiresTrue(false);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new CodeUnderTest.RewrittenContractTest().RequiresTrue(false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveRequiresWithExceptionTest() {
       new CodeUnderTest.RewrittenContractTest().RequiresTrue<ArgumentException>(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(ArgumentException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeRequiresWithExceptionTest() {
-      new CodeUnderTest.RewrittenContractTest().RequiresTrue<ArgumentException>(false);
+      Assert.Throws<ArgumentException>(() => new CodeUnderTest.RewrittenContractTest().RequiresTrue<ArgumentException>(false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeRequiresWithExceptionTest2() {
       try {
         new CodeUnderTest.RewrittenContractTest().RequiresTrue<ArgumentException>(false);
       } catch (ArgumentException e) {
-        Assert.AreEqual("Precondition failed: mustBeTrue", e.Message, true);
+        Assert.Equal("Precondition failed: mustBeTrue", e.Message, true);
       }
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositivePrivateRequiresTest() {
       new CodeUnderTest.RewrittenContractTest().CallPrivateRequiresTrue(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
     
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [Ignore] // This test should be ignored, because the whole test suite is running without /publicsurface flag!
+    [Fact(Skip = "This test should be ignored, because the whole test suite is running without /publicsurface flag!")]
+    [Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositivePrivateRequiresTest2() {
       // Does not trigger due to /publicsurface
       new CodeUnderTest.RewrittenContractTest().CallPrivateRequiresTrue(false);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsuresTest() {
       new CodeUnderTest.RewrittenContractTest().EnsuresTrue(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEnsuresTest() {
-      new CodeUnderTest.RewrittenContractTest().EnsuresTrue(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().EnsuresTrue(false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositivePrivateEnsuresTest() {
       new CodeUnderTest.RewrittenContractTest().CallPrivateEnsuresTrue(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [Ignore] // This test should be ignored, because the whole test suite is running without /publicsurface flag!
+    [Fact(Skip = "This test should be ignored, because the whole test suite is running without /publicsurface flag!")]
+    [Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositivePrivateEnsuresTest2() {
       // Does not trigger due to /publicsurface
       new CodeUnderTest.RewrittenContractTest().CallPrivateEnsuresTrue(false);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsureReturnTest() {
       new CodeUnderTest.RewrittenContractTest().EnsuresReturnsTrue(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEnsuresReturnTest() {
-      new CodeUnderTest.RewrittenContractTest().EnsuresReturnsTrue(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().EnsuresReturnsTrue(false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsuresAnythingTest() {
       new CodeUnderTest.RewrittenContractTest().EnsuresAnything(true);
       new CodeUnderTest.RewrittenContractTest().EnsuresAnything(false);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveRequiresAndEnsuresTest() {
       new CodeUnderTest.RewrittenContractTest().RequiresAndEnsuresTrue(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeRequiresAndEnsuresTest() {
-      new CodeUnderTest.RewrittenContractTest().RequiresAndEnsuresTrue(false);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new CodeUnderTest.RewrittenContractTest().RequiresAndEnsuresTrue(false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInvariantTest() {
       new CodeUnderTest.RewrittenContractTest().MakeInvariantTrue();
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.InvariantException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInvariantTest() {
-      new CodeUnderTest.RewrittenContractTest().MakeInvariantFalse();
+      Assert.Throws<TestRewriterMethods.InvariantException>(() => new CodeUnderTest.RewrittenContractTest().MakeInvariantFalse());
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsureResultTest() {
       bool output;
       new CodeUnderTest.RewrittenContractTest().EnsuresSetsTrue(true, out output);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEnsureResultTest() {
       bool output;
-      new CodeUnderTest.RewrittenContractTest().EnsuresSetsTrue(false, out output);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().EnsuresSetsTrue(false, out output));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveOldTest() {
       bool anything = true;
-      Assert.AreEqual(true, new CodeUnderTest.RewrittenContractTest().SetsAndReturnsOld(ref anything));
-      Assert.IsFalse(anything);
-      Assert.AreEqual(false, new CodeUnderTest.RewrittenContractTest().SetsAndReturnsOld(ref anything));
-      Assert.IsTrue(anything);
+      Assert.Equal(true, new CodeUnderTest.RewrittenContractTest().SetsAndReturnsOld(ref anything));
+      Assert.False(anything);
+      Assert.Equal(false, new CodeUnderTest.RewrittenContractTest().SetsAndReturnsOld(ref anything));
+      Assert.True(anything);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveThrowTest() {
       new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(0, false);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(ApplicationException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveThrowTest1() {
-      new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(1, true);
+      Assert.Throws<ApplicationException>(() => new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(1, true));
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(SystemException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveThrowTest2() {
-      new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(2, true);
+      Assert.Throws<SystemException>(() => new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(2, true));
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     //[ExpectedException(typeof(Exception))] VS Unit Tests can't handle this.
     public void PositiveThrowTest3() {
       try {
         new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(3, true);
       } catch (Exception e) {
-        Assert.IsTrue(e.GetType() == typeof(Exception));
+        Assert.True(e.GetType() == typeof(Exception));
+        Assert.Equal(0, TestRewriterMethods.FailureCount);
         return;
       }
-      Assert.Fail();
+      Assert.True(false);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeThrowTest0() {
-      new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(0, true);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(0, true));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionOnThrowException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeThrowTest1() {
-      new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(1, false);
+      Assert.Throws<TestRewriterMethods.PostconditionOnThrowException>(() => new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(1, false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionOnThrowException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeThrowTest2() {
-      new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(2, false);
+      Assert.Throws<TestRewriterMethods.PostconditionOnThrowException>(() => new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(2, false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionOnThrowException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeThrowTest3() {
-      new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(3, false);
+      Assert.Throws<TestRewriterMethods.PostconditionOnThrowException>(() => new CodeUnderTest.RewrittenContractTest().ThrowsEnsuresTrue(3, false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveRequiresForAll() {
       int[] A = new int[] { 3, 4, 5 };
       new CodeUnderTest.RewrittenContractTest().RequiresForAll(A);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeRequiresForAll() {
       int[] A = new int[] { 3, -4, 5 };
-      new CodeUnderTest.RewrittenContractTest().RequiresForAll(A);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new CodeUnderTest.RewrittenContractTest().RequiresForAll(A));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveRequiresExists() {
       int[] A = new int[] { -3, -4, 5 };
       new CodeUnderTest.RewrittenContractTest().RequiresExists(A);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeRequiresExists() {
       int[] A = new int[] { -3, -4, -5 };
-      new CodeUnderTest.RewrittenContractTest().RequiresExists(A);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new CodeUnderTest.RewrittenContractTest().RequiresExists(A));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsuresForAll() {
       int[] A = new int[] { 3, 4, 5 };
       int[] B = new CodeUnderTest.RewrittenContractTest().EnsuresForAll(A, true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEnsuresForAll() {
       int[] A = new int[] { 3, -4, 5 };
-      int[] B = new CodeUnderTest.RewrittenContractTest().EnsuresForAll(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(
+        () =>
+        {
+          int[] B = new CodeUnderTest.RewrittenContractTest().EnsuresForAll(A, false);
+        });
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsuresExists() {
       int[] A = new int[] { -3, -4, 5 };
       int[] B = new CodeUnderTest.RewrittenContractTest().EnsuresExists(A, true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEnsuresExists() {
       int[] A = new int[] { -3, -4, -5 };
-      int[] B = new CodeUnderTest.RewrittenContractTest().EnsuresExists(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(
+        () =>
+        {
+          int[] B = new CodeUnderTest.RewrittenContractTest().EnsuresExists(A, false);
+        });
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsuresForAllWithOld() {
       int[] A = new int[] { 3, 4, 5 };
       new CodeUnderTest.RewrittenContractTest().EnsuresForAllWithOld(A, true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEnsuresForAllWithOld() {
       int[] A = new int[] { 3, -4, 5 };
-      new CodeUnderTest.RewrittenContractTest().EnsuresForAllWithOld(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().EnsuresForAllWithOld(A, false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsuresDoubleClosure() {
       int[] A = new int[] { 3, 4, 5 };
       new CodeUnderTest.RewrittenContractTest().EnsuresDoubleClosure(A, A, true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEnsuresDoubleClosure() {
       int[] A = new int[] { 3, 4, 5 };
       int[] B = new int[] { 3, 4 };
-      new CodeUnderTest.RewrittenContractTest().EnsuresDoubleClosure(A, B, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().EnsuresDoubleClosure(A, B, false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsuresExistsWithOld() {
       int[] A = new int[] { -3, -4, 5 };
       new CodeUnderTest.RewrittenContractTest().EnsuresExistsWithOld(A, true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEnsuresExistsWithOld() {
       int[] A = new int[] { -3, -4, -5 };
-      new CodeUnderTest.RewrittenContractTest().EnsuresExistsWithOld(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().EnsuresExistsWithOld(A, false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEnsuresWithResultAndQuantifiers() {
       int[] A = new int[] { -3, -4, -5 };
       new CodeUnderTest.RewrittenContractTest().EnsuresWithResultAndQuantifiers(A, true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEnsuresWithResultAndQuantifiers() {
       int[] A = new int[] { -3, -4, -5 };
-      new CodeUnderTest.RewrittenContractTest().EnsuresWithResultAndQuantifiers(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().EnsuresWithResultAndQuantifiers(A, false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 #if TURNINGSTATICCLOSUREINTOOBJECTCLOSURE
-        [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+        [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
         public void PositiveEnsuresWithStaticClosure()
         {
           EnsuresWithStaticClosure(true);
+          Assert.Equal(0, TestRewriterMethods.FailureCount);
         }
-        [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-        [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+        [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
         public void NegativeEnsuresWithStaticClosure()
         {
-          EnsuresWithStaticClosure(false);
+          Assert.Throws<TestRewriterMethods.PostconditionException>(() => EnsuresWithStaticClosure(false));
+          Assert.Equal(1, TestRewriterMethods.FailureCount);
         }
 #endif
 
     #region IfThenThrow
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveIfThenThrowAsPrecondition() {
       new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(System.ArgumentException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeIfThenThrowAsPrecondition() {
-      new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition(false);
+      Assert.Throws<ArgumentException>(() => new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition(false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveIfThenThrowAsPrecondition2() {
       new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition2(1);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(System.ArgumentOutOfRangeException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeIfThenThrowAsPrecondition2() {
-      new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition2(-1);
+      Assert.Throws<ArgumentOutOfRangeException>(() => new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition2(-1));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveIfThenThrowAsPrecondition3() {
       new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition3(3);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(System.ArgumentOutOfRangeException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeIfThenThrowAsPrecondition3a() {
-      new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition3(-1);
+      Assert.Throws<ArgumentOutOfRangeException>(() => new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition3(-1));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeIfThenThrowAsPrecondition3b() {
-      new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition3(2);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new CodeUnderTest.RewrittenContractTest().IfThenThrowAsPrecondition3(2));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
     #endregion IfThenThrow
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveUseAParamsMethodInContract() {
       new CodeUnderTest.RewrittenContractTest().UseAParamsMethodInContract(3);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeUseAParamsMethodInContract() {
-      new CodeUnderTest.RewrittenContractTest().UseAParamsMethodInContract(5);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new CodeUnderTest.RewrittenContractTest().UseAParamsMethodInContract(5));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveAssertArgumentIsPositive() {
       new CodeUnderTest.RewrittenContractTest().AssertArgumentIsPositive(3);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAssertArgumentIsPositive() {
       try {
         new CodeUnderTest.RewrittenContractTest().AssertArgumentIsPositive(-3);
         throw new Exception();
       } catch (TestRewriterMethods.AssertException e) {
-        Assert.AreEqual("0 < y", e.Condition);
+        Assert.Equal("0 < y", e.Condition);
       }
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveOldExpressionWithoutGoodNameToUseForLocal() {
       int a = 3;
       int b = 5;
       new CodeUnderTest.RewrittenContractTest().Swap(ref a, ref b, true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOldExpressionWithoutGoodNameToUseForLocal1() {
       int a = 3;
       int b = 3;
-      new CodeUnderTest.RewrittenContractTest().Swap(ref a, ref b, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new CodeUnderTest.RewrittenContractTest().Swap(ref a, ref b, true));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOldExpressionWithoutGoodNameToUseForLocal2() {
       int a = 3;
       int b = 5;
-      new CodeUnderTest.RewrittenContractTest().Swap(ref a, ref b, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().Swap(ref a, ref b, false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositivePostConditionUsingResultAsCallee() {
       new CodeUnderTest.RewrittenContractTest().PostConditionUsingResultAsCallee(true);
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativePostConditionUsingResultAsCallee() {
-      new CodeUnderTest.RewrittenContractTest().PostConditionUsingResultAsCallee(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new CodeUnderTest.RewrittenContractTest().PostConditionUsingResultAsCallee(false));
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeRequiresExceptionTest1() {
       try {
         new CodeUnderTest.RewrittenContractTest().RequiresArgumentNullException(null);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentNullException a) {
-        Assert.AreEqual("parameter", a.ParamName);
+        Assert.Equal("parameter", a.ParamName);
       }
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeRequiresExceptionTest2() {
       try {
         new CodeUnderTest.RewrittenContractTest().RequiresArgumentOutOfRangeException(-1);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentOutOfRangeException a) {
-        Assert.AreEqual("parameter", a.ParamName);
+        Assert.Equal("parameter", a.ParamName);
       }
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeRequiresExceptionTest3() {
       try {
         new CodeUnderTest.RewrittenContractTest().RequiresArgumentException(0, 1);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentException a) {
-        //Assert.AreEqual(null, a.ParamName);
-        Assert.AreEqual("Precondition failed: x >= y: x must be at least y\r\nParameter name: x must be at least y", a.Message);
+        //Assert.Equal(null, a.ParamName);
+        Assert.Equal("Precondition failed: x >= y: x must be at least y\r\nParameter name: x must be at least y", a.Message);
       }
+      Assert.Equal(1, TestRewriterMethods.FailureCount);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveTestForMemberVisibility1() {
       CodeUnderTest.RewrittenContractTest.TestForMemberVisibility1(3); // call is not really needed since the test is to make sure the rewriter doesn't crash.
+      Assert.Equal(0, TestRewriterMethods.FailureCount);
     }
     #endregion
   }
@@ -667,11 +755,9 @@ namespace Tests {
   /// "return true" (i.e., it is a void method so it just returns
   /// without throwing an exception).
   /// </summary>
-  [TestClass]
   public class ReEntrantInvariantTest : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public ReEntrantInvariantTest() {
       object[] attrs = typeof(CodeUnderTest.ReEntrantInvariantTest).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -684,47 +770,35 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void TestReenterInvariant() {
       var c = new CodeUnderTest.ReEntrantInvariantTest.ClassWithInvariant();
       c.ReEnter();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void FailInvariant1() {
       var c = new CodeUnderTest.ReEntrantInvariantTest.ClassWithInvariant();
       try {
         c.FailInvariant1();
         throw new Exception("Expected failure did not happen");
       } catch (TestRewriterMethods.InvariantException e) {
-        Assert.AreEqual("b", e.Condition);
+        Assert.Equal("b", e.Condition);
       }
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void FailInvariant2() {
       var c = new CodeUnderTest.ReEntrantInvariantTest.ClassWithInvariant();
       try {
         c.FailInvariant2();
         throw new Exception("Expected failure did not happen");
       } catch (TestRewriterMethods.InvariantException e) {
-        Assert.AreEqual("PureMethod()", e.Condition);
+        Assert.Equal("PureMethod()", e.Condition);
       }
     }
     #endregion Tests
@@ -734,11 +808,9 @@ namespace Tests {
   /// Test to make sure that an invariant in a class does not get
   /// "inherited" by any nested classes.
   /// </summary>
-  [TestClass]
   public class ClassWithInvariantAndNestedClass : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public ClassWithInvariantAndNestedClass() {
       object[] attrs = typeof(CodeUnderTest.ClassWithInvariantAndNestedClass).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -751,23 +823,11 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.  This is usually done in the post build script of the test project.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.  This is usually done in the post build script of the test project.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void ReEnterInvariant() {
       // Don't need to call another method because this method
       // must be public and so gets rewritten to call the invariant.
@@ -778,11 +838,9 @@ namespace Tests {
     #endregion Tests
   }
 
-  [TestClass]
   public class LocalsOfStructTypeEndingUpInAssignments : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public LocalsOfStructTypeEndingUpInAssignments() {
       object[] attrs = typeof(CodeUnderTest.LocalsOfStructTypeEndingUpInAssignments).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -795,47 +853,31 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveLocalOfStructType() {
       var l = new CodeUnderTest.LocalsOfStructTypeEndingUpInAssignments.MyCollection<int, CodeUnderTest.LocalsOfStructTypeEndingUpInAssignments.Positive>();
       l.Add(5);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeLocalOfStructType1() {
       var l = new CodeUnderTest.LocalsOfStructTypeEndingUpInAssignments.MyCollection<int, CodeUnderTest.LocalsOfStructTypeEndingUpInAssignments.Positive>();
-      l.Add(0);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => l.Add(0));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeLocalOfStructType2() {
       var l = new CodeUnderTest.LocalsOfStructTypeEndingUpInAssignments.MyCollection<int, CodeUnderTest.LocalsOfStructTypeEndingUpInAssignments.Positive>();
-      l.Pull();
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => l.Pull());
     }
     #endregion Tests
   }
 
-  [TestClass]
   public class LegacyPreconditions : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public LegacyPreconditions() {
       object[] attrs = typeof(CodeUnderTest.LegacyPreconditions).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -848,52 +890,36 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.  This is usually done in the post build script of the test project.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.  This is usually done in the post build script of the test project.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveLegacyRequiresDirectThrow() {
       var c = new CodeUnderTest.LegacyPreconditions.C();
       c.DirectThrow(3);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeLegacyRequiresDirectThrow() {
       var c = new CodeUnderTest.LegacyPreconditions.C();
-      c.DirectThrow(-3);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => c.DirectThrow(-3));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveLegacyRequiresIndirectThrow() {
       var c = new CodeUnderTest.LegacyPreconditions.C();
       c.IndirectThrow(3);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeLegacyRequiresIndirectThrow() {
       var c = new CodeUnderTest.LegacyPreconditions.C();
-      c.IndirectThrow(-3);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => c.IndirectThrow(-3));
     }
     #endregion Tests
   }
 
-  [TestClass]
   public class GenericClassWithDeferringCtor :DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public GenericClassWithDeferringCtor() {
       object[] attrs = typeof(CodeUnderTest.GenericClassWithDeferringCtor).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -906,39 +932,28 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveGenericClassWithDeferringCtor() {
       var c = new CodeUnderTest.GenericClassWithDeferringCtor.C<int>('a');
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeGenericClassWithDeferringCtor() {
-      var c = new CodeUnderTest.GenericClassWithDeferringCtor.C<int>('z');
+      Assert.Throws<TestRewriterMethods.PreconditionException>(
+        () =>
+        {
+          var c = new CodeUnderTest.GenericClassWithDeferringCtor.C<int>('z');
+        });
     }
     #endregion Tests
   }
 
-  [TestClass]
   public class IfaceContractUsingLocalToHoldSelf : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public IfaceContractUsingLocalToHoldSelf() {
       object[] attrs = typeof(CodeUnderTest.IfaceContractUsingLocalToHoldSelf).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -951,50 +966,34 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveIfaceContractUsingLocalToHoldSelf() {
       CodeUnderTest.IfaceContractUsingLocalToHoldSelf.J j = new CodeUnderTest.IfaceContractUsingLocalToHoldSelf.B();
       int[] A = new int[] { 3, 4, 5 };
       j.M(A, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeIfaceContractUsingLocalToHoldSelf1() {
       CodeUnderTest.IfaceContractUsingLocalToHoldSelf.J j = new CodeUnderTest.IfaceContractUsingLocalToHoldSelf.B();
       int[] A = new int[] { 3, 0, 5 };
-      j.M(A, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => j.M(A, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeIfaceContractUsingLocalToHoldSelf2() {
       CodeUnderTest.IfaceContractUsingLocalToHoldSelf.J j = new CodeUnderTest.IfaceContractUsingLocalToHoldSelf.B();
       int[] A = new int[] { 3, 4, 5 };
-      j.M(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => j.M(A, false));
     }
     #endregion Tests
   }
 
-  [TestClass]
   public class EvaluateOldExpressionsAfterPreconditions :DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public EvaluateOldExpressionsAfterPreconditions() {
       object[] attrs = typeof(CodeUnderTest.EvaluateOldExpressionsAfterPreconditions).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -1007,40 +1006,27 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEvaluateOldExpressionsAfterPreconditions() {
       var c = new CodeUnderTest.EvaluateOldExpressionsAfterPreconditions.C();
       int[] A = new int[] { 3, 4, 5 };
       c.M(A);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeEvaluateOldExpressionsAfterPreconditions() {
       var c = new CodeUnderTest.EvaluateOldExpressionsAfterPreconditions.C();
-      c.M(null); // if the old value for xs.Length is evaluated before the precondition this results in a null dereference
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => c.M(null)); // if the old value for xs.Length is evaluated before the precondition this results in a null dereference
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEvaluateFailingOldExpression1() {
       var c = new CodeUnderTest.EvaluateOldExpressionsAfterPreconditions.C();
       c.ConditionalOld(null);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveEvaluateFailingOldExpression2() {
       var c = new CodeUnderTest.EvaluateOldExpressionsAfterPreconditions.C();
       c.ConditionalOld(new int[] { 3, 4 });
@@ -1048,11 +1034,9 @@ namespace Tests {
     #endregion Tests
   }
 
-  [TestClass]
   public class PostConditionsInStructCtorsMentioningFields : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public PostConditionsInStructCtorsMentioningFields() {
       object[] attrs = typeof(CodeUnderTest.PostConditionsInStructCtorsMentioningFields).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -1065,39 +1049,28 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveFieldsInStructCtorEnsures() {
       var s = new CodeUnderTest.PostConditionsInStructCtorsMentioningFields.S(3, 4, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeFieldsInStructCtorEnsures() {
-      var s = new CodeUnderTest.PostConditionsInStructCtorsMentioningFields.S(3, 4, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(
+        () =>
+        {
+          var s = new CodeUnderTest.PostConditionsInStructCtorsMentioningFields.S(3, 4, false);
+        });
     }
     #endregion Tests
   }
 
-  [TestClass]
   public class PrivateInvariantInSealedType : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public PrivateInvariantInSealedType() {
       object[] attrs = typeof(CodeUnderTest.PrivateInvariantInSealedType).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -1110,39 +1083,28 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositivePrivateInvariantMethod() {
       var t = new CodeUnderTest.PrivateInvariantInSealedType.T(3, 4, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.InvariantException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativePrivateInvariantMethod() {
-      var t = new CodeUnderTest.PrivateInvariantInSealedType.T(3, 4, false);
+      Assert.Throws<TestRewriterMethods.InvariantException>(
+        () =>
+        {
+          var t = new CodeUnderTest.PrivateInvariantInSealedType.T(3, 4, false);
+        });
     }
     #endregion Tests
   }
 
-  [TestClass]
   public class ConstructorsWithClosures : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public ConstructorsWithClosures() {
       object[] attrs = typeof(CodeUnderTest.ConstructorsWithClosures).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -1155,164 +1117,152 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveCtorWithClosure1() {
       var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping("hello");
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveCtorWithClosure2() {
       var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping(new Object());
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveCtorWithClosure3() {
       var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping("hello", true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveCtorWithClosure4() {
       var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping(new object(), false);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveCtorWithClosure5() {
       var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping("Hello", new[] { "Foo", "Bar", "Hello" });
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveCtorWithClosure6() {
       var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping("Hello", "Hello");
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeCtorWithClosure1() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping(null);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentException a) {
-        Assert.AreEqual("Precondition failed: encoder != null", a.Message);
+        Assert.Equal("Precondition failed: encoder != null", a.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeCtorWithClosure2() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping(null, false);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentException a) {
-        Assert.AreEqual("Precondition failed: encoder != null", a.Message);
+        Assert.Equal("Precondition failed: encoder != null", a.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeCtorWithClosure3() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping(null, (string[])null);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentException a) {
-        Assert.AreEqual("Precondition failed: encoder != null", a.Message);
+        Assert.Equal("Precondition failed: encoder != null", a.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeCtorWithClosure4() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping("Hello", new[] { "A", "b", "D" });
         throw new Exception("Expected failure did not happen");
       } catch (TestRewriterMethods.PostconditionException a) {
-        Assert.AreEqual(": Contract.Exists(0, data.Length, i => data[i] == this.name)", a.Message);
+        Assert.Equal(": Contract.Exists(0, data.Length, i => data[i] == this.name)", a.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeCtorWithClosure5() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.ValueMapping(null, (string)null);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentException a) {
-        Assert.AreEqual("Precondition failed: encoder != null", a.Message);
+        Assert.Equal("Precondition failed: encoder != null", a.Message);
       }
     }
 
     /// <summary>
     /// Structs
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveStructCtorWithClosure1() {
       var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors("hello");
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveStructCtorWithClosure2() {
       var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors(new Object());
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveStructCtorWithClosure3() {
       var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors("hello", true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveStructCtorWithClosure4() {
       var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors(new object(), false);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveStructCtorWithClosure5() {
       var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors("Hello", new[] { "Foo", "Bar", "Hello" });
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveStructCtorWithClosure6() {
       var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors("Hello", "Hello");
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeStructCtorWithClosure1() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors(null);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentException a) {
-        Assert.AreEqual("Precondition failed: encoder != null", a.Message);
+        Assert.Equal("Precondition failed: encoder != null", a.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeStructCtorWithClosure2() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors(null, false);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentException a) {
-        Assert.AreEqual("Precondition failed: encoder != null", a.Message);
+        Assert.Equal("Precondition failed: encoder != null", a.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeStructCtorWithClosure3() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors(null, (string[])null);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentException a) {
-        Assert.AreEqual("Precondition failed: encoder != null", a.Message);
+        Assert.Equal("Precondition failed: encoder != null", a.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeStructCtorWithClosure4() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors("Hello", new[] { "A", "b", "D" });
         throw new Exception("Expected failure did not happen");
       } catch (TestRewriterMethods.PostconditionException a) {
-        Assert.AreEqual(": Contract.Exists(0, data.Length, i => data[i] == (encoder as string))", a.Message);
+        Assert.Equal(": Contract.Exists(0, data.Length, i => data[i] == (encoder as string))", a.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeStructCtorWithClosure5() {
       try {
         var c = new CodeUnderTest.ConstructorsWithClosures.StructCtors(null, (string)null);
         throw new Exception("Expected failure did not happen");
       } catch (ArgumentException a) {
-        Assert.AreEqual("Precondition failed: encoder != null", a.Message);
+        Assert.Equal("Precondition failed: encoder != null", a.Message);
       }
     }
 
@@ -1355,14 +1305,13 @@ namespace Tests {
   /// 
   /// Iterator + ("" (non-generic type non-generic method) | GenCls | GenMeth | GenClsMeth | GenStr |GenStrMth) + (Pos | Neg) + ( "" (meaning precondition) | Post) + ( "" (meaning parameter) | collection | elem) + "NN | Eq ... | LT |...".
   /// </summary>
-  [TestClass]
   public class IteratorSimpleContract : DisableAssertUI {
     #region Test Drivers
     #region Non-generic class drivers
     /// <summary>
     /// This driver passes the preconditions of Test1a.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorPositiveNN() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       test2.Test1a("hello"); // Precondition of Test1a holds
@@ -1371,28 +1320,26 @@ namespace Tests {
     /// <summary>
     /// This driver violates the precondition of Test1a.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorNegativeNN() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
-      test2.Test1a(null); // Precondition of Test1a violated.
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test2.Test1a(null)); // Precondition of Test1a violated.
     }
 
     /// <summary>
     /// This driver catches the postcondition violation of Test1aa.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorNegativePostAllNN() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
-      test2.Test1aa("hello"); // Postcondition of Test1aa is invalid. 
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => test2.Test1aa("hello")); // Postcondition of Test1aa is invalid. 
     }
 
     /// <summary>
     /// This driver tests a legacy precondition
     /// Legacy contract throws an exception when violated (and is caught by the driver).
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorNegativeLegacyArgNN() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       try
@@ -1403,7 +1350,7 @@ namespace Tests {
       }
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorPositiveLegacyArgNN() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       test2.Test1b("hello");
@@ -1412,29 +1359,27 @@ namespace Tests {
     /// <summary>
     /// This driver fails the first precondition of Test1d.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorNegativeCollectionNN() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       IEnumerable<string> x = null;
-      test2.Test1d(x);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test2.Test1d(x));
     }
 
     /// <summary>
     /// This driver fails the second precondition of Test1d.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorNegativeElemNN() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       string[] strs = { null };
-      test2.Test1d(strs);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test2.Test1d(strs));
     }
 
     /// <summary>
     /// This driver passes the preconditions of Test1d.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorPositivePostElemNN() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       string[] strs = { "hello" };
@@ -1444,7 +1389,7 @@ namespace Tests {
     /// <summary>
     /// This driver passes preconditions of Test1f.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorPositiveElemLTMax() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       int[] xs = { 2, 3, 4, 8 };
@@ -1454,82 +1399,76 @@ namespace Tests {
     /// <summary>
     /// This driver fails the precondition of Test1f.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorNegativeElemLTMax() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       int[] xs = { 2, 3, 4, 11 };
-      test2.Test1f(xs, 10);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test2.Test1f(xs, 10));
     }
 
     /// <summary>
     /// This driver catches the postcondition violation of Test1f.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorNegativePostElemLTMax() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       int[] xs = { 2, 3, 4, 9 };
-      test2.Test1f(xs, 10);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => test2.Test1f(xs, 10));
     }
 
     /// <summary>
     /// This driver passes Test1g.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorPositivePostElemEqParam2() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       string[] strs = { "hello", "hello" };
       test2.Test1g(strs, "hello");
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorNegativePostElemEqParam2() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
       string[] strs = { "aaa", "hello" };
-      test2.Test1g(strs, "hello");
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test2.Test1g(strs, "hello"));
     }
 
     /// <summary>
     /// This driver catches the postcondition violation of Test1h. 
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorNegativePostElemLTMaxConstrained() {
       var test2 = new CodeUnderTest.IteratorSimpleContract.Test2();
-      test2.Test2h();
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => test2.Test2h());
     }
     #endregion NonGeneric Class Drivers
     #region Generic Class Drivers
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsPosNN() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
       test3.Test1a(new CodeUnderTest.IteratorSimpleContract.A("hello"));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsNegNN() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
-      test3.Test1a(null);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test3.Test1a(null));
     }
 
     /// <summary>
     /// This driver catches the postcondition violation of Test1aa.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsNegPostAllNN() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
-      test3.Test1aa(new CodeUnderTest.IteratorSimpleContract.A(""));
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => test3.Test1aa(new CodeUnderTest.IteratorSimpleContract.A("")));
     }
 
     /// <summary>
     /// This driver tests a legacy precondition
     /// Legacy contract throws an exception when violated (and is caught by the driver).
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsNegLegacyArgNN() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
       try
@@ -1540,35 +1479,33 @@ namespace Tests {
       }
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsPosLegacyArgNN() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
       test3.Test1b(new CodeUnderTest.IteratorSimpleContract.A("hello"));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsMethNegCollectionNN() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
       IEnumerable<CodeUnderTest.IteratorSimpleContract.A> x = null;
-      test3.Test1d(x);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test3.Test1d(x));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsMethNegElemNN() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
       CodeUnderTest.IteratorSimpleContract.A[] aa = { null };
-      test3.Test1d(aa);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test3.Test1d(aa));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsMethPosPostElemNN() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A(null));
       CodeUnderTest.IteratorSimpleContract.A[] strs = { new CodeUnderTest.IteratorSimpleContract.A("hello") };
       test3.Test1d(strs);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsMethPosElemMethEqParamMeth() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A(null));
       CodeUnderTest.IteratorSimpleContract.A a = new CodeUnderTest.IteratorSimpleContract.A("hello");
@@ -1576,16 +1513,15 @@ namespace Tests {
       test3.Test1e(aa, a);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsMethNegElemMethEqParamMeth() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A(null));
       CodeUnderTest.IteratorSimpleContract.A a = new CodeUnderTest.IteratorSimpleContract.A("hello");
       CodeUnderTest.IteratorSimpleContract.A[] aa = { new CodeUnderTest.IteratorSimpleContract.A("12345"), new CodeUnderTest.IteratorSimpleContract.A("5432") };
-      test3.Test1e(aa, a);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test3.Test1e(aa, a));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsMethInsClPosElemEqParam() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A(null));
       CodeUnderTest.IteratorSimpleContract.A a = new CodeUnderTest.IteratorSimpleContract.A("hello");
@@ -1593,24 +1529,22 @@ namespace Tests {
       test3.Test1g(aa, a);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsMethInsClNegElemEqParam() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A(null));
       CodeUnderTest.IteratorSimpleContract.A a = new CodeUnderTest.IteratorSimpleContract.A("hello");
       CodeUnderTest.IteratorSimpleContract.A[] aa = { new CodeUnderTest.IteratorSimpleContract.A("12345"), new CodeUnderTest.IteratorSimpleContract.A("321") };
-      test3.Test1g(aa, a);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test3.Test1g(aa, a));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsMethInsClNegPostElemLTProp() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
       CodeUnderTest.IteratorSimpleContract.A[] aa = { new CodeUnderTest.IteratorSimpleContract.A("45"), new CodeUnderTest.IteratorSimpleContract.A("321") };
-      test3.Test1h(aa);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => test3.Test1h(aa));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenClsMethPostElemLTProp() {
       var test3 = new CodeUnderTest.IteratorSimpleContract.Test3<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
       CodeUnderTest.IteratorSimpleContract.A[] aa = { new CodeUnderTest.IteratorSimpleContract.A("1234567"), new CodeUnderTest.IteratorSimpleContract.A("213456") };
@@ -1618,30 +1552,28 @@ namespace Tests {
     }
     #endregion Generic Class Drivers
     #region Generic Struct Drivers
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenStrPosNN() {
       var test4 = new CodeUnderTest.IteratorSimpleContract.Test4<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
       test4.Test1a(new CodeUnderTest.IteratorSimpleContract.A("hello"));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenStrNegNN() {
       var test4 = new CodeUnderTest.IteratorSimpleContract.Test4<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
-      test4.Test1a(null);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test4.Test1a(null));
     }
 
     /// <summary>
     /// This driver catches the postcondition violation of Test1aa.
     /// </summary>
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenStrNegPostAllNN() {
       var test4 = new CodeUnderTest.IteratorSimpleContract.Test4<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A("hello"));
-      test4.Test1aa(new CodeUnderTest.IteratorSimpleContract.A(""));
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => test4.Test1aa(new CodeUnderTest.IteratorSimpleContract.A("")));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenStrMethPosElemMethEqParamMeth() {
       var test4 = new CodeUnderTest.IteratorSimpleContract.Test4<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A(null));
       CodeUnderTest.IteratorSimpleContract.A a = new CodeUnderTest.IteratorSimpleContract.A("hello");
@@ -1649,36 +1581,32 @@ namespace Tests {
       test4.Test1e(aa, a);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IteratorGenStrMethNegElemMethEqParamMeth() {
       var test4 = new CodeUnderTest.IteratorSimpleContract.Test4<CodeUnderTest.IteratorSimpleContract.A>(new CodeUnderTest.IteratorSimpleContract.A(null));
       CodeUnderTest.IteratorSimpleContract.A a = new CodeUnderTest.IteratorSimpleContract.A("hello");
       CodeUnderTest.IteratorSimpleContract.A[] aa = { new CodeUnderTest.IteratorSimpleContract.A("12345"), new CodeUnderTest.IteratorSimpleContract.A("5432") };
-      test4.Test1e(aa, a);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => test4.Test1e(aa, a));
     }
 
     #endregion Generic Struct Drivers
     #region IEnumerator Drivers
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IEnumeratorPos() {
       new CodeUnderTest.IteratorSimpleContract().Test5a(2);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void IEnumeratorNeg() {
-      new CodeUnderTest.IteratorSimpleContract().Test5a(0);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new CodeUnderTest.IteratorSimpleContract().Test5a(0));
     }
     #endregion
     #endregion Test Drivers
   }
 
-  [TestClass]
   public class LocalVariableForResult : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public LocalVariableForResult() {
       object[] attrs = typeof(CodeUnderTest.LocalVariableForResult).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -1691,23 +1619,11 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveLocalAsResult1() {
       var c = new CodeUnderTest.LocalVariableForResult.C();
       c.Test1(1);
@@ -1716,50 +1632,48 @@ namespace Tests {
       var c = new CodeUnderTest.LocalVariableForResult.C();
       c.Test2(1, new bool[] { });
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveLocalAsResult3() {
       var c = new CodeUnderTest.LocalVariableForResult.C();
       c.Test2(1, new bool[] { true, true, true });
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeLocalAsResult1() {
       try {
         var c = new CodeUnderTest.LocalVariableForResult.C();
         c.Test1(2);
         throw new Exception("Expected failure did not happen");
       } catch (TestRewriterMethods.PostconditionException p) {
-        Assert.AreEqual(": result != false", p.Message);
+        Assert.Equal(": result != false", p.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeLocalAsResult2() {
       try {
         var c = new CodeUnderTest.LocalVariableForResult.C();
         c.Test2(2, new bool[] { });
         throw new Exception("Expected failure did not happen");
       } catch (TestRewriterMethods.PostconditionException p) {
-        Assert.AreEqual(": result != false", p.Message);
+        Assert.Equal(": result != false", p.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeLocalAsResult3() {
       try {
         var c = new CodeUnderTest.LocalVariableForResult.C();
         c.Test2(1, new bool[] { true, false });
         throw new Exception("Expected failure did not happen");
       } catch (TestRewriterMethods.PostconditionException p) {
-        Assert.AreEqual(": Contract.ForAll(0, arr.Length, i => arr[i] == result)", p.Message);
+        Assert.Equal(": Contract.ForAll(0, arr.Length, i => arr[i] == result)", p.Message);
       }
     }
 
     #endregion Tests
   }
 
-  [TestClass]
   public class IgnoreRuntimeAttributeTest : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public IgnoreRuntimeAttributeTest() {
       object[] attrs = typeof(CodeUnderTest.IgnoreRuntimeAttributeTest).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -1772,35 +1686,23 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveIgnoreRuntimeAttributeTest() {
       var c = new CodeUnderTest.IgnoreRuntimeAttributeTest.C();
       c.M(3, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeIgnoreRuntimeAttributeTest() {
       try {
         var c = new CodeUnderTest.IgnoreRuntimeAttributeTest.C();
         c.M(2, false);
         throw new Exception("Expected failure did not happen");
       } catch (TestRewriterMethods.PostconditionException p) {
-        Assert.AreEqual(": Contract.Result<bool>()", p.Message);
+        Assert.Equal(": Contract.Result<bool>()", p.Message);
       }
     }
 
@@ -1813,11 +1715,9 @@ namespace Tests {
   /// their initial value is used in the postcondition in case the
   /// parameter is updated in the method body.
   /// </summary>
-  [TestClass]
   public class WrapParametersInOld : DisableAssertUI {
     #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context) {
+    public WrapParametersInOld() {
       object[] attrs = typeof(CodeUnderTest.WrapParametersInOld).Assembly.GetCustomAttributes(true);
       bool found = false;
       foreach (var a in attrs) {
@@ -1830,33 +1730,21 @@ namespace Tests {
           break;
         }
       }
-      Assert.IsTrue(found, "This assembly must have been rewritten before running these tests.");
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup() {
-    }
-
-    [TestInitialize]
-    public void TestInitialize() {
-    }
-
-    [TestCleanup]
-    public void TestCleanup() {
+      Assert.True(found, "This assembly must have been rewritten before running these tests.");
     }
     #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveWrapParam1() {
       var c = new CodeUnderTest.WrapParametersInOld.C(3);
       c.Identity(true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveWrapParam2() {
       var c = new CodeUnderTest.WrapParametersInOld.C(3);
       c.Identity(false);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveWrapParam3() {
       var c = new CodeUnderTest.WrapParametersInOld.C(3);
       var s = new CodeUnderTest.WrapParametersInOld.C.S();

--- a/Foxtrot/Tests/UnitTests/RewrittenInheritanceTest.cs
+++ b/Foxtrot/Tests/UnitTests/RewrittenInheritanceTest.cs
@@ -12,402 +12,356 @@
 // 
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 using System;
 using System.Text;
 using System.Collections.Generic;
 using CodeUnderTest;
+using Xunit;
 
 namespace Tests {
 
   #region Tests
-  [TestClass]
   public class RewrittenInheritanceTest : DisableAssertUI {
 
-    [ClassCleanup]
-    public static void ClassCleanup()
-    {
-    }
-
-    [TestInitialize]
-    public void TestInitialize()
-    {
-    }
-
-    [TestCleanup]
-    public void TestCleanup()
-    {
-    }
-
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveOneLevelInheritanceInvariantTest()
     {
       new RewrittenInheritanceDerived().SetInheritedValueMustBeTrue(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.InvariantException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeOneLevelInheritanceInvariantTest()
     {
-      new RewrittenInheritanceDerived().SetInheritedValueMustBeTrue(false);
+      Assert.Throws<TestRewriterMethods.InvariantException>(() => new RewrittenInheritanceDerived().SetInheritedValueMustBeTrue(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveTwoLevelInheritanceInvariantTest()
     {
       new RewrittenInheritanceDerived().SetBaseValueMustBeTrue(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.InvariantException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeTwoLevelInheritanceInvariantTest()
     {
-      new RewrittenInheritanceDerived().SetBaseValueMustBeTrue(false);
+      Assert.Throws<TestRewriterMethods.InvariantException>(() => new RewrittenInheritanceDerived().SetBaseValueMustBeTrue(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveBareInheritanceRequiresTest()
     {
       new RewrittenInheritanceDerived().BareRequires(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeBareInheritanceRequiresTest()
     {
-      new RewrittenInheritanceDerived().BareRequires(false);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().BareRequires(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveLegacyInheritanceRequiresTest()
     {
       new RewrittenInheritanceDerived().LegacyRequires("");
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(ArgumentNullException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeLegacyInheritanceRequiresTest()
     {
-      new RewrittenInheritanceDerived().LegacyRequires(null);
+      Assert.Throws<ArgumentNullException>(() => new RewrittenInheritanceDerived().LegacyRequires(null));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInheritanceRequiresWithExceptionTest()
     {
       new RewrittenInheritanceDerived().RequiresWithException("");
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(ArgumentNullException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInheritanceRequiresWithExceptionTest()
     {
-      new RewrittenInheritanceDerived().RequiresWithException(null);
+      Assert.Throws<ArgumentNullException>(() => new RewrittenInheritanceDerived().RequiresWithException(null));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveAdditiveInheritanceRequiresTest()
     {
       new RewrittenInheritanceDerived().AdditiveRequires(101);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAdditiveOneLevelInheritanceRequiresTest()
     {
-      new RewrittenInheritanceDerived().AdditiveRequires(0);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().AdditiveRequires(0));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAdditiveTwoLevelInheritanceRequiresTest()
     {
-      new RewrittenInheritanceDerived().AdditiveRequires(0);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().AdditiveRequires(0));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveSubtractiveInheritanceRequiresTest()
     {
       new RewrittenInheritanceDerived().SubtractiveRequires(101);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeSubtractiveOneLevelInheritanceRequiresTest()
     {
-      new RewrittenInheritanceDerived().SubtractiveRequires(0);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().SubtractiveRequires(0));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeSubtractiveTwoLevelInheritanceRequiresTest()
     {
-      new RewrittenInheritanceDerived().SubtractiveRequires(1);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().SubtractiveRequires(1));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveAdditiveInheritanceEnsuresTest()
     {
       new RewrittenInheritanceDerived().AdditiveEnsures(101);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAdditiveOneLevelInheritanceEnsuresTest()
     {
-      new RewrittenInheritanceDerived().AdditiveEnsures(1);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().AdditiveEnsures(1));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAdditiveTwoLevelInheritanceEnsuresTest()
     {
-      new RewrittenInheritanceDerived().AdditiveEnsures(0);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().AdditiveEnsures(0));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveSubtractiveInheritanceEnsuresTest()
     {
       new RewrittenInheritanceDerived().SubtractiveEnsures(101);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeSubtractiveOneLevelInheritanceEnsuresTest()
     {
-      new RewrittenInheritanceDerived().SubtractiveEnsures(0);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().SubtractiveEnsures(0));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeSubtractiveTwoLevelInheritanceEnsuresTest()
     {
-      new RewrittenInheritanceDerived().SubtractiveEnsures(1);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().SubtractiveEnsures(1));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInheritedImplicitRequiresTest()
     {
       new RewrittenInheritanceDerived().InterfaceBaseRequires(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInheritedImplicitEnsuresTest()
     {
       new RewrittenInheritanceDerived().InterfaceBaseEnsures(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInheritedImplicitRequiresTest()
     {
-      new RewrittenInheritanceDerived().InterfaceBaseRequires(false);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().InterfaceBaseRequires(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInheritedImplicitEnsuresTest()
     {
-      new RewrittenInheritanceDerived().InterfaceBaseEnsures(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().InterfaceBaseEnsures(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveImplicitlyOverriddenRequiresTest()
     {
       new RewrittenInheritanceDerived().ImplicitlyOverriddenInterfaceRequires(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveImplicitlyOverriddenEnsuresTest()
     {
       new RewrittenInheritanceDerived().ImplicitlyOverriddenInterfaceEnsures(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeImplicitlyOverriddenRequiresTest()
     {
-      new RewrittenInheritanceDerived().ImplicitlyOverriddenInterfaceRequires(false);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().ImplicitlyOverriddenInterfaceRequires(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeImplicitlyOverriddenEnsuresTest()
     {
-      new RewrittenInheritanceDerived().ImplicitlyOverriddenInterfaceEnsures(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().ImplicitlyOverriddenInterfaceEnsures(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveExplicitlyOverriddenRequiresTest()
     {
       new RewrittenInheritanceDerived().ExplicitlyOverriddenInterfaceRequires(true);
       new RewrittenInheritanceDerived().ExplicitlyOverriddenInterfaceRequires(false);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveExplicitlyOverriddenEnsuresTest()
     {
       new RewrittenInheritanceDerived().ExplicitlyOverriddenInterfaceEnsures(true);
       new RewrittenInheritanceDerived().ExplicitlyOverriddenInterfaceEnsures(false);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveMultiplyImplicitlyOverriddenRequiresTest()
     {
       new RewrittenInheritanceDerived().MultiplyImplicitlyOverriddenInterfaceRequires(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveMultiplyImplicitlyOverriddenEnsuresTest()
     {
       new RewrittenInheritanceDerived().MultiplyImplicitlyOverriddenInterfaceEnsures(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeMultiplyImplicitlyOverriddenRequiresTest()
     {
-      new RewrittenInheritanceDerived().MultiplyImplicitlyOverriddenInterfaceRequires(false);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().MultiplyImplicitlyOverriddenInterfaceRequires(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeMultiplyImplicitlyOverriddenEnsuresTest()
     {
-      new RewrittenInheritanceDerived().MultiplyImplicitlyOverriddenInterfaceEnsures(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().MultiplyImplicitlyOverriddenInterfaceEnsures(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveMultiplyExplicitlyOverriddenRequiresTest()
     {
       ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyExplicitlyOverriddenInterfaceRequires(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveMultiplyExplicitlyOverriddenEnsuresTest()
     {
       ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyExplicitlyOverriddenInterfaceEnsures(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeMultiplyExplicitlyOverriddenRequiresTest()
     {
-      ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyExplicitlyOverriddenInterfaceRequires(false);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyExplicitlyOverriddenInterfaceRequires(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeMultiplyExplicitlyOverriddenEnsuresTest()
     {
-      ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyExplicitlyOverriddenInterfaceEnsures(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyExplicitlyOverriddenInterfaceEnsures(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveMultiplyDifferentlyImplicitlyOverriddenRequiresTest()
     {
       new RewrittenInheritanceDerived().MultiplyDifferentlyOverriddenInterfaceRequires(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveMultiplyDifferentlyExplicitlyOverriddenRequiresTest()
     {
       ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyDifferentlyOverriddenInterfaceRequires(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveMultiplyDifferentlyImplicitlyOverriddenEnsuresTest()
     {
       new RewrittenInheritanceDerived().MultiplyDifferentlyOverriddenInterfaceEnsures(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveMultiplyDifferentlyExplicitlyOverriddenEnsuresTest()
     {
       ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyDifferentlyOverriddenInterfaceEnsures(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeMultiplyDifferentlyImplicitlyOverriddenRequiresTest()
     {
-      new RewrittenInheritanceDerived().MultiplyDifferentlyOverriddenInterfaceRequires(false);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().MultiplyDifferentlyOverriddenInterfaceRequires(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeMultiplyDifferentlyExplicitlyOverriddenRequiresTest()
     {
-      ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyDifferentlyOverriddenInterfaceRequires(false);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyDifferentlyOverriddenInterfaceRequires(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeMultiplyDifferentlyImplicitlyOverriddenEnsuresTest()
     {
-      new RewrittenInheritanceDerived().MultiplyDifferentlyOverriddenInterfaceEnsures(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().MultiplyDifferentlyOverriddenInterfaceEnsures(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeMultiplyDifferentlyExplicitlyOverriddenEnsuresTest()
     {
-      ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyDifferentlyOverriddenInterfaceEnsures(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => ((IRewrittenMultipleInheritanceInterface)new RewrittenInheritanceDerived()).MultiplyDifferentlyOverriddenInterfaceEnsures(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveImplicitRequiresTest()
     {
       new RewrittenInheritanceDerived().InterfaceRequiresMultipleOfTwo(2);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveImplicitEnsuresTest()
     {
       new RewrittenInheritanceDerived().InterfaceEnsuresMultipleOfTwo(2);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeImplicitRequiresTest()
     {
-      new RewrittenInheritanceDerived().InterfaceRequiresMultipleOfTwo(3);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().InterfaceRequiresMultipleOfTwo(3));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeImplicitEnsuresTest()
     {
-      new RewrittenInheritanceDerived().InterfaceEnsuresMultipleOfTwo(3);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().InterfaceEnsuresMultipleOfTwo(3));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveExplicitRequiresTest()
     {
       ((IRewrittenInheritanceInterfaceDerived2)new RewrittenInheritanceDerived()).InterfaceRequiresMultipleOfThree(3);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveExplicitEnsuresTest()
     {
       ((IRewrittenInheritanceInterfaceDerived2)new RewrittenInheritanceDerived()).InterfaceEnsuresMultipleOfThree(3);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeExplicitRequiresTest()
     {
-      ((IRewrittenInheritanceInterfaceDerived2)new RewrittenInheritanceDerived()).InterfaceRequiresMultipleOfThree(2);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => ((IRewrittenInheritanceInterfaceDerived2)new RewrittenInheritanceDerived()).InterfaceRequiresMultipleOfThree(2));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeExplicitEnsuresTest()
     {
-      ((IRewrittenInheritanceInterfaceDerived2)new RewrittenInheritanceDerived()).InterfaceEnsuresMultipleOfThree(2);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => ((IRewrittenInheritanceInterfaceDerived2)new RewrittenInheritanceDerived()).InterfaceEnsuresMultipleOfThree(2));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveNonExplicitRequiresTest()
     {
       new RewrittenInheritanceDerived().InterfaceRequiresMultipleOfThree(1);
@@ -415,7 +369,7 @@ namespace Tests {
       new RewrittenInheritanceDerived().InterfaceRequiresMultipleOfThree(3);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveNonExplicitEnsuresTest()
     {
       new RewrittenInheritanceDerived().InterfaceEnsuresMultipleOfThree(1);
@@ -423,61 +377,55 @@ namespace Tests {
       new RewrittenInheritanceDerived().InterfaceEnsuresMultipleOfThree(3);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveDoubleRequiresTest()
     {
       new RewrittenInheritanceDerived().InterfaceRequires(6);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveDoubleEnsuresTest()
     {
       new RewrittenInheritanceDerived().InterfaceEnsures(6);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeDoubleRequiresTest1()
     {
-      new RewrittenInheritanceDerived().InterfaceRequires(1);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().InterfaceRequires(1));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeDoubleRequiresTest2()
     {
-      new RewrittenInheritanceDerived().InterfaceRequires(2);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().InterfaceRequires(2));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeDoubleRequiresTest3()
     {
-      new RewrittenInheritanceDerived().InterfaceRequires(3);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new RewrittenInheritanceDerived().InterfaceRequires(3));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeDoubleEnsuresTest1()
     {
-      new RewrittenInheritanceDerived().InterfaceEnsures(1);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().InterfaceEnsures(1));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeDoubleEnsuresTest2()
     {
-      new RewrittenInheritanceDerived().InterfaceEnsures(2);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().InterfaceEnsures(2));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeDoubleEnsuresTest3()
     {
-      new RewrittenInheritanceDerived().InterfaceEnsures(3);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new RewrittenInheritanceDerived().InterfaceEnsures(3));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveQuantifierTest1()
     {
       IQuantifierTest1 iq = new QuantifierTest1();
@@ -485,24 +433,22 @@ namespace Tests {
       iq.ModifyArray(A, 3, true);
       iq.CopyArray(A, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeQuantifierTest1a()
     {
       IQuantifierTest1 iq = new QuantifierTest1();
       int[] A = new int[] { 3, 4, 5 };
-      iq.ModifyArray(A, 3, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => iq.ModifyArray(A, 3, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeQuantifierTest1b()
     {
       IQuantifierTest1 iq = new QuantifierTest1();
       int[] A = new int[] { 3, 4, 5 };
-      iq.CopyArray(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => iq.CopyArray(A, false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveQuantifierTest2()
     {
       IQuantifierTest2 iq = new QuantifierTest2();
@@ -510,124 +456,119 @@ namespace Tests {
       iq.ModifyArray(A, 3, true);
       iq.CopyArray(A, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeQuantifierTest2a()
     {
       IQuantifierTest2 iq = new QuantifierTest2();
       int[] A = new int[] { 3, 4, 5 };
-      iq.ModifyArray(A, 3, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => iq.ModifyArray(A, 3, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeQuantifierTest2b()
     {
       IQuantifierTest2 iq = new QuantifierTest2();
       int[] A = new int[] { 3, 4, 5 };
-      iq.CopyArray(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => iq.CopyArray(A, false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveAbstractClass()
     {
       AbstractClassInterface a = new AbstractClassInterfaceImplementationSubType();
       a.M(true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAbstractClass()
     {
       AbstractClassInterface a = new AbstractClassInterfaceImplementationSubType();
-      a.M(false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => a.M(false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveBaseClassWithMethodCallInContract()
     {
       DerivedClassForBaseClassWithMethodCallInContract o = new DerivedClassForBaseClassWithMethodCallInContract();
       o.M(3);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeBaseClassWithMethodCallInContract()
     {
       DerivedClassForBaseClassWithMethodCallInContract o = new DerivedClassForBaseClassWithMethodCallInContract();
-      o.M(0);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => o.M(0));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInheritOld()
     {
       DerivedFromBaseClassWithOldAndResult o = new DerivedFromBaseClassWithOldAndResult();
       int z = 3;
       o.InheritOld(ref z, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInheritOld()
     {
       DerivedFromBaseClassWithOldAndResult o = new DerivedFromBaseClassWithOldAndResult();
       int z = 3;
-      o.InheritOld(ref z, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => o.InheritOld(ref z, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInheritOldInQuantifier()
     {
       DerivedFromBaseClassWithOldAndResult o = new DerivedFromBaseClassWithOldAndResult();
       int[] A = new int[] { 3, 4, 5 };
       o.InheritOldInQuantifier(A, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInheritOldInQuantifier()
     {
       DerivedFromBaseClassWithOldAndResult o = new DerivedFromBaseClassWithOldAndResult();
       int[] A = new int[] { 3, 4, 5 };
-      o.InheritOldInQuantifier(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => o.InheritOldInQuantifier(A, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInheritResultInContract()
     {
       DerivedFromBaseClassWithOldAndResult o = new DerivedFromBaseClassWithOldAndResult();
       o.InheritResult(3, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInheritResultInContract()
     {
       DerivedFromBaseClassWithOldAndResult o = new DerivedFromBaseClassWithOldAndResult();
-      o.InheritResult(3, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => o.InheritResult(3, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInheritResultInQuantifier()
     {
       DerivedFromBaseClassWithOldAndResult o = new DerivedFromBaseClassWithOldAndResult();
       int[] A = new int[] { 3, 4, 5 };
       o.InheritResultInQuantifier(A, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInheritResultInQuantifier()
     {
       DerivedFromBaseClassWithOldAndResult o = new DerivedFromBaseClassWithOldAndResult();
       int[] A = new int[] { 3, 4, 5 };
-      o.InheritResultInQuantifier(A, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => o.InheritResultInQuantifier(A, false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.InvariantException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeProperlyInstantiateInheritedInvariants()
     {
-      NonGenericDerivedFromGenericWithInvariant ng = new NonGenericDerivedFromGenericWithInvariant(false);
+      Assert.Throws<TestRewriterMethods.InvariantException>(
+        () =>
+        {
+          NonGenericDerivedFromGenericWithInvariant ng = new NonGenericDerivedFromGenericWithInvariant(false);
+        });
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveProperlyInstantiateInheritedInvariants()
     {
       NonGenericDerivedFromGenericWithInvariant ng = new NonGenericDerivedFromGenericWithInvariant(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveExplicitGenericInterfaceMethod()
     {
       IInterfaceWithGenericMethod i = new ExplicitGenericInterfaceMethodImplementation(0);
@@ -637,7 +578,7 @@ namespace Tests {
 
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeExplicitGenericInterfaceMethod1()
     {
       try
@@ -650,10 +591,10 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PostconditionException e)
       {
-        Assert.AreEqual(": Contract.ForAll(Contract.Result<IEnumerable<T>>(), x => x != null)", e.Message);
+        Assert.Equal(": Contract.ForAll(Contract.Result<IEnumerable<T>>(), x => x != null)", e.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeExplicitGenericInterfaceMethod2()
     {
       try
@@ -666,12 +607,12 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PostconditionException e)
       {
-        Assert.AreEqual(": Contract.Result<IEnumerable<T>>() != null", e.Message);
+        Assert.Equal(": Contract.Result<IEnumerable<T>>() != null", e.Message);
       }
     }
 
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveImplicitGenericInterfaceMethod()
     {
       var i = new ImplicitGenericInterfaceMethodImplementation(0);
@@ -681,7 +622,7 @@ namespace Tests {
 
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeImplicitGenericInterfaceMethod1()
     {
       try
@@ -694,10 +635,10 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PostconditionException e)
       {
-        Assert.AreEqual(": Contract.ForAll(Contract.Result<IEnumerable<T>>(), x => x != null)", e.Message);
+        Assert.Equal(": Contract.ForAll(Contract.Result<IEnumerable<T>>(), x => x != null)", e.Message);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeImplicitGenericInterfaceMethod2()
     {
       try
@@ -710,183 +651,177 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PostconditionException e)
       {
-        Assert.AreEqual(": Contract.Result<IEnumerable<T>>() != null", e.Message);
+        Assert.Equal(": Contract.Result<IEnumerable<T>>() != null", e.Message);
       }
     }
 
 
     #region Interface with method call in contract
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveIFaceWithMethodCalInContract()
     {
       IFaceWithMethodCallInContract o = new ImplForIFaceWithMethodCallInContract();
       o.M(1);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeIFaceWithMethodCalInContract1()
     {
       IFaceWithMethodCallInContract o = new ImplForIFaceWithMethodCallInContract();
-      o.M(3);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => o.M(3));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeIFaceWithMethodCalInContract2()
     {
       IFaceWithMethodCallInContract o = new ImplForIFaceWithMethodCallInContract();
-      o.M(5);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => o.M(5));
     }
     #endregion Interface with method call in contract
 
     #region ContractClass for abstract methods
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveAbstractMethodWithContract()
     {
       AbstractClass a = new ImplForAbstractMethod();
       a.ReturnFirst(new int[] { 3, 4, 5 }, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveAbstractMethodWithContract2()
     {
       AbstractClass a = new ImplForAbstractMethod();
       a.Increment(3, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAbstractMethodWithContract1()
     {
       AbstractClass a = new ImplForAbstractMethod();
-      a.ReturnFirst(null, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => a.ReturnFirst(null, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAbstractMethodWithContract2()
     {
       AbstractClass a = new ImplForAbstractMethod();
-      a.ReturnFirst(new int[] { }, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => a.ReturnFirst(new int[] { }, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAbstractMethodWithContract3()
     {
       AbstractClass a = new ImplForAbstractMethod();
-      a.ReturnFirst(new int[] { 3, 4, 5 }, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => a.ReturnFirst(new int[] { 3, 4, 5 }, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAbstractMethodWithContract4()
     {
       AbstractClass a = new ImplForAbstractMethod();
-      a.Increment(-3, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => a.Increment(-3, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeAbstractMethodWithContract5()
     {
       AbstractClass a = new ImplForAbstractMethod();
-      a.Increment(3, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => a.Increment(3, false));
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveGenericAbstractClassWithContract()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
       a.ReturnFirst(new[] { "a", "B", "c" }, "B", true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveGenericAbstractClassWithContract2()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
       var result = a.Collection(2, 3);
-      Assert.AreEqual(2, result.Length);
+      Assert.Equal(2, result.Length);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveGenericAbstractClassWithContract3()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
       var result = a.FirstNonNullMatch(new[] { null, null, "a", "b" });
-      Assert.AreEqual("a", result);
+      Assert.Equal("a", result);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveGenericAbstractClassWithContract5()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
       var result = a.GenericMethod<float>(new[] { null, null, "a", "b" });
-      Assert.AreEqual(0, result.Length);
+      Assert.Equal(0, result.Length);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveGenericAbstractClassWithContract6()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
       var result = a.GenericMethod<string>(new[] { "a", "b" });
-      Assert.AreEqual(2, result.Length);
+      Assert.Equal(2, result.Length);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveGenericAbstractClassWithContract7()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
       var result = a.GenericMethod<object>(new[] { "a", "b" });
-      Assert.AreEqual(2, result.Length);
+      Assert.Equal(2, result.Length);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeGenericAbstractClassWithContract1()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
-      a.ReturnFirst(null, null, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => a.ReturnFirst(null, null, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeGenericAbstractClassWithContract2()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
-      a.ReturnFirst(new string[] { }, null, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => a.ReturnFirst(new string[] { }, null, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeGenericAbstractClassWithContract3()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
-      a.ReturnFirst(new[] { "3", "4", "5" }, "", false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => a.ReturnFirst(new[] { "3", "4", "5" }, "", false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeGenericAbstractClassWithContract4()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
-      a.Collection(5, 5);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => a.Collection(5, 5));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeGenericAbstractClassWithContract5()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
-      a.FirstNonNullMatch(new string[] { null, null, null });
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => a.FirstNonNullMatch(new string[] { null, null, null }));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeGenericAbstractClassWithContract6()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
-      var result = a.GenericMethod<string>(null);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(
+        () =>
+        {
+          var result = a.GenericMethod<string>(null);
+        });
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeGenericAbstractClassWithContract7()
     {
       GenericAbstractClass<string, string> a = new ImplForGenericAbstractClass();
-      var result = a.GenericMethod<int>(new string[0]);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(
+        () =>
+        {
+          var result = a.GenericMethod<int>(new string[0]);
+        });
     }
     #endregion ContractClass for abstract methods
 
     #region Stelem specialization
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveStelemSpecialization1()
     {
       var st = new DerivedOfClosureWithStelem<string>();
       st.M(new string[] { "a", "b", "c" }, 1);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeStelemSpecialization1()
     {
       var st = new DerivedOfClosureWithStelem<string>();
@@ -897,7 +832,7 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PreconditionException e)
       {
-        Assert.AreEqual(e.Message, ": i + 1 < ts.Length");
+        Assert.Equal(e.Message, ": i + 1 < ts.Length");
       }
     }
     #endregion
@@ -906,40 +841,21 @@ namespace Tests {
 
   #endregion
 
-  [TestClass]
   public class PublicProperty : DisableAssertUI {
-    #region Test Management
-
-    [ClassCleanup]
-    public static void ClassCleanup()
-    {
-    }
-
-    [TestInitialize]
-    public void TestInitialize()
-    {
-    }
-
-    [TestCleanup]
-    public void TestCleanup()
-    {
-    }
-    #endregion Test Management
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositivePublicProperty()
     {
       D d = new D();
       d.foo(-3);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativePublicProperty()
     {
       D d = new D();
-      d.foo(3);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => d.foo(3));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositivePublicPropertyUsingVirtualProperty()
     {
       SubtypeOfUsingVirtualProperty d = new SubtypeOfUsingVirtualProperty();
@@ -948,14 +864,14 @@ namespace Tests {
       d.foo(3);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveTestProperRetargettingOfImplicitInterfaceMethod()
     {
       var o = new Strilanc.C(true);
       o.S();
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeTestProperRetargettingOfImplicitInterfaceMethod()
     {
       var o = new Strilanc.C(false);
@@ -966,23 +882,22 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PreconditionException p)
       {
-        Assert.AreEqual("this.P", p.Condition);
+        Assert.Equal("this.P", p.Condition);
       }
     }
     #endregion Tests
   }
 
-  [TestClass]
   public class ThomasPani : DisableAssertUI
   {
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void PositiveInheritedInv()
     {
       var u = new CodeUnderTest.ThomasPani.U();
       u.SetToValidValue(true);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void NegativeInheritedInv()
     {
       var u = new CodeUnderTest.ThomasPani.U();
@@ -992,7 +907,7 @@ namespace Tests {
         throw new Exception();
       } catch (TestRewriterMethods.InvariantException e)
       {
-        Assert.AreEqual("i > 0", e.Condition);
+        Assert.Equal("i > 0", e.Condition);
       }
     }
     

--- a/Foxtrot/Tests/UnitTests/Structs.cs
+++ b/Foxtrot/Tests/UnitTests/Structs.cs
@@ -18,45 +18,22 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Win32;
 using System.Diagnostics.Contracts;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CodeUnderTest;
+using Xunit;
 
 namespace Tests {
-  [TestClass]
   public class StructTests : DisableAssertUI {
-    #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context)
-    {
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup()
-    {
-    }
-
-    [TestInitialize]
-    public void TestInitialize()
-    {
-    }
-
-    [TestCleanup]
-    public void TestCleanup()
-    {
-    }
-    #endregion Test Management
-
     #region Tests
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void StructInheritingFromInterfacePositive1()
     {
       EmptyIndexable<int> empty = new EmptyIndexable<int>();
       int x = empty.Count;
-      Assert.AreEqual(0, x);
+      Assert.Equal(0, x);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void StructInheritingFromInterfaceNegative1()
     {
       EmptyIndexable<int> empty = new EmptyIndexable<int>();
@@ -67,19 +44,19 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PreconditionException p)
       {
-        Assert.AreEqual("index < this.Count", p.Condition);
+        Assert.Equal("index < this.Count", p.Condition);
       }
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void StructInheritingFromInterfacePositive2()
     {
       var empty = new EmptyIntIndexable();
       int x = empty.Count;
-      Assert.AreEqual(0, x);
+      Assert.Equal(0, x);
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void StructInheritingFromInterfaceNegative2()
     {
       var empty = new EmptyIntIndexable();
@@ -90,7 +67,7 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PreconditionException p)
       {
-        Assert.AreEqual("index < this.Count", p.Condition);
+        Assert.Equal("index < this.Count", p.Condition);
       }
     }
 

--- a/Foxtrot/Tests/UnitTests/SubtypeWithoutContracts.cs
+++ b/Foxtrot/Tests/UnitTests/SubtypeWithoutContracts.cs
@@ -12,8 +12,6 @@
 // 
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 using System;
 using System.Text;
 using System.Collections.Generic;
@@ -24,58 +22,33 @@ using Microsoft.Contracts.Foxtrot;
 using System.Reflection;
 using Microsoft.CSharp;
 using SubtypeWithoutContracts;
+using Xunit;
 
 namespace Tests {
-  [TestClass()]
   public class TestSubtypeWithoutContracts : DisableAssertUI {
-    #region Test Management
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context)
-    {
-    }
-
-    [ClassCleanup]
-    public static void ClassCleanup()
-    {
-    }
-
-    [TestInitialize]
-    public void TestInitialize()
-    {
-    }
-
-    [TestCleanup]
-    public void TestCleanup()
-    {
-    }
-    #endregion Test Management
-
     #region Tests
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     //[DeploymentItem("Foxtrot\\Tests\\AssemblyWithContracts\\bin\\Debug\\v3.5\\AssemblyWithContracts.Contracts.dll")]
     public void SubTypeWithoutContractsPositive()
     {
       new SubtypeWithoutContracts.Subtype1().M(3, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsNegative1()
     {
-      new SubtypeWithoutContracts.Subtype1().M(-3, true);
+      Assert.Throws<TestRewriterMethods.PreconditionException>(() => new SubtypeWithoutContracts.Subtype1().M(-3, true));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsNegative2()
     {
-      new SubtypeWithoutContracts.Subtype1().M(3, false);
+      Assert.Throws<TestRewriterMethods.PostconditionException>(() => new SubtypeWithoutContracts.Subtype1().M(3, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-    [ExpectedException(typeof(TestRewriterMethods.PostconditionOnThrowException))]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsNegative3()
     {
-      new SubtypeWithoutContracts.Subtype1().M(1, false);
+      Assert.Throws<TestRewriterMethods.PostconditionOnThrowException>(() => new SubtypeWithoutContracts.Subtype1().M(1, false));
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsTestConditionNegative1()
     {
       try
@@ -84,11 +57,11 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PreconditionException p)
       {
-        Assert.AreEqual("0 < x", p.Condition);
-        Assert.AreEqual(null, p.User);
+        Assert.Equal("0 < x", p.Condition);
+        Assert.Equal(null, p.User);
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsTestConditionNegative2()
     {
       try
@@ -97,12 +70,12 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PostconditionException p)
       {
-        Assert.AreEqual("Contract.Result<int>() == -x", p.Condition);
-        Assert.AreEqual(null, p.User);
+        Assert.Equal("Contract.Result<int>() == -x", p.Condition);
+        Assert.Equal(null, p.User);
       }
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsTestConditionNegative3()
     {
       try
@@ -111,19 +84,19 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PostconditionOnThrowException p)
       {
-        Assert.AreEqual("x == 0", p.Condition);
-        Assert.AreEqual(null, p.User);
+        Assert.Equal("x == 0", p.Condition);
+        Assert.Equal(null, p.User);
       }
     }
 
 
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsUserStringsPositive()
     {
       new SubtypeWithoutContracts.Subtype1().WithUserStrings(3, true);
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsUserStringsNegative1()
     {
       try
@@ -132,11 +105,11 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PreconditionException p)
       {
-        Assert.AreEqual("0 < x", p.Condition);
-        Assert.AreEqual(null, p.User); // user string must be masked here as it is not accessible
+        Assert.Equal("0 < x", p.Condition);
+        Assert.Equal(null, p.User); // user string must be masked here as it is not accessible
       }
     }
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsUserStringsNegative2()
     {
       try
@@ -145,12 +118,12 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PostconditionException p)
       {
-        Assert.AreEqual("Contract.Result<int>() == -x", p.Condition);
-        Assert.AreEqual("result is negated x", p.User);
+        Assert.Equal("Contract.Result<int>() == -x", p.Condition);
+        Assert.Equal("result is negated x", p.User);
       }
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsUserStringsNegative3()
     {
       try
@@ -159,12 +132,12 @@ namespace Tests {
       }
       catch (TestRewriterMethods.PostconditionOnThrowException p)
       {
-        Assert.AreEqual("x == 0", p.Condition);
-        Assert.AreEqual("Throws only if x == 0", p.User);
+        Assert.Equal("x == 0", p.Condition);
+        Assert.Equal("Throws only if x == 0", p.User);
       }
     }
 
-    [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+    [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
     public void SubTypeWithoutContractsUserStringsNegative4()
     {
       try
@@ -173,7 +146,7 @@ namespace Tests {
       }
       catch (ArgumentException arg)
       {
-        Assert.AreEqual("Precondition failed: 1 < x: x must be greater than 1", arg.Message);
+        Assert.Equal("Precondition failed: 1 < x: x must be greater than 1", arg.Message);
       }
     }
 

--- a/Foxtrot/Tests/UnitTests/UnitTests.csproj
+++ b/Foxtrot/Tests/UnitTests/UnitTests.csproj
@@ -1,34 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.1.0-beta4-build1109\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.1.0-beta4-build1109\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\..\packages\xunit.core.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\..\packages\xunit.core.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>
-    </ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{29FD2FE2-CC61-4399-812D-B40A5D5795DF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTests</RootNamespace>
     <AssemblyName>UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -95,12 +80,21 @@
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3109, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.assert.2.1.0-beta4-build3109\lib\portable-net45+netcore45+wp8+wpa81\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3109, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.core.2.1.0-beta4-build3109\lib\portable-net45+netcore45+wp8+wpa81\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GenericsTest.cs" />
@@ -154,31 +148,16 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <WCFMetadata Include="Service References\" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.0">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4 %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\xunit.core.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.core.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\xunit.runner.visualstudio.2.1.0-beta4-build1109\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.runner.visualstudio.2.1.0-beta4-build1109\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Foxtrot/Tests/UnitTests/UserFeedback.cs
+++ b/Foxtrot/Tests/UnitTests/UserFeedback.cs
@@ -15,33 +15,32 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using CodeUnderTest;
 using CodeUnderTest.PDC;
+using Xunit;
 
 namespace UserFeedback {
   namespace Peli {
     /// <summary>
     /// Summary description for UnitTest1
     /// </summary>
-    [TestClass]
     public class UnitTest1 : Tests.DisableAssertUI {
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestProperlyRewrittenResult()
       {
         new CodeUnderTest.Peli.UnitTest1.Foo().GetValue(0);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestInvariantStrings1()
       {
         new CodeUnderTest.Peli.UnitTest1.Foo(2);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestInvariantStrings2()
       {
         try
@@ -51,12 +50,12 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.InvariantException i)
         {
-          Assert.AreEqual("x > 0", i.Condition);
-          Assert.AreEqual(null, i.User);
+          Assert.Equal("x > 0", i.Condition);
+          Assert.Equal(null, i.User);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestInvariantStrings3()
       {
         try
@@ -66,22 +65,21 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.InvariantException i)
         {
-          Assert.AreEqual("x < 10", i.Condition);
-          Assert.AreEqual("upper bound", i.User);
+          Assert.Equal("x < 10", i.Condition);
+          Assert.Equal("upper bound", i.User);
         }
       }
 
 
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-      [ExpectedException(typeof(ArgumentException))]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOnThrowPositive()
       {
         CodeUnderTest.Peli.UnitTest1.Bar b = new CodeUnderTest.Peli.UnitTest1.Bar(0);
-        new CodeUnderTest.Peli.UnitTest1.Foo().TestException(b, 0);
+        Assert.Throws<ArgumentException>(() => new CodeUnderTest.Peli.UnitTest1.Foo().TestException(b, 0));
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOnThrowNegative1()
       {
         CodeUnderTest.Peli.UnitTest1.Bar b = new CodeUnderTest.Peli.UnitTest1.Bar(0);
@@ -92,12 +90,12 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.PostconditionOnThrowException p)
         {
-          Assert.AreEqual("b.ID == 0", p.Condition);
-          Assert.AreEqual("Peli3", p.User);
+          Assert.Equal("b.ID == 0", p.Condition);
+          Assert.Equal("Peli3", p.User);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOnThrowNegative2()
       {
         CodeUnderTest.Peli.UnitTest1.Bar b = new CodeUnderTest.Peli.UnitTest1.Bar(0);
@@ -108,14 +106,14 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.PostconditionOnThrowException p)
         {
-          Assert.AreEqual("b.ID >= 0", p.Condition);
-          Assert.AreEqual(null, p.User);
+          Assert.Equal("b.ID >= 0", p.Condition);
+          Assert.Equal(null, p.User);
         }
       }
 
 
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestRequiresConditionStringAndUserString()
       {
         try
@@ -131,7 +129,7 @@ namespace UserFeedback {
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestRequiresConditionStringOnly()
       {
         try
@@ -147,7 +145,7 @@ namespace UserFeedback {
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestEnsuresConditionStringAndUserString()
       {
         try
@@ -156,8 +154,8 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.PostconditionException e)
         {
-          Assert.AreEqual("Contract.Result<Bar>() == null || Contract.Result<Bar>().ID == 0", e.Condition);
-          Assert.AreEqual("peli2", e.User);
+          Assert.Equal("Contract.Result<Bar>() == null || Contract.Result<Bar>().ID == 0", e.Condition);
+          Assert.Equal("peli2", e.User);
           return;
         }
       }
@@ -167,116 +165,109 @@ namespace UserFeedback {
   namespace WinSharp {
     using System.Linq;
 
-    [TestClass]
       public class RecursionChecks : Tests.DisableAssertUI
       {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest1()
       {
         var mydict = new CodeUnderTest.WinSharp.MyDict<string, int>();
 
         var result = mydict.ContainsKey("foo");
 
-        Assert.IsFalse(result);
+        Assert.False(result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest2()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.Odd(5);
 
-        Assert.IsTrue(result);
+        Assert.True(result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest3()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.Odd(6);
 
-        Assert.IsFalse(result);
+        Assert.False(result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest4()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.Even(7);
 
-        Assert.IsFalse(result);
+        Assert.False(result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest5()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.Even(8);
 
-        Assert.IsTrue(result);
+        Assert.True(result);
       }
 
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest6()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.SubEven(8);
 
-        Assert.AreEqual(0, result);
+        Assert.Equal(0, result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest7()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.SubEven(5);
 
-        Assert.AreEqual(0, result);
+        Assert.Equal(0, result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest8()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.SubOdd(8);
 
-        Assert.AreEqual(0, result);
+        Assert.Equal(0, result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest9()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.SubOdd(5);
 
-        Assert.AreEqual(0, result);
+        Assert.Equal(0, result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest10()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.ThrowOnEven(5);
 
-        Assert.IsFalse(result);
+        Assert.False(result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-      [ExpectedException(typeof(ArgumentException))]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest11()
       {
-        var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.ThrowOnEven(4);
-
-        Assert.IsFalse(true);
+        Assert.Throws<ArgumentException>(() => CodeUnderTest.WinSharp.ExplicitlyRecursive.ThrowOnEven(4));
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest12()
       {
         var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.ThrowOnOdd(4);
 
-        Assert.IsFalse(result);
+        Assert.False(result);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-      [ExpectedException(typeof(ArgumentException))]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void RecursionTest13()
       {
-        var result = CodeUnderTest.WinSharp.ExplicitlyRecursive.ThrowOnOdd(3);
-
-        Assert.IsFalse(true);
+        Assert.Throws<ArgumentException>(() => CodeUnderTest.WinSharp.ExplicitlyRecursive.ThrowOnOdd(3));
       }
 
     }
@@ -284,10 +275,9 @@ namespace UserFeedback {
   }
 
   namespace Multani {
-    [TestClass]
       public class MultaniTestClass1 : Tests.DisableAssertUI
       {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveMultani1()
       {
         double[] initialValues = new[] { 1.0, 2.0, 3.0 };
@@ -297,8 +287,7 @@ namespace UserFeedback {
         int randomSeed = 44;
         var c = new CodeUnderTest.Multani.CorrelatedGeometricBrownianMotionFuelPriceSimulator(initialValues, stDevs, drifts, correlations, randomSeed);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-      [ExpectedException(typeof(TestRewriterMethods.PreconditionException))]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeMultani1()
       {
         double[] initialValues = null;
@@ -306,16 +295,15 @@ namespace UserFeedback {
         double[] drifts = null;
         double[,] correlations = null;
         int randomSeed = 44;
-        var c = new CodeUnderTest.Multani.CorrelatedGeometricBrownianMotionFuelPriceSimulator(initialValues, stDevs, drifts, correlations, randomSeed);
+        Assert.Throws<TestRewriterMethods.PreconditionException>(() => new CodeUnderTest.Multani.CorrelatedGeometricBrownianMotionFuelPriceSimulator(initialValues, stDevs, drifts, correlations, randomSeed));
       }
     }
   }
 
   namespace Somebody {
-    [TestClass]
     public class TestResourceStringUserMessage : Tests.DisableAssertUI {
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveTestUserMessages()
       {
         var o = new CodeUnderTest.Somebody.TestResourceStringUserMessage();
@@ -324,7 +312,7 @@ namespace UserFeedback {
         o.RequiresWithPublicGetterMessage("hello");
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTestInternalUserMessageString()
       {
         try
@@ -336,11 +324,11 @@ namespace UserFeedback {
         catch (TestRewriterMethods.PreconditionException p)
         {
           // resource not as visible as the contract method
-          Assert.AreEqual("Can't call me with null", p.User);
+          Assert.Equal("Can't call me with null", p.User);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTestPublicFieldUserMessageString()
       {
         try
@@ -352,11 +340,11 @@ namespace UserFeedback {
         catch (TestRewriterMethods.PreconditionException p)
         {
           // resource not as visible as the contract method
-          Assert.AreEqual(CodeUnderTest.Somebody.TestResourceStringUserMessage.Message2, p.User);
+          Assert.Equal(CodeUnderTest.Somebody.TestResourceStringUserMessage.Message2, p.User);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTestPublicGetterUserMessageString()
       {
         try
@@ -368,11 +356,11 @@ namespace UserFeedback {
         catch (TestRewriterMethods.PreconditionException p)
         {
           // resource not as visible as the contract method
-          Assert.AreEqual(CodeUnderTest.Somebody.TestResourceStringUserMessage.Message3, p.User);
+          Assert.Equal(CodeUnderTest.Somebody.TestResourceStringUserMessage.Message3, p.User);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeLegacyThrowWithPrivateExceptionArgument()
       {
         try
@@ -383,11 +371,11 @@ namespace UserFeedback {
         } catch (ArgumentException e)
         {
           // resource not as visible as the contract method
-          Assert.AreEqual("Illegal value 2", e.Message);
+          Assert.Equal("Illegal value 2", e.Message);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveLegacyThrowWithPrivateExceptionArgument()
       {
         var o = new CodeUnderTest.Somebody.TestResourceStringUserMessage();
@@ -398,16 +386,15 @@ namespace UserFeedback {
 
   namespace PDC {
 
-    [TestClass]
       public class DontCheckInvariantsDuringConstructors : Tests.DisableAssertUI
       {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveTrickyAutoProp1()
       {
         var tricky = new TrickyAutoPropInvariants<Valid>(new Valid(true), 0, false);
         tricky.Change(true, 5);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveTrickyAutoProp2()
       {
         var tricky = new TrickyAutoPropInvariants<Valid>(new Valid(true), 0, false);
@@ -419,7 +406,7 @@ namespace UserFeedback {
         // now we can violate invariant further without being punished
         tricky.Change(false, 5);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveTrickyAutoProp3()
       {
         var tricky = new TrickyAutoPropInvariants<Valid>(new Valid(true), 0, false);
@@ -431,7 +418,7 @@ namespace UserFeedback {
         // now we can violate invariant further without being punished
         tricky.Age = 5;
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTrickyAutoProp1()
       {
         try
@@ -442,10 +429,10 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.InvariantException i)
         {
-          Assert.AreEqual("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
+          Assert.Equal("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
         }
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTrickyAutoProp2()
       {
         try
@@ -456,10 +443,10 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.PreconditionException i)
         {
-          Assert.AreEqual("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
+          Assert.Equal("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
         }
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTrickyAutoProp3()
       {
         try
@@ -471,20 +458,20 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.PreconditionException i)
         {
-          Assert.AreEqual("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
+          Assert.Equal("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
         }
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTrickyAutoProp3b() {
         try {
           var tricky = new TrickyAutoPropInvariants<Valid>(new Valid(true), 0, false);
           tricky.LeaveObjectConsistentWrong(); // will throw invariant
           throw new Exception();
         } catch (TestRewriterMethods.InvariantException i) {
-          Assert.AreEqual("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
+          Assert.Equal("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
         }
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTrickyAutoProp4()
       {
         try
@@ -500,11 +487,11 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.PreconditionException i)
         {
-          Assert.AreEqual("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
+          Assert.Equal("Flag ? Age > 0 : Age == 0 && Value.IsValid", i.Condition);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveInvariantOffDuringConstruction1()
       {
         var p = new Invariants("Joe", 42);
@@ -512,7 +499,7 @@ namespace UserFeedback {
       }
 
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeInvariantOffDuringConstruction1()
       {
         try
@@ -522,11 +509,11 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.InvariantException i)
         {
-          Assert.AreEqual("name != null", i.Condition);
+          Assert.Equal("name != null", i.Condition);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveInvariantOffDuringConstruction2()
       {
         var p = new Invariants<string>("Joe", 42, 2, 1);
@@ -534,7 +521,7 @@ namespace UserFeedback {
       }
 
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeInvariantOffDuringConstruction2()
       {
         try
@@ -544,11 +531,11 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.InvariantException i)
         {
-          Assert.AreEqual("age > 0", i.Condition);
+          Assert.Equal("age > 0", i.Condition);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeInvariantOfAutoPropIntoRequires1()
       {
         try
@@ -558,11 +545,11 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.InvariantException p)
         {
-          Assert.AreEqual("Name != null", p.Condition);
+          Assert.Equal("Name != null", p.Condition);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeInvariantOfAutoPropIntoRequires2()
       {
         try
@@ -572,11 +559,11 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.InvariantException p)
         {
-          Assert.AreEqual("age > 0", p.Condition);
+          Assert.Equal("age > 0", p.Condition);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeInvariantOfAutoPropIntoRequires3()
       {
         try
@@ -586,11 +573,11 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.InvariantException p)
         {
-          Assert.AreEqual("X > Y", p.Condition);
+          Assert.Equal("X > Y", p.Condition);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeInvariantOfAutoPropIntoRequires4()
       {
         try
@@ -601,11 +588,11 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.PreconditionException p)
         {
-          Assert.AreEqual("Name != null", p.Condition);
+          Assert.Equal("Name != null", p.Condition);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeInvariantOfAutoPropIntoRequires5()
       {
         try
@@ -616,11 +603,11 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.PreconditionException p)
         {
-          Assert.AreEqual("X > Y", p.Condition);
+          Assert.Equal("X > Y", p.Condition);
         }
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeInvariantOfAutoPropIntoRequires6()
       {
         try
@@ -631,7 +618,7 @@ namespace UserFeedback {
         }
         catch (TestRewriterMethods.PreconditionException p)
         {
-          Assert.AreEqual("X > Y", p.Condition);
+          Assert.Equal("X > Y", p.Condition);
         }
       }
 
@@ -639,32 +626,29 @@ namespace UserFeedback {
   }
 
   namespace Arnott {
-    [TestClass]
       public class C : Tests.DisableAssertUI
       {
  
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveRequiresWithException()
       {
         new CodeUnderTest.Arnott.C().M(this);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-      [ExpectedException(typeof(ArgumentNullException))]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeRequiresWithException()
       {
-        new CodeUnderTest.Arnott.C().M(null);
+        Assert.Throws<ArgumentNullException>(() => new CodeUnderTest.Arnott.C().M(null));
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void WorksCorrectlyWithThisOrder()
       {
         new CodeUnderTest.Arnott.C().OkayOrder(new int[20]);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-      [ExpectedException(typeof(ArgumentOutOfRangeException))]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void WorksInCorrectlyWithThisOrder()
       {
-        new CodeUnderTest.Arnott.C().BadOrder(new int[10]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CodeUnderTest.Arnott.C().BadOrder(new int[10]));
       }
 
     }
@@ -672,48 +656,44 @@ namespace UserFeedback {
   }
 
   namespace DavidAllen {
-    [TestClass]
       public class AutoPropProblem : Tests.DisableAssertUI
       {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveNoAutoPropTreatmentForImplsAndOverrides0(){
         new CodeUnderTest.DavidAllen.AutoPropProblem.Impl1().P = 1;
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveNoAutoPropTreatmentForImplsAndOverrides1() {
         CodeUnderTest.DavidAllen.AutoPropProblem.J j = new CodeUnderTest.DavidAllen.AutoPropProblem.Impl2();
         j.P = 1;
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveNoAutoPropTreatmentForImplsAndOverrides2() {
         new CodeUnderTest.DavidAllen.AutoPropProblem.Sub().P = 1;
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-      [ExpectedException(typeof(TestRewriterMethods.InvariantException))]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeNoAutoPropTreatmentForImplsAndOverrides0() {
         // gets invariant exception but *not* precondition exception which
         // would indicate that the autoprop
-        new CodeUnderTest.DavidAllen.AutoPropProblem.Impl1().P = -1;
+        Assert.Throws<TestRewriterMethods.InvariantException>(() => new CodeUnderTest.DavidAllen.AutoPropProblem.Impl1().P = -1);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveNoAutoPropTreatmentForImplsAndOverrides3() {
         CodeUnderTest.DavidAllen.AutoPropProblem.J j = new CodeUnderTest.DavidAllen.AutoPropProblem.Impl2();
         j.P = 0; // no violation of invariant because explicit interface implementations don't get invariants checked
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
-      [ExpectedException(typeof(TestRewriterMethods.InvariantException))]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeNoAutoPropTreatmentForImplsAndOverrides1() {
-        new CodeUnderTest.DavidAllen.AutoPropProblem.Sub().P = -1;
+        Assert.Throws<TestRewriterMethods.InvariantException>(() => new CodeUnderTest.DavidAllen.AutoPropProblem.Sub().P = -1);
       }
     }
   }
 
   namespace MaF
   {
-    [TestClass]
       public class TestContractCheckingOffOn : Tests.DisableAssertUI
     {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTest0WhereCheckingIsOn()
       {
         Helpers.CheckEnsures(() =>
@@ -721,13 +701,13 @@ namespace UserFeedback {
           "Contract.Result<int>() > 0");
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveTest1WhereCheckingIsOff()
       {
         new CodeUnderTest.MaF.TestContractCheckingOffOn().Test1(null);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTest2WhereCheckingIsOn()
       {
         Helpers.CheckRequires(() =>
@@ -735,17 +715,16 @@ namespace UserFeedback {
           "s != null");
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveTest3WhereCheckingIsBackOff()
       {
         new CodeUnderTest.MaF.TestContractCheckingOffOn.Nested().Test3(null);
       }
     }
 
-    [TestClass]
     public class TestContractInheritanceOffOn : Tests.DisableAssertUI 
     {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTest0WhereInheritanceIsBackOn()
       {
         Helpers.CheckEnsures(() =>
@@ -753,19 +732,19 @@ namespace UserFeedback {
           "Contract.Result<int>() > 0");
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveTest1WhereInheritanceIsOff()
       {
         new CodeUnderTest.MaF.TestContractInheritanceOffOn().Test1(null);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void PositiveTest2WhereInheritanceIsOff()
       {
         new CodeUnderTest.MaF.TestContractInheritanceOffOn.Nested().Test2(null);
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void NegativeTest3WhereInheritanceIsBackOn()
       {
         Helpers.CheckRequires( () =>
@@ -774,51 +753,50 @@ namespace UserFeedback {
       }
     }
 
-    [TestClass]
     public class TestOldArray : Tests.DisableAssertUI
     {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOldParameterArrayPositive()
       {
         new CodeUnderTest.MaF.TestOldArrays().OldParameterArray(new[] { 1, 2, 3, 4, 5, 6 }, true);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOldParameterArrayNegative()
       {
         Helpers.CheckEnsures(() =>
           new CodeUnderTest.MaF.TestOldArrays().OldParameterArray(new[] { 1, 2, 3, 4, 5, 6 }, false),
           "Contract.ForAll(0, z.Length, i => z[i] == Contract.OldValue(z[i]))");
       }
-      //[TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      //[Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOldThisFieldArrayPositive()
       {
         new CodeUnderTest.MaF.TestOldArrays().OldThisFieldArray(true);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOldThisFieldArrayNegative()
       {
         Helpers.CheckEnsures(() =>
           new CodeUnderTest.MaF.TestOldArrays().OldThisFieldArray(false),
           "Contract.ForAll(0, this.field.Length, i => this.field[i] == Contract.OldValue(this.field[i]))");
       }
-      //[TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      //[Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOldThisFieldClosurePositive()
       {
         new CodeUnderTest.MaF.TestOldArrays().OldThisFieldClosure(true);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOldThisFieldClosureNegative()
       {
         Helpers.CheckEnsures(() =>
           new CodeUnderTest.MaF.TestOldArrays().OldThisFieldClosure(false),
           "Contract.ForAll(this.field, elem => elem == Contract.OldValue(elem))");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOldParameterFieldArrayPositive()
       {
         new CodeUnderTest.MaF.TestOldArrays().OldParameterFieldArray(new CodeUnderTest.MaF.TestOldArrays(), true);
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestOldParameterFieldArrayNegative()
       {
         Helpers.CheckEnsures(() =>
@@ -826,41 +804,41 @@ namespace UserFeedback {
           "Contract.ForAll(0, other.field.Length, i => other.field[i] == Contract.OldValue(other.field[i]))");
       }
     }
-    [TestClass]
+
     public class ClosuresInValidators : Tests.DisableAssertUI
     {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionValidatorPositive()
       {
         new CodeUnderTest.MaF.TestClosureValidators().TestCollectionValidator(new[] { "ab", "c", "d", "efg" }, new[] { "ab", "c", "d", "efg" });
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionValidatorNegative1()
       {
         Helpers.CheckException<ArgumentException>(() =>
           new CodeUnderTest.MaF.TestClosureValidators().TestCollectionValidator(new[] { "ab", null, "d", "efg" }, new[] { "ab", "c", "d", "efg" }),
           "all elements of coll1 must be non-null");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionValidatorNegative2()
       {
         Helpers.CheckException<ArgumentException>(() =>
           new CodeUnderTest.MaF.TestClosureValidators().TestCollectionValidator(new[] { "ab", "c", "d", "efg" }, new[] { "ab", null, "d", "efg" }),
           "all elements of coll2 must be non-null");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayValidatorPositive()
       {
         new CodeUnderTest.MaF.TestClosureValidators().TestArrayValidator(new[] { "ab", "c", "d", "efg" }, new[] { "ab", "c", "d", "efg" });
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayValidatorNegative1()
       {
         Helpers.CheckException<ArgumentException>(() =>
           new CodeUnderTest.MaF.TestClosureValidators().TestArrayValidator(new[] { "ab", null, "d", "efg" }, new[] { "ab", "c", "d", "efg" }),
           "all elements of array1 must be non-null");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayValidatorNegative2()
       {
         Helpers.CheckException<ArgumentException>(() =>
@@ -868,57 +846,57 @@ namespace UserFeedback {
           "all elements of array2 must be non-null");
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionValidator2Positive() {
         new CodeUnderTest.MaF.TestClosureValidators().TestCollectionValidator2(new[] { "ab", "c", "d", "efg" }, new[] { "ab", "c", "d", "efg" });
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionValidator2Negative1() {
         Helpers.CheckException<ArgumentException>(() =>
           new CodeUnderTest.MaF.TestClosureValidators().TestCollectionValidator2(new[] { "ab", null, "d", "efg" }, new[] { "ab", "c", "d", "efg" }),
           "all elements of coll1 must be non-null");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionValidator2Negative2() {
         Helpers.CheckException<ArgumentException>(() =>
           new CodeUnderTest.MaF.TestClosureValidators().TestCollectionValidator2(new[] { "ab", "c", "d", "efg" }, new[] { "ab", null, "d", "efg" }),
           "all elements of coll2 must be non-null");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayValidator2Positive() {
         new CodeUnderTest.MaF.TestClosureValidators().TestArrayValidator2(new[] { "ab", "c", "d", "efg" }, new[] { "ab", "c", "d", "efg" });
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayValidator2Negative1() {
         Helpers.CheckException<ArgumentException>(() =>
           new CodeUnderTest.MaF.TestClosureValidators().TestArrayValidator2(new[] { "ab", null, "d", "efg" }, new[] { "ab", "c", "d", "efg" }),
           "all elements of array1 must be non-null");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayValidator2Negative2() {
         Helpers.CheckException<ArgumentException>(() =>
           new CodeUnderTest.MaF.TestClosureValidators().TestArrayValidator2(new[] { "ab", "c", "d", "efg" }, new[] { "ab", null, "d", "efg" }),
           "all elements of array2 must be non-null");
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestFieldArrayAbbreviatorPositive()
       {
         new CodeUnderTest.MaF.TestClosureValidators(new[] { "ab", "c", "d", "efg" }).TestFieldArrayUnchanged();
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestFieldArrayAbbreviatorNegative()
       {
         Helpers.CheckEnsures(() =>
           new CodeUnderTest.MaF.TestClosureValidators(new[] { "ab", null, "d", "efg" }).TestFieldArrayUnchanged(),
           "Contract.ForAll(0, this.field.Length, i => this.field[i] != null)");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestFieldAsCollectionAbbreviatorPositive()
       {
         new CodeUnderTest.MaF.TestClosureValidators(new[] { "ab", "c", "d", "efg" }).TestFieldAsCollectionUnchanged();
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestFieldAsCollectionAbbreviatorNegative()
       {
         Helpers.CheckEnsures(() =>
@@ -928,24 +906,24 @@ namespace UserFeedback {
 
 
 #if false
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestPassedFieldArrayValidatorPositive()
       {
         CodeUnderTest.MaF.CallerClass.TestFieldArrayUnchanged(new CodeUnderTest.MaF.TestClosureValidators(new[] { "ab", "c", "d", "efg" }));
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestPassedFieldArrayValidatorNegative()
       {
         Helpers.CheckException<ArgumentException>(() =>
           CodeUnderTest.MaF.CallerClass.TestFieldArrayUnchanged(new CodeUnderTest.MaF.TestClosureValidators(new[] { "ab", "c", null, "efg" })),
           "all elements of array must be non-null");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestPassedFieldAsCollectionValidatorPositive()
       {
         CodeUnderTest.MaF.CallerClass.TestFieldAsCollectionUnchanged(new CodeUnderTest.MaF.TestClosureValidators(new[] { "ab", "c", "d", "efg" }));
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestPassedFieldAsCollectionValidatorNegative()
       {
         Helpers.CheckException<ArgumentException>(() =>
@@ -955,90 +933,89 @@ namespace UserFeedback {
 #endif
     }
 
-    [TestClass]
     public class ClosuresInAbbreviators : Tests.DisableAssertUI
     {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionAbbreviatorPositive() {
         new CodeUnderTest.MaF.TestClosureAbbreviators().TestCollectionAbbreviator(new[] { "ab", "c", "d", "efg" }, new[] { "ab", "c", "d", "efg" });
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionAbbreviatorNegative1() {
         Helpers.CheckRequires(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators().TestCollectionAbbreviator(new[] { "ab", null, "d", "efg" }, new[] { "ab", "c", "d", "efg" }),
           "Contract.ForAll(collection, element => element != null)", "coll1");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionAbbreviatorNegative2() {
         Helpers.CheckRequires(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators().TestCollectionAbbreviator(new[] { "ab", "c", "d", "efg" }, new[] { "ab", null, "d", "efg" }),
           "Contract.ForAll(collection, element => element != null)", "coll2");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayAbbreviatorPositive() {
         new CodeUnderTest.MaF.TestClosureAbbreviators().TestArrayAbbreviator(new[] { "ab", "c", "d", "efg" }, new[] { "ab", "c", "d", "efg" });
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayAbbreviatorNegative1() {
         Helpers.CheckRequires(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators().TestArrayAbbreviator(new[] { "ab", null, "d", "efg" }, new[] { "ab", "c", "d", "efg" }),
           "Contract.ForAll(0, array.Length, i => array[i] != null)", "array1");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayAbbreviatorNegative2() {
         Helpers.CheckRequires(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators().TestArrayAbbreviator(new[] { "ab", "c", "d", "efg" }, new[] { "ab", null, "d", "efg" }),
           "Contract.ForAll(0, array.Length, i => array[i] != null)", "array2");
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionAbbreviator2Positive() {
         new CodeUnderTest.MaF.TestClosureAbbreviators().TestCollectionAbbreviator2(new[] { "ab", "c", "d", "efg" }, new[] { "ab", "c", "d", "efg" });
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionAbbreviator2Negative1() {
         Helpers.CheckRequires(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators().TestCollectionAbbreviator2(new[] { "ab", null, "d", "efg" }, new[] { "ab", "c", "d", "efg" }),
           "Contract.ForAll(collection, element => element != null)", "coll1");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestCollectionAbbreviator2Negative2() {
         Helpers.CheckRequires(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators().TestCollectionAbbreviator2(new[] { "ab", "c", "d", "efg" }, new[] { "ab", null, "d", "efg" }),
           "Contract.ForAll(collection, element => element != null)", "coll2");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayAbbreviator2Positive() {
         new CodeUnderTest.MaF.TestClosureAbbreviators().TestArrayAbbreviator2(new[] { "ab", "c", "d", "efg" }, new[] { "ab", "c", "d", "efg" });
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayAbbreviator2Negative1() {
         Helpers.CheckRequires(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators().TestArrayAbbreviator2(new[] { "ab", null, "d", "efg" }, new[] { "ab", "c", "d", "efg" }),
           "Contract.ForAll(0, array.Length, i => array[i] != null)", "array1");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestArrayAbbreviator2Negative2() {
         Helpers.CheckRequires(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators().TestArrayAbbreviator2(new[] { "ab", "c", "d", "efg" }, new[] { "ab", null, "d", "efg" }),
           "Contract.ForAll(0, array.Length, i => array[i] != null)", "array2");
       }
 
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestFieldArrayAbbreviatorPositive() {
         new CodeUnderTest.MaF.TestClosureAbbreviators(new[] { "ab", "c", "d", "efg" }).TestFieldArrayUnchanged();
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestFieldArrayAbbreviatorNegative() {
         Helpers.CheckEnsures(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators(new[] { "ab", null, "d", "efg" }).TestFieldArrayUnchanged(),
           "Contract.ForAll(0, this.field.Length, i => this.field[i] != null)");
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestFieldAsCollectionAbbreviatorPositive() {
         new CodeUnderTest.MaF.TestClosureAbbreviators(new[] { "ab", "c", "d", "efg" }).TestFieldAsCollectionUnchanged();
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestFieldAsCollectionAbbreviatorNegative() {
         Helpers.CheckEnsures(() =>
           new CodeUnderTest.MaF.TestClosureAbbreviators(new[] { "ab", null, "d", "efg" }).TestFieldAsCollectionUnchanged(),
@@ -1050,15 +1027,14 @@ namespace UserFeedback {
   }
   namespace Mokosh
   {
-    [TestClass]
     public class Tests : global::Tests.DisableAssertUI
     {
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestEnumeratorWithRequiresPositive()
       {
         CodeUnderTest.Mokosh.Enumerate.Test(new CodeUnderTest.Mokosh.Projects());
       }
-      [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+      [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
       public void TestEnumeratorWithRequiresNegative()
       {
         Helpers.CheckRequires(() =>
@@ -1070,10 +1046,9 @@ namespace UserFeedback {
 
     namespace BenLerner
     {
-      [TestClass]
       public class Closures : global::Tests.DisableAssertUI
       {
-        [TestMethod, TestCategory("Runtime"), TestCategory("V4.0"), TestCategory("CoreTest"), TestCategory("Short")]
+        [Fact, Trait("Category", "Runtime"), Trait("Category", "V4.0"), Trait("Category", "CoreTest"), Trait("Category", "Short")]
         public void TestPositiveDeepClosures()
         {
           CodeUnderTest.BenLerner.ManyForAlls.DoIt();
@@ -1092,7 +1067,7 @@ namespace UserFeedback {
       }
       catch (TestRewriterMethods.PreconditionException e)
       {
-        Assert.AreEqual(expectedCondition, e.Condition);
+        Assert.Equal(expectedCondition, e.Condition);
       }
     }
     public static void CheckRequires(Action action, string expectedCondition, string userString)
@@ -1104,8 +1079,8 @@ namespace UserFeedback {
       }
       catch (TestRewriterMethods.PreconditionException e)
       {
-        Assert.AreEqual(expectedCondition, e.Condition);
-        Assert.AreEqual(userString, e.User);
+        Assert.Equal(expectedCondition, e.Condition);
+        Assert.Equal(userString, e.User);
       }
     }
     public static void CheckEnsures(Action action, string expectedCondition)
@@ -1117,7 +1092,7 @@ namespace UserFeedback {
       }
       catch (TestRewriterMethods.PostconditionException e)
       {
-        Assert.AreEqual(expectedCondition, e.Condition);
+        Assert.Equal(expectedCondition, e.Condition);
       }
     }
     public static void CheckException<E>(Action action, string expectedMessage)
@@ -1130,7 +1105,7 @@ namespace UserFeedback {
       }
       catch (E e)
       {
-        Assert.AreEqual(expectedMessage, e.Message);
+        Assert.Equal(expectedMessage, e.Message);
       }
     }
   }

--- a/Foxtrot/Tests/UnitTests/packages.config
+++ b/Foxtrot/Tests/UnitTests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.1.0-beta4-build3109" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0-beta4-build3109" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0-beta4-build3109" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0-beta4-build3109" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0-beta4-build1109" targetFramework="net45" />
+</packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ build_script:
 test:
   assemblies:
   - '**\FoxtrotTests.dll'
+  - '**\UnitTests.dll'
 #  - '**\ClousotCacheTests\bin\Debug\ClousotCacheTests.dll'
 #  - '**\ClousotTests\bin\Debug\ClousotTests.dll'
-#  - '**\Foxtrot\Tests\UnitTests\bin\Debug\UnitTests.dll'
 artifacts:
 - path: '**\ManagedContract.Setup\devlab9ts\Microsoft.Contracts.*.nupkg'
 - path: '**\ManagedContract.Setup\devlab9ts\msi\Contracts.devlab9ts.msi'


### PR DESCRIPTION
Update the UnitTests project to use xUnit.net

Following this change, tests in the project can be run without special configuration (e.g. selection of the testsettings file).
