### PR TITLE
Add special logic for pdbs without /names stream

### DIFF
--- a/Foxtrot/Driver/Program.cs
+++ b/Foxtrot/Driver/Program.cs
@@ -268,6 +268,17 @@ namespace Microsoft.Contracts.Foxtrot.Driver
 
                 // Check to see if any metadata errors were reported
 
+                if (assemblyNode.MetadataImportWarnings != null && assemblyNode.MetadataImportWarnings.Count > 0)
+                {
+                    string msg = "\tThere were warnings reported in " + assemblyNode.Name + "'s metadata.\n";
+                    foreach (Exception e in assemblyNode.MetadataImportWarnings)
+                    {
+                        msg += "\t" + e.Message;
+                    }
+
+                    Console.WriteLine(msg);
+                }
+
                 if (assemblyNode.MetadataImportErrors != null && assemblyNode.MetadataImportErrors.Count > 0)
                 {
                     string msg = "\tThere were errors reported in " + assemblyNode.Name + "'s metadata.\n";
@@ -1587,6 +1598,15 @@ namespace Microsoft.Contracts.Foxtrot.Driver
         private static bool CheckForMetaDataErrors(AssemblyNode aref)
         {
             Contract.Requires(aref != null);
+
+            if (aref.MetadataImportWarnings != null && aref.MetadataImportWarnings.Count > 0)
+            {
+                Console.WriteLine("Assembly '{0}' from '{1}' was skipped due to non-critical warnings.", aref.Name, aref.Location);
+                foreach (Exception e in aref.MetadataImportWarnings)
+                {
+                    Console.WriteLine("\t" + e.Message);
+                }
+            }
 
             bool result = false;
             if (aref.MetadataImportErrors != null && aref.MetadataImportErrors.Count > 0)

--- a/Foxtrot/Foxtrot/AssemblyResolver.cs
+++ b/Foxtrot/Foxtrot/AssemblyResolver.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Contracts.Foxtrot
                         string pdbFullName;
                         if (String.IsNullOrEmpty(ext))
                         {
-                            pdbFullName = Path.Combine(directory, Path.GetFileNameWithoutExtension(assemblyName) + ".pdb");
+                            pdbFullName = Path.ChangeExtension(fullName, ".pdb");
                         }
                         else
                         {

--- a/System.Compiler/Nodes.cs
+++ b/System.Compiler/Nodes.cs
@@ -5609,6 +5609,19 @@ namespace System.Compiler{
       get{return this.metadataImportErrors;}
       set{this.metadataImportErrors = value;}
     }
+      
+    private ArrayList metadataImportWarnings;
+    /// <summary>
+    /// Holds information about non-critical errors.
+    /// For instance, lack of /names stream in the PDB is not a critical error and should be handled
+    /// gracefully.
+    /// </summary>
+    public ArrayList MetadataImportWarnings {
+      get { return this.metadataImportWarnings; }
+      set { this.metadataImportWarnings = value; }
+    }
+
+
 #endif
     protected AttributeList attributes;
     /// <summary>

--- a/System.Compiler/PDBreader/PdbDebugException.cs
+++ b/System.Compiler/PDBreader/PdbDebugException.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Cci.Pdb
   /// The exception that is thrown when pdb does not contains /names stream.
   /// </summary>
   /// <remarks>
-  /// Not all pdb-s contains all possible streams required for debugging. For instnace, 'stripped pdb' (see /PDBSTRIPPED at msdn)
+  /// Not all pdb-s contains all possible streams required for debugging. For instance, 'stripped pdb' (see /PDBSTRIPPED at msdn)
   /// does not have /names stream and should be handled the same way if the pdb is absent.
   /// </remarks>
   public class NoNameStreamPdbException : PdbDebugException

--- a/System.Compiler/PDBreader/PdbDebugException.cs
+++ b/System.Compiler/PDBreader/PdbDebugException.cs
@@ -27,11 +27,25 @@ using System.IO;
 
 namespace Microsoft.Cci.Pdb
 {
-  internal class PdbDebugException : IOException
+  public class PdbDebugException : IOException
   {
     internal PdbDebugException(String format, params object[] args)
       : base(String.Format(format, args))
     {
     }
+  }
+
+  /// <summary>
+  /// The exception that is thrown when pdb does not contains /names stream.
+  /// </summary>
+  /// <remarks>
+  /// Not all pdb-s contains all possible streams required for debugging. For instnace, 'stripped pdb' (see /PDBSTRIPPED at msdn)
+  /// does not have /names stream and should be handled the same way if the pdb is absent.
+  /// </remarks>
+  public class NoNameStreamPdbException : PdbDebugException
+  {
+    internal NoNameStreamPdbException()
+     : base("No '/names' stream was found in the specified pdb")
+    {}
   }
 }

--- a/System.Compiler/PDBreader/PdbFile.cs
+++ b/System.Compiler/PDBreader/PdbFile.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Cci.Pdb
       int nameStream;
       if (!nameIndex.TryGetValue("/NAMES", out nameStream))
       {
-        throw new PdbDebugException("No `name' stream");
+        throw new NoNameStreamPdbException();
       }
       dir.streams[nameStream].Read(reader, bits);
       IntHashTable names = LoadNameStream(bits);
@@ -493,7 +493,7 @@ namespace Microsoft.Cci.Pdb
       int nameStream;
       if (!nameIndex.TryGetValue("/NAMES", out nameStream))
       {
-        throw new PdbDebugException("No `name' stream");
+        throw new NoNameStreamPdbException();
       }
       dir.streams[nameStream].Read(reader, bits);
       IntHashTable names = LoadNameStream(bits);

--- a/System.Compiler/Reader.cs
+++ b/System.Compiler/Reader.cs
@@ -445,7 +445,15 @@ namespace System.Compiler.Metadata{
 #endif
         return assembly;
 #if !FxCop
-      }catch(Exception e){
+      }
+      catch(Microsoft.Cci.Pdb.NoNameStreamPdbException e)
+      {
+        if (this.module == null) return null;
+        if (this.module.MetadataImportWarnings == null) this.module.MetadataImportWarnings = new ArrayList();
+        this.module.MetadataImportWarnings.Add(e);
+        return this.module as AssemblyNode;
+      }
+      catch(Exception e){
         if (this.module == null) return null;
         if (this.module.MetadataImportErrors == null) this.module.MetadataImportErrors = new ArrayList();
         this.module.MetadataImportErrors.Add(e);


### PR DESCRIPTION
Fix for #270.

I've tested this stuff manually for generated pdb without /names stream, ran all the tests to check regression.
