### PR TITLE
Producing contract reference assemblies for .NET Framework 4.6

### DIFF
--- a/Microsoft.Research/Contracts/Microsoft.VisualBasic.Compatibility/Microsoft.VisualBasic.Compatibility10.vbproj
+++ b/Microsoft.Research/Contracts/Microsoft.VisualBasic.Compatibility/Microsoft.VisualBasic.Compatibility10.vbproj
@@ -164,8 +164,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <PropertyGroup>
     <ContractReferenceOutputPathRoot>..\$(OutputPath)</ContractReferenceOutputPathRoot>

--- a/Microsoft.Research/Contracts/Microsoft.VisualBasic.Contracts/Microsoft.VisualBasic10.vbproj
+++ b/Microsoft.Research/Contracts/Microsoft.VisualBasic.Contracts/Microsoft.VisualBasic10.vbproj
@@ -168,8 +168,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <PropertyGroup>
     <ContractReferenceOutputPathRoot>..\$(OutputPath)</ContractReferenceOutputPathRoot>

--- a/Microsoft.Research/Contracts/MsCorlib/MsCorlib.Contracts10.csproj
+++ b/Microsoft.Research/Contracts/MsCorlib/MsCorlib.Contracts10.csproj
@@ -1238,8 +1238,8 @@ Include="System.Security.Principal.WindowsIdentity.cs" /> -->
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/Multitarget.targets
+++ b/Microsoft.Research/Contracts/Multitarget.targets
@@ -23,7 +23,8 @@
      SILVERLIGHT;SILVERLIGHT_5_0
      NETFRAMEWORK;NETFRAMEWORK_3_5
      NETFRAMEWORK;NETFRAMEWORK_4_0
-     NETFRAMEWORK;NETFRAMEWORK_4_5
+     NETFRAMEWORK;NETFRAMEWORK_4_0;NETFRAMEWORK_4_5
+     NETFRAMEWORK;NETFRAMEWORK_4_0;NETFRAMEWORK_4_5;NETFRAMEWORK_4_6
 
   ======================================================================-->
   <Import Project="AsmMeta.MsBuild.Tasks"/>
@@ -81,6 +82,12 @@
       <TargetDefinesCS>NETFRAMEWORK%3BNETFRAMEWORK_4_0%3BNETFRAMEWORK_4_5</TargetDefinesCS>
       <TargetDefinesVB>NETFRAMEWORK=-1%2CNETFRAMEWORK_4_0=-1%2CNETFRAMEWORK_4_5=-1</TargetDefinesVB>
       <TargetDir>.NETFramework\v4.5\</TargetDir>
+    </ReferenceAssemblyDirectories>
+    <ReferenceAssemblyDirectories Include="Microsoft\Framework\.NETFramework\v4.6\Target">
+      <TargetFramework>NetFramework</TargetFramework>
+      <TargetDefinesCS>NETFRAMEWORK%3BNETFRAMEWORK_4_0%3BNETFRAMEWORK_4_5%3BNETFRAMEWORK_4_6</TargetDefinesCS>
+      <TargetDefinesVB>NETFRAMEWORK=-1%2CNETFRAMEWORK_4_0=-1%2CNETFRAMEWORK_4_5=-1%2CNETFRAMEWORK_4_6=-1</TargetDefinesVB>
+      <TargetDir>.NETFramework\v4.6\</TargetDir>
     </ReferenceAssemblyDirectories>
   </ItemGroup>
 

--- a/Microsoft.Research/Contracts/PresentationCore/PresentationCore.csproj
+++ b/Microsoft.Research/Contracts/PresentationCore/PresentationCore.csproj
@@ -106,8 +106,8 @@
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.5\Profile\Client\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\.NETFramework\v4.5\Profile\Client\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Sources\System.Windows.Markup.IUriContext.cs" />

--- a/Microsoft.Research/Contracts/PresentationFramework/PresentationFramework.csproj
+++ b/Microsoft.Research/Contracts/PresentationFramework/PresentationFramework.csproj
@@ -104,8 +104,8 @@
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Sources\System.Windows.Application.cs" />

--- a/Microsoft.Research/Contracts/System.ComponentModel.Composition/System.ComponentModel.Composition.csproj
+++ b/Microsoft.Research/Contracts/System.ComponentModel.Composition/System.ComponentModel.Composition.csproj
@@ -105,8 +105,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Sources\System.ComponentModel.Composition.Primitives.ComposablePart.cs" />

--- a/Microsoft.Research/Contracts/System.Configuration.Install/System.Configuration.Install10.csproj
+++ b/Microsoft.Research/Contracts/System.Configuration.Install/System.Configuration.Install10.csproj
@@ -181,8 +181,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PreContractsBuildDummy\PreContractsBuildDummy.csproj">

--- a/Microsoft.Research/Contracts/System.Configuration/System.Configuration10.csproj
+++ b/Microsoft.Research/Contracts/System.Configuration/System.Configuration10.csproj
@@ -215,8 +215,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/System.Core.Contracts/System.Core.Contracts10.csproj
+++ b/Microsoft.Research/Contracts/System.Core.Contracts/System.Core.Contracts10.csproj
@@ -257,8 +257,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/System.Core/System.Core.csproj
+++ b/Microsoft.Research/Contracts/System.Core/System.Core.csproj
@@ -18,9 +18,8 @@
   <CodeContractsCheckReferenceAssembly>true</CodeContractsCheckReferenceAssembly>
 </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.5\Profile\Client\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v4.5\Target;Microsoft\Framework\v3.5\Target"/>
-
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\.NETFramework\v4.5\Profile\Client\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v4.5\Target;Microsoft\Framework\v3.5\Target"/>
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
 <ItemGroup>
 	<Compile Include = "Sources\System.Diagnostics.Eventing.EventDescriptor.cs" />

--- a/Microsoft.Research/Contracts/System.Data.Services/System.Data.Services.csproj
+++ b/Microsoft.Research/Contracts/System.Data.Services/System.Data.Services.csproj
@@ -111,8 +111,8 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Sources\System.Data.Services.Providers.DataServiceProviderMethods.cs" />

--- a/Microsoft.Research/Contracts/System.Data/System.Data10.csproj
+++ b/Microsoft.Research/Contracts/System.Data/System.Data10.csproj
@@ -250,8 +250,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/System.DirectoryServices/System.DirectoryServices.csproj
+++ b/Microsoft.Research/Contracts/System.DirectoryServices/System.DirectoryServices.csproj
@@ -104,8 +104,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.5\Profile\Client\Target;Microsoft\Framework\v3.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\.NETFramework\v4.5\Profile\Client\Target;Microsoft\Framework\v3.5\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Sources\System.DirectoryServices.ActiveDirectoryAccessRule.cs" />

--- a/Microsoft.Research/Contracts/System.Drawing/System.Drawing10.csproj
+++ b/Microsoft.Research/Contracts/System.Drawing/System.Drawing10.csproj
@@ -212,8 +212,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/System.Numerics/System.Numerics.csproj
+++ b/Microsoft.Research/Contracts/System.Numerics/System.Numerics.csproj
@@ -182,8 +182,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Foxtrot\Contracts\Microsoft.Contracts10.csproj">

--- a/Microsoft.Research/Contracts/System.Runtime.Caching/System.Runtime.Caching.csproj
+++ b/Microsoft.Research/Contracts/System.Runtime.Caching/System.Runtime.Caching.csproj
@@ -104,8 +104,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Sources\System.Runtime.Caching.CacheEntryChangeMonitor.cs" />

--- a/Microsoft.Research/Contracts/System.Security/System.Security10.csproj
+++ b/Microsoft.Research/Contracts/System.Security/System.Security10.csproj
@@ -190,8 +190,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/System.ServiceModel/System.ServiceModel.csproj
+++ b/Microsoft.Research/Contracts/System.ServiceModel/System.ServiceModel.csproj
@@ -105,8 +105,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Sources\System.ServiceModel.Configuration.HttpBindingBaseElement.cs" />

--- a/Microsoft.Research/Contracts/System.ServiceProcess/System.ServiceProcess.csproj
+++ b/Microsoft.Research/Contracts/System.ServiceProcess/System.ServiceProcess.csproj
@@ -103,8 +103,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\v3.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\v3.5\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Sources\System.ServiceProcess.ServiceBase.cs">

--- a/Microsoft.Research/Contracts/System.Web.ApplicationServices/System.Web.ApplicationServices.csproj
+++ b/Microsoft.Research/Contracts/System.Web.ApplicationServices/System.Web.ApplicationServices.csproj
@@ -103,8 +103,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Sources\System.Web.Security.IMembershipAdapter.cs" />

--- a/Microsoft.Research/Contracts/System.Web/System.Web10.csproj
+++ b/Microsoft.Research/Contracts/System.Web/System.Web10.csproj
@@ -380,8 +380,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/System.Windows.Forms/System.Windows.Forms10.csproj
+++ b/Microsoft.Research/Contracts/System.Windows.Forms/System.Windows.Forms10.csproj
@@ -263,8 +263,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/System.Xml.Linq/System.Xml.Linq10.csproj
+++ b/Microsoft.Research/Contracts/System.Xml.Linq/System.Xml.Linq10.csproj
@@ -219,8 +219,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/System.Xml/System.Xml10.csproj
+++ b/Microsoft.Research/Contracts/System.Xml/System.Xml10.csproj
@@ -256,8 +256,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/System/System.Contracts10.csproj
+++ b/Microsoft.Research/Contracts/System/System.Contracts10.csproj
@@ -676,8 +676,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target;Microsoft\Framework\Silverlight\v3.0\Target;Microsoft\Framework\Silverlight\v4.0\Target;Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\Target;Microsoft\Framework\Silverlight\v5.0\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/Contracts/WindowsBase/WindowsBase10.csproj
+++ b/Microsoft.Research/Contracts/WindowsBase/WindowsBase10.csproj
@@ -221,8 +221,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target" />
-    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)" />
+    <BuildTargetList Include="Microsoft\Framework\v3.5\Target;Microsoft\Framework\.NETFramework\v4.0\Target;Microsoft\Framework\.NETFramework\v4.5\Target;Microsoft\Framework\.NETFramework\v4.6\Target" />
+    <MultiTargetReferencePaths Include="..\..\Imported\ReferenceAssemblies\;$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\;..\$(OutputPath)" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContractAnalysis.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContractAnalysis.targets
@@ -220,7 +220,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <_CodeContractsCCCheckArguments>-nobox -nologo -nopex -remote  -suggest=!! -premode combined -suggest codefixes -framework:$(TargetFrameworkVersion) -warninglevel $(CodeContractsAnalysisWarning) $(CodeContractCodeAnalysisOptions) "-resolvedPaths:@(ReferencePath)" "-libPaths:@(CodeContractsAllLibPaths) " "$(DeclarativeAssemblyPath)"</_CodeContractsCCCheckArguments>
+      <_CodeContractsCCCheckArguments>-nobox -nologo -nopex -remote  -suggest=!! -premode combined -suggest codefixes -framework:$(TargetFrameworkVersion) -warninglevel $(CodeContractsAnalysisWarning) $(CodeContractCodeAnalysisOptions) "-resolvedPaths:@(ReferencePath)" "-libPaths:@(CodeContractsAllLibPaths)" "$(DeclarativeAssemblyPath)"</_CodeContractsCCCheckArguments>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -67,10 +67,10 @@
         </When>        
         <When Condition="'$(TargetFrameworkVersion)' == 'v4.6'">
           <PropertyGroup>
-            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
-        </When>        
-				<Otherwise>
+        </When>
+        <Otherwise>
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/ManagedContracts.wxs
+++ b/Microsoft.Research/ManagedContract.Setup/ManagedContracts.wxs
@@ -71,6 +71,7 @@
 <?define var.EnvironmentVariablesCompGuid     = "{990ACAFB-1AAE-4fa6-A178-9BF28206012F}" ?>
 <?define var.OutOfBandCompGuid40              = "{990ACAFC-1AAE-4fa6-A178-9BF28206012F}" ?>
 <?define var.OutOfBandCompGuid45              = "{990ACAFD-1AAE-4fa6-A178-9BF28206012F}" ?>
+<?define var.OutOfBandCompGuid46              = "{990ACB0D-1AAE-4fa6-A178-9BF28206012F}" ?>
 <?define var.OutOfBandCompGuidSL30            = "{990ACAFE-1AAE-4fa6-A178-9BF28206012F}" ?>
 <?define var.OutOfBandCompGuidSL40            = "{990ACAFF-1AAE-4fa6-A178-9BF28206012F}" ?>
 <?define var.OutOfBandCompGuidSL50            = "{990ACB03-1AAE-4fa6-A178-9BF28206012F}" ?>
@@ -670,6 +671,112 @@
                        Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.5\$(var.WindowsBaseContracts)' Vital='yes'/>
                   </Component>
                 </Directory>
+                <Directory Id='OUTOFBANDDIR46' Name='v4.6'>
+                  <Component Id='OutOfBandContracts46' Guid='$(var.OutOfBandCompGuid46)'>
+                    <File
+                       Id='$(var.MicrosoftVBCompatContracts)46'
+                       Name='$(var.MicrosoftVBCompatContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.MicrosoftVBCompatContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.MSFTVBContracts)46'
+                       Name='$(var.MSFTVBContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.MSFTVBContracts)'
+                       Vital='yes'/>
+                    <File
+                       Id='$(var.mscorlibContracts)46'
+                       Name='$(var.mscorlibContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.mscorlibContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.PresentationCoreContracts)46'
+                       Name='$(var.PresentationCoreContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.PresentationCoreContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.PresentationFrameworkContracts)46'
+                       Name='$(var.PresentationFrameworkContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.PresentationFrameworkContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemComponentModelCompositionContracts)46'
+                       Name='$(var.SystemComponentModelCompositionContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemComponentModelCompositionContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemConfigurationContracts)46'
+                       Name='$(var.SystemConfigurationContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemConfigurationContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemConfigurationInstallContracts)46'
+                       Name='$(var.SystemConfigurationInstallContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemConfigurationInstallContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemContracts)46'
+                       Name='$(var.SystemContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemCoreContracts)46'
+                       Name='$(var.SystemCoreContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemCoreContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemDataContracts)46'
+                       Name='$(var.SystemDataContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemDataContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemDataServicesContracts)46'
+                       Name='$(var.SystemDataServicesContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemDataServicesContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemDirectoryServicesContracts)46'
+                       Name='$(var.SystemDirectoryServicesContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemDirectoryServicesContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemDrawingContracts)46'
+                       Name='$(var.SystemDrawingContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemDrawingContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemNumericsContracts)46'
+                       Name='$(var.SystemNumericsContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemNumericsContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemRuntimeCachingContracts)46'
+                       Name='$(var.SystemRuntimeCachingContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemRuntimeCachingContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemSecurityContracts)46'
+                       Name='$(var.SystemSecurityContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemSecurityContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemServiceModelContracts)46'
+                       Name='$(var.SystemServiceModelContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemServiceModelContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemServiceProcessContracts)46'
+                       Name='$(var.SystemServiceProcessContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemServiceProcessContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemWebApplicationServicesContracts)46'
+                       Name='$(var.SystemWebApplicationServicesContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemWebApplicationServicesContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemWebContracts)46'
+                       Name='$(var.SystemWebContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemWebContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemWindowsFormsContracts)46'
+                       Name='$(var.SystemWindowsFormsContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemWindowsFormsContracts)'
+                       Vital='yes'/>
+                    <File
+                       Id='$(var.SystemXmlContracts)46'
+                       Name='$(var.SystemXmlContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemXmlContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.SystemXmlLinqContracts)46'
+                       Name='$(var.SystemXmlLinqContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.SystemXmlLinqContracts)' Vital='yes'/>
+                    <File
+                       Id='$(var.WindowsBaseContracts)46'
+                       Name='$(var.WindowsBaseContracts)'
+                       Source='$(var.ContractReferenceAssemblyRoot)\.NETFramework\v4.6\$(var.WindowsBaseContracts)' Vital='yes'/>
+                  </Component>
+                </Directory>
               </Directory>
               <Directory Id='SilverlightContracts' Name='Silverlight'>
                 <Directory Id='OUTOFBANDDIRSL30' Name='v3.0'>
@@ -1187,6 +1294,7 @@
         <ComponentRef Id='OutOfBandContracts35' />
         <ComponentRef Id='OutOfBandContracts40' />
         <ComponentRef Id='OutOfBandContracts45' />
+        <ComponentRef Id='OutOfBandContracts46' />
         <ComponentRef Id='OutOfBandContractsSL30' />
         <ComponentRef Id='OutOfBandContractsSL40' />
         <ComponentRef Id='OutOfBandContractsSL50' />


### PR DESCRIPTION
This pull request adds compiling and installing contract reference assemblies specific for .NET Framework 4.6. This pull request does not add any new system contracts for .NET Framework 4.6, but it would be a prerequisite for adding any such contracts.

##### Why do we need 4.6-specific assemblies?
.NET Framework 4.6 adds new overloads to frequently used methods. For example, there are now

```
static string String.Format(IFormatProvider, string, object)
static string String.Format(IFormatProvider, string, object, object)
static string String.Format(IFormatProvider, string, object, object, object)
```

in addition to 

```
static string String.Format(IFormatProvider, string, object[])
```

This causes innocently looking code like this:

```
string str = String.Format(CultureInfo.InvariantCulture, "Value: {0}", x);
Contract.Assert(str != null);
```

to fail static contract verification when targeting .NET Framework 4.6 because the specific overload is not present in .NET 4.5 CRAs.

##### Caveats
Building new contract reference assemblies requires .NET Framework 4.6 and [.NET Framework 4.6 Targeting Pack](http://www.microsoft.com/en-us/download/details.aspx?id=48136) to be installed on the build machine. 

An alternative would be to stuff another 100MB of reference assemblies into `Microsoft.Research\Imported\ReferenceAssemblies`, but [we seem to feel strongly about not doing so](https://github.com/Microsoft/CodeContracts/blob/master/Microsoft.Research/Imported/ReferenceAssemblies/.NETFramework/v4.6/_readme.txt).