### PR TITLE
Fix for issue #307

### DIFF
--- a/Foxtrot/Foxtrot/Extraction/ExtractorVisitor.cs
+++ b/Foxtrot/Foxtrot/Extraction/ExtractorVisitor.cs
@@ -3494,6 +3494,7 @@ namespace Microsoft.Contracts.Foxtrot
 
                 // now we have an auto prop
                 // make sure we have a setter too
+
                 Property prop = getter.DeclaringMember as Property;
                 if (prop == null) return;
 

--- a/Foxtrot/Foxtrot/Extraction/ExtractorVisitor.cs
+++ b/Foxtrot/Foxtrot/Extraction/ExtractorVisitor.cs
@@ -3494,7 +3494,6 @@ namespace Microsoft.Contracts.Foxtrot
 
                 // now we have an auto prop
                 // make sure we have a setter too
-
                 Property prop = getter.DeclaringMember as Property;
                 if (prop == null) return;
 

--- a/Microsoft.Research/CCDoc/BooleanExpressionHelper.cs
+++ b/Microsoft.Research/CCDoc/BooleanExpressionHelper.cs
@@ -341,5 +341,23 @@ namespace CCDoc {
       }
       return base.Rewrite(conditional);
     }
+
+      public override IExpression Rewrite(IGreaterThan greaterThan)
+      {
+          // Catch use of the x > null idiom used by Roslyn as generated
+          // code for x != null statements.
+          if (ExpressionHelper.IsNullLiteral(greaterThan.RightOperand))
+          {
+              var c = new NotEquality
+              {
+                  LeftOperand = greaterThan.LeftOperand,
+                  RightOperand = greaterThan.RightOperand,
+                  Type = greaterThan.Type
+              };
+              return c;
+          }
+
+          return base.Rewrite(greaterThan);
+      }
   }
 }


### PR DESCRIPTION
Fairly straightforward, this adds a overriding method to greater than expressions to look for statements like (x > null) to rewrite them as x != null. Seems to address the issue of documentation (xml documents no longer have !(x <= null) as the source code). 