### PR TITLE
Contract for TypeConverter.ConvertFrom(object)

### DIFF
--- a/Microsoft.Research/Contracts/System/System.ComponentModel.TypeConverter.cs
+++ b/Microsoft.Research/Contracts/System/System.ComponentModel.TypeConverter.cs
@@ -83,7 +83,7 @@ namespace System.ComponentModel
     // Returns:
     //     true if this converter can perform the conversion; otherwise, false.
     //public virtual bool CanConvertTo(ITypeDescriptorContext context, Type destinationType);
-    //
+
     // Summary:
     //     Converts the given value to the type of this converter.
     //
@@ -97,8 +97,12 @@ namespace System.ComponentModel
     // Exceptions:
     //   System.NotSupportedException:
     //     The conversion cannot be performed.
-    //public object ConvertFrom(object value);
-    //
+    public object ConvertFrom(object value)
+		{
+			Contract.Ensures(Contract.Result<object>() != null);
+			return default(object);
+		}
+    
     // Summary:
     //     Converts the given object to the type of this converter, using the specified
     //     context and culture information.

--- a/Microsoft.Research/Contracts/System/System.ComponentModel.TypeConverter.cs
+++ b/Microsoft.Research/Contracts/System/System.ComponentModel.TypeConverter.cs
@@ -83,7 +83,7 @@ namespace System.ComponentModel
     // Returns:
     //     true if this converter can perform the conversion; otherwise, false.
     //public virtual bool CanConvertTo(ITypeDescriptorContext context, Type destinationType);
-
+		//
     // Summary:
     //     Converts the given value to the type of this converter.
     //

--- a/Microsoft.Research/Contracts/System/System.ComponentModel.TypeConverter.cs
+++ b/Microsoft.Research/Contracts/System/System.ComponentModel.TypeConverter.cs
@@ -83,7 +83,7 @@ namespace System.ComponentModel
     // Returns:
     //     true if this converter can perform the conversion; otherwise, false.
     //public virtual bool CanConvertTo(ITypeDescriptorContext context, Type destinationType);
-		//
+    //
     // Summary:
     //     Converts the given value to the type of this converter.
     //
@@ -98,10 +98,10 @@ namespace System.ComponentModel
     //   System.NotSupportedException:
     //     The conversion cannot be performed.
     public object ConvertFrom(object value)
-		{
-			Contract.Ensures(Contract.Result<object>() != null);
-			return default(object);
-		}
+    {
+      Contract.Ensures(Contract.Result<object>() != null);
+      return default(object);
+    }
     
     // Summary:
     //     Converts the given object to the type of this converter, using the specified


### PR DESCRIPTION
As far as I can tell this is a valid contract, it doesn't appear that ConvertFrom should ever return null - it either successfully returns the conversion or throws a NotSupportedException