### PR TITLE
Changed registry access to use 32 bit view for CodeToolsUpdate project.

### DIFF
--- a/Microsoft.VisualStudio.CodeTools/CodeToolsUpdate/Common.cs
+++ b/Microsoft.VisualStudio.CodeTools/CodeToolsUpdate/Common.cs
@@ -61,13 +61,19 @@ namespace CodeToolsUpdate
         // magically to HKEY_CURRENT_USER\Software\Microsoft\VisualStudio\10.0_Config
         public static RegistryKey GetLocalRegistryRoot(string vsRoot, string subKey, bool forWrite)
         {
-            return OpenKey(Registry.LocalMachine, vsRoot + "\\" + subKey, forWrite);
+            using (RegistryKey root = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+            {
+                return OpenKey(root, vsRoot + "\\" + subKey, forWrite);
+            }
         }
 
         // The user VS registry root: HKEY_CURRENT_USER\Software\Microsoft\VisualStudio\10.0
         internal static RegistryKey GetUserRegistryRoot(string vsRoot, string subKey, bool forWrite)
         {
-            return OpenKey(Registry.CurrentUser, vsRoot + "\\" + subKey, forWrite);
+            using (RegistryKey root = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32))
+            {
+                return OpenKey(root, vsRoot + "\\" + subKey, forWrite);
+            }
         }
         #endregion
     }

--- a/Microsoft.VisualStudio.CodeTools/CodeToolsUpdate/Program.cs
+++ b/Microsoft.VisualStudio.CodeTools/CodeToolsUpdate/Program.cs
@@ -63,21 +63,24 @@ namespace CodeToolsUpdate
                 }
 
                 string vs = @"Software\Microsoft\VisualStudio";
-                RegistryKey vsKey = Registry.LocalMachine.OpenSubKey(vs);
-                if (vsKey != null)
+                using (RegistryKey baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+                using (RegistryKey vsKey = baseKey.OpenSubKey(vs))
                 {
-                    foreach (string version in vsKey.GetSubKeyNames())
+                    if (vsKey != null)
                     {
-                        string vsRoot = vs + "\\" + version;
-                        if (Common.GetLocalRegistryRoot(vsRoot, "CodeTools") != null)
+                        foreach (string version in vsKey.GetSubKeyNames())
                         {
-                            if (listMode)
+                            string vsRoot = vs + "\\" + version;
+                            if (Common.GetLocalRegistryRoot(vsRoot, "CodeTools") != null)
                             {
-                                Listing(toolNames, vsRoot);
-                            }
-                            else
-                            {
-                                Update(updateMode, toolNames, vsRoot);
+                                if (listMode)
+                                {
+                                    Listing(toolNames, vsRoot);
+                                }
+                                else
+                                {
+                                    Update(updateMode, toolNames, vsRoot);
+                                }
                             }
                         }
                     }

--- a/Microsoft.VisualStudio.CodeTools/CodeToolsUpdate/PropertyPageInfo.cs
+++ b/Microsoft.VisualStudio.CodeTools/CodeToolsUpdate/PropertyPageInfo.cs
@@ -271,10 +271,13 @@ namespace CodeToolsUpdate
                     // special logic for FSharp. For vs2010 we need to remove it from the user 10.0_Config too
                     if (tool.VsVersion >= 10.0 && new Guid(project) == fsharpProject)
                     {
-                        RegistryKey fsharpPropPagesKey = Registry.CurrentUser.OpenSubKey(tool.VsRoot + "_Config\\Projects\\" + project + "\\" + category, true);
-                        if (fsharpPropPagesKey != null)
+                        using (RegistryKey baseKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32))
+                        using (RegistryKey fsharpPropPagesKey = baseKey.OpenSubKey(tool.VsRoot + "_Config\\Projects\\" + project + "\\" + category, true))
                         {
-                            fsharpPropPagesKey.DeleteSubKeyTree(pageid.ToString("B"));
+                            if (fsharpPropPagesKey != null)
+                            {
+                                fsharpPropPagesKey.DeleteSubKeyTree(pageid.ToString("B"));
+                            }
                         }
                     }
                 }
@@ -389,7 +392,10 @@ namespace CodeToolsUpdate
                 // special logic for FSharp. Somehow for vs2010 we need to put it in the user 10.0_Config too
                 if (tool.VsVersion >= 10.0 && new Guid(project) == fsharpProject)
                 {
-                    Registry.CurrentUser.CreateSubKey(tool.VsRoot + "_Config\\Projects\\" + project + "\\" + category + "\\" + pageid.ToString("B"));
+                    using (RegistryKey baseKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32))
+                    {
+                        baseKey.CreateSubKey(tool.VsRoot + "_Config\\Projects\\" + project + "\\" + category + "\\" + pageid.ToString("B"));
+                    }
                 }
 
 

--- a/Microsoft.VisualStudio.CodeTools/CodeToolsUpdate/TargetInfo.cs
+++ b/Microsoft.VisualStudio.CodeTools/CodeToolsUpdate/TargetInfo.cs
@@ -133,14 +133,17 @@ namespace CodeToolsUpdate
             List<string> buildVersions = new List<string>();
             if (versions == null || versions.Length == 0)
             {
-                RegistryKey msbuild = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\MSBuild");
-                if (msbuild != null)
+                using (RegistryKey baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+                using (RegistryKey msbuild = baseKey.OpenSubKey(@"Software\Microsoft\MSBuild"))
                 {
-                    foreach (string ver in msbuild.GetSubKeyNames())
+                    if (msbuild != null)
                     {
-                        if (ver != null && ver.Length > 0 && Char.IsDigit(ver[0]))
+                        foreach (string ver in msbuild.GetSubKeyNames())
                         {
-                            buildVersions.Add(ver);
+                            if (ver != null && ver.Length > 0 && Char.IsDigit(ver[0]))
+                            {
+                                buildVersions.Add(ver);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This change is required to show Code Contracts property page in Visual Studio after the project platform was changed from x86 to Any CPU.