### PR TITLE
Some .NET Framework 4.6 contracts

### DIFF
--- a/Microsoft.Research/Contracts/MsCorlib/MsCorlib.Contracts10.csproj
+++ b/Microsoft.Research/Contracts/MsCorlib/MsCorlib.Contracts10.csproj
@@ -331,8 +331,10 @@
     <Compile Include="System.Collections.ObjectModel.Collection.cs" />
     <Compile Include="System.Diagnostic.Tracing.EventSource.cs" />
     <Compile Include="System.Diagnostic.Tracing.EventWrittenEventArgs.cs" />
+    <Compile Include="System.Runtime.CompilerServices.FormattableStringFactory.cs" />
     <Compile Include="System.Globalization.CalendarWeekRule.cs" />
     <Compile Include="System.Globalization.DateTimeFormatInfo.cs" />
+    <Compile Include="System.FormattableString.cs" />
     <Compile Include="System.IO.DirectoryNotFoundException.cs" />
     <Compile Include="System.IO.FileNotFoundException.cs" />
     <Compile Include="System.IO.PathTooLongException.cs" />

--- a/Microsoft.Research/Contracts/MsCorlib/System.Array.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.Array.cs
@@ -936,6 +936,15 @@ namespace System
     }
 #endif
 
+#if NETFRAMEWORK_4_6
+    public static T[] Empty<T>()
+    {
+      Contract.Ensures(Contract.Result<T>() != null);
+      Contract.Ensures(Contract.Result<T[]>().Length == 0);
+      return default(T[]);
+    }
+#endif
+
     #region ICollection Members
 
 

--- a/Microsoft.Research/Contracts/MsCorlib/System.FormattableString.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.FormattableString.cs
@@ -1,0 +1,144 @@
+// CodeContracts
+// 
+// Copyright (c) Microsoft Corporation
+// 
+// All rights reserved. 
+// 
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#if NETFRAMEWORK_4_6
+
+using System;
+using System.Diagnostics.Contracts;
+
+namespace System 
+{
+    /// <summary>
+    /// A composite format string along with the arguments to be formatted. An instance of this
+    /// type may result from the use of the C# or VB language primitive "interpolated string".
+    /// </summary>
+    [ContractClass(typeof(FormattableStringContract))]
+    public abstract class FormattableString : IFormattable
+    {
+        /// <summary>
+        /// The composite format string.
+        /// </summary>
+        public abstract String Format { get; }
+
+        /// <summary>
+        /// Returns an object array that contains zero or more objects to format. Clients should not
+        /// mutate the contents of the array.
+        /// </summary>
+        public abstract Object[] GetArguments();
+
+        /// <summary>
+        /// The number of arguments to be formatted.
+        /// </summary>
+        public abstract int ArgumentCount { get; }
+
+        /// <summary>
+        /// Returns one argument to be formatted from argument position <paramref name="index"/>.
+        /// </summary>
+        public abstract Object GetArgument(int index);
+
+        /// <summary>
+        /// Format to a string using the given culture.
+        /// </summary>
+        public abstract String ToString(IFormatProvider formatProvider);
+
+        String IFormattable.ToString(string ignored, IFormatProvider formatProvider)
+        {
+            return default(String);
+        }
+
+        /// <summary>
+        /// Format the given object in the invariant culture. This static method may be
+        /// imported in C# by
+        /// <code>
+        /// using static System.FormattableString;
+        /// </code>.
+        /// Within the scope
+        /// of that import directive an interpolated string may be formatted in the
+        /// invariant culture by writing, for example,
+        /// <code>
+        /// Invariant($"{{ lat = {latitude}; lon = {longitude} }}")
+        /// </code>
+        /// </summary>
+        [Pure]
+        public static String Invariant(FormattableString formattable)
+        {
+            Contract.Requires(formattable != null);
+            Contract.Ensures(Contract.Result<String>() != null);
+            return default(String);
+        }
+    }
+
+    [ContractClassFor(typeof(FormattableString))]
+    abstract class FormattableStringContract : FormattableString
+    {
+        /// <summary>
+        /// The composite format string.
+        /// </summary>
+        public override String Format
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<String>() != null);
+                return default(String);
+            }
+        }
+
+        /// <summary>
+        /// Returns an object array that contains zero or more objects to format. Clients should not
+        /// mutate the contents of the array.
+        /// </summary>
+        [Pure]
+        public override Object[] GetArguments()
+        {
+            Contract.Ensures(Contract.Result<Object[]>() != null);
+            Contract.Ensures(Contract.Result<Object[]>().Length == ArgumentCount);
+            return default(Object[]);
+        }
+
+        /// <summary>
+        /// The number of arguments to be formatted.
+        /// </summary>
+        public override int ArgumentCount
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                return default(int);
+            }
+        }
+
+        /// <summary>
+        /// Returns one argument to be formatted from argument position <paramref name="index"/>.
+        /// </summary>
+        [Pure]
+        public override Object GetArgument(int index)
+        {
+            Contract.Requires(index >= 0);
+            Contract.Requires(index < ArgumentCount);
+            return default(Object);
+        }
+
+        /// <summary>
+        /// Format to a string using the given culture.
+        /// </summary>
+        [Pure]
+        public override String ToString(IFormatProvider formatProvider)
+        {
+            Contract.Ensures(Contract.Result<String>() != null);
+            return default(String);
+        }
+    }
+}
+
+#endif

--- a/Microsoft.Research/Contracts/MsCorlib/System.Runtime.CompilerServices.FormattableStringFactory.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.Runtime.CompilerServices.FormattableStringFactory.cs
@@ -1,0 +1,43 @@
+// CodeContracts
+// 
+// Copyright (c) Microsoft Corporation
+// 
+// All rights reserved. 
+// 
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#if NETFRAMEWORK_4_6
+
+using System;
+using System.Diagnostics.Contracts;
+
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// A factory type used by compilers to create instances of the type <see cref="FormattableString"/>.
+    /// </summary>
+    public static class FormattableStringFactory
+    {
+        /// <summary>
+        /// Create a <see cref="FormattableString"/> from a composite format string and object
+        /// array containing zero or more objects to format.
+        /// </summary>
+        public static FormattableString Create(string format, params object[] arguments)
+        {
+            Contract.Requires(format != null);
+            Contract.Requires(arguments != null);
+            Contract.Ensures(Contract.Result<FormattableString>() != null);
+            Contract.Ensures(Contract.Result<FormattableString>().ArgumentCount == arguments.Length);
+            return default(FormattableString);
+        }
+    }
+}
+
+#endif

--- a/Microsoft.Research/Contracts/MsCorlib/System.String.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.String.cs
@@ -200,6 +200,39 @@ namespace System
       Contract.Ensures(Contract.Result<String>() != null);
       return default(String);
     }
+
+#if NETFRAMEWORK_4_6
+    [Pure]
+    [Reads(ReadsAttribute.Reads.Nothing)]
+    public static String Format(IFormatProvider provider, String format, object arg0, object arg1, object arg2)
+    {
+        Contract.Requires(format != null);
+
+        Contract.Ensures(Contract.Result<String>() != null);
+        return default(String);
+    }
+
+    [Pure]
+    [Reads(ReadsAttribute.Reads.Nothing)]
+    public static String Format(IFormatProvider provider, String format, object arg0, object arg1)
+    {
+        Contract.Requires(format != null);
+
+        Contract.Ensures(Contract.Result<String>() != null);
+        return default(String);
+    }
+
+    [Pure]
+    [Reads(ReadsAttribute.Reads.Nothing)]
+    public static String Format(IFormatProvider provider, String format, object arg0)
+    {
+        Contract.Requires(format != null);
+
+        Contract.Ensures(Contract.Result<String>() != null);
+        return default(String);
+    }
+#endif
+
     [Pure]
     [Reads(ReadsAttribute.Reads.Nothing)]
     public static String Format(String format, object[] args)


### PR DESCRIPTION
This adds contracts for:
* Array.Empty\<T\>()
* String.Format overloads
* FormattableString
* FormattableStringFactory

It can be compiled independently of #291, but needs it merged in order to be effective.