### PR TITLE
Remove false contract on PropertyChangedEventArgs

### DIFF
--- a/Microsoft.Research/Contracts/System/System.ComponentModel.PropertyChangedEventArgs.cs
+++ b/Microsoft.Research/Contracts/System/System.ComponentModel.PropertyChangedEventArgs.cs
@@ -7,7 +7,6 @@ namespace System.ComponentModel
    {
        public PropertyChangedEventArgs(string propertyName)
        {
-           Contract.Requires(!string.IsNullOrEmpty(Contract.Result<string>()));
            Contract.Ensures(this.PropertyName == propertyName);
        }
 
@@ -19,8 +18,6 @@ namespace System.ComponentModel
        {
            get
            {
-               Contract.Ensures(!string.IsNullOrEmpty(Contract.Result<string>()));
-
                return default(string);
            }
         }


### PR DESCRIPTION
MSDN documentation for [PropertyChangedEventArgs Constructor (String)](https://msdn.microsoft.com/en-us/library/system.componentmodel.propertychangedeventargs.propertychangedeventargs(v=vs.110).aspx):
 > An [Empty](https://msdn.microsoft.com/en-us/library/system.string.empty(v=vs.110).aspx) value or **null** for the *propertyName* parameter indicates that all of the properties have changed.