### PR TITLE
Extend postcondition on Path.GetTempFileName

### DIFF
--- a/Microsoft.Research/Contracts/MsCorlib/System.IO.Path.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.IO.Path.cs
@@ -216,7 +216,8 @@ namespace System.IO
 
     public static string GetTempFileName()
     {
-      Contract.Ensures(Contract.Result<string>() != null);
+      Contract.Ensures(!string.IsNullOrWhitespace(Contract.Result<string>()));
+      Contract.Ensures(Contract.Result<string>().Length >= 4);
       Contract.EnsuresOnThrow<System.IO.IOException>(true, @"An I/O error occurs, such as no unique temporary file name is available. - or - This method was unable to create a temporary file.");
       return default(string);
     }


### PR DESCRIPTION
Extends postcondition to not-null or whitespace, and length >= 4 since it must end with ".TMP"

Resolves #298.