### PR TITLE
Added test for issue #321

### DIFF
--- a/Foxtrot/Driver/Foxtrot.csproj
+++ b/Foxtrot/Driver/Foxtrot.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Rewriting\CollectBoundVariables.cs" />
     <Compile Include="Rewriting\CollectOldExpressions.cs" />
     <Compile Include="Rewriting\EmitAsyncClosure.cs" />
+    <Compile Include="Rewriting\PostRewriteChecker.cs" />
     <Compile Include="Rewriting\RemoveContractClasses.cs" />
     <Compile Include="Rewriting\RemoveShortBranches.cs" />
     <Compile Include="Rewriting\ReplaceResult.cs" />

--- a/Foxtrot/Driver/Program.cs
+++ b/Foxtrot/Driver/Program.cs
@@ -1472,6 +1472,9 @@ namespace Microsoft.Contracts.Foxtrot.Driver
 
                 rewriter.Verbose = 0 < options.verbose;
                 rewriter.Visit(assemblyNode);
+
+                PostRewriteChecker checker = new PostRewriteChecker();
+                checker.Visit(assemblyNode);
             }
 
             //Console.WriteLine(">>>Finished Rewriting<<<");

--- a/Foxtrot/Driver/Rewriting/PostRewriteChecker.cs
+++ b/Foxtrot/Driver/Rewriting/PostRewriteChecker.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Compiler;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Contracts.Foxtrot
+{
+    public sealed class PostRewriteChecker : Inspector
+    {
+        private Member currentMember;
+
+        public override void VisitProperty(Property property)
+        {
+            bool exchanged = false;
+            if (this.currentMember == null)
+            {
+                this.currentMember = property;
+                exchanged = true;
+            }
+
+            base.VisitProperty(property);
+
+            if (exchanged)
+            {
+                this.currentMember = null;
+            }
+        }
+
+        public override void VisitEvent(Event evnt)
+        {
+            bool exchanged = false;
+            if (this.currentMember == null)
+            {
+                this.currentMember = evnt;
+                exchanged = true;
+            }
+
+            base.VisitEvent(evnt);
+
+            if (exchanged)
+            {
+                this.currentMember = null;
+            }
+        }
+
+        public override void VisitMethod(Method method)
+        {
+            bool exchanged = false;
+            if (this.currentMember == null)
+            {
+                this.currentMember = method;
+                exchanged = true;
+            }
+
+            base.VisitMethod(method);
+
+            if (exchanged)
+            {
+                this.currentMember = null;
+            }
+        }
+
+        public override void VisitMemberBinding(MemberBinding memberBinding)
+        {
+            base.VisitMemberBinding(memberBinding);
+
+            if (this.currentMember == null)
+            {
+                return;
+            }
+
+            Method method = memberBinding.BoundMember as Method;
+            if (method == null)
+            {
+                return;
+            }
+            
+            if (!method.DeclaringType.Namespace.Matches(ContractNodes.ContractNamespace))
+            {
+                return;
+            }
+
+            if (!method.DeclaringType.Name.Matches(ContractNodes.ContractClassName))
+            {
+                return;
+            }
+
+            if (method.DeclaringType.DeclaringModule.Name != "mscorlib" &&
+                method.DeclaringType.DeclaringModule.Name != "Microsoft.Contracts")
+            {
+                return;
+            }
+
+            if (method.Name.Matches(ContractNodes.RequiresName) ||
+                method.Name.Matches(ContractNodes.EnsuresName) ||
+                method.Name.Matches(ContractNodes.EnsuresOnThrowName) ||
+                method.Name.Matches(ContractNodes.InvariantName) ||
+                method.Name.Matches(ContractNodes.OldName) ||
+                method.Name.Matches(ContractNodes.ResultName) ||
+                method.Name.Matches(ContractNodes.ValueAtReturnName) ||
+                method.Name.Matches(ContractNodes.EndContractBlockName))
+            {
+
+                string message = string.Format("Not rewritten call to contract method '{0}' has been detected in member '{1}'.", method.FullName, this.currentMember.FullName);
+                throw new RewriteException(message);
+            }
+        }
+    }
+}

--- a/Foxtrot/Foxtrot/ContractNodes.cs
+++ b/Foxtrot/Foxtrot/ContractNodes.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Contracts.Foxtrot
 
             // Look for each member of the contract class
 
-            var requiresMethods = ContractClass.GetMethods(Identifier.For("Requires"), SystemTypes.Boolean);
+            var requiresMethods = ContractClass.GetMethods(RequiresName, SystemTypes.Boolean);
             for (int i = 0; i < requiresMethods.Count; i++)
             {
                 var method = requiresMethods[i];
@@ -260,7 +260,7 @@ namespace Microsoft.Contracts.Foxtrot
                 return;
             }
 
-            var requiresMethodsWithMsg = ContractClass.GetMethods(Identifier.For("Requires"), SystemTypes.Boolean, SystemTypes.String);
+            var requiresMethodsWithMsg = ContractClass.GetMethods(RequiresName, SystemTypes.Boolean, SystemTypes.String);
             for (int i = 0; i < requiresMethodsWithMsg.Count; i++)
             {
                 var method = requiresMethodsWithMsg[i];
@@ -276,20 +276,20 @@ namespace Microsoft.Contracts.Foxtrot
                 }
             }
 
-            EnsuresMethod = ContractClass.GetMethod(Identifier.For("Ensures"), SystemTypes.Boolean);
+            EnsuresMethod = ContractClass.GetMethod(EnsuresName, SystemTypes.Boolean);
             
-            EnsuresWithMsgMethod = ContractClass.GetMethod(Identifier.For("Ensures"), SystemTypes.Boolean, SystemTypes.String);
-            EnsuresOnThrowTemplate = ContractClass.GetMethod(Identifier.For("EnsuresOnThrow"), SystemTypes.Boolean);
-            EnsuresOnThrowWithMsgTemplate = ContractClass.GetMethod(Identifier.For("EnsuresOnThrow"), SystemTypes.Boolean, SystemTypes.String);
+            EnsuresWithMsgMethod = ContractClass.GetMethod(EnsuresName, SystemTypes.Boolean, SystemTypes.String);
+            EnsuresOnThrowTemplate = ContractClass.GetMethod(EnsuresOnThrowName, SystemTypes.Boolean);
+            EnsuresOnThrowWithMsgTemplate = ContractClass.GetMethod(EnsuresOnThrowName, SystemTypes.Boolean, SystemTypes.String);
 
-            InvariantMethod = ContractClass.GetMethod(Identifier.For("Invariant"), SystemTypes.Boolean);
-            InvariantWithMsgMethod = ContractClass.GetMethod(Identifier.For("Invariant"), SystemTypes.Boolean, SystemTypes.String);
+            InvariantMethod = ContractClass.GetMethod(InvariantName, SystemTypes.Boolean);
+            InvariantWithMsgMethod = ContractClass.GetMethod(InvariantName, SystemTypes.Boolean, SystemTypes.String);
 
-            AssertMethod = ContractClass.GetMethod(Identifier.For("Assert"), SystemTypes.Boolean);
-            AssertWithMsgMethod = ContractClass.GetMethod(Identifier.For("Assert"), SystemTypes.Boolean, SystemTypes.String);
+            AssertMethod = ContractClass.GetMethod(AssertName, SystemTypes.Boolean);
+            AssertWithMsgMethod = ContractClass.GetMethod(AssertName, SystemTypes.Boolean, SystemTypes.String);
 
-            AssumeMethod = ContractClass.GetMethod(Identifier.For("Assume"), SystemTypes.Boolean);
-            AssumeWithMsgMethod = ContractClass.GetMethod(Identifier.For("Assume"), SystemTypes.Boolean, SystemTypes.String);
+            AssumeMethod = ContractClass.GetMethod(AssumeName, SystemTypes.Boolean);
+            AssumeWithMsgMethod = ContractClass.GetMethod(AssumeName, SystemTypes.Boolean, SystemTypes.String);
 
             ResultTemplate = ContractClass.GetMethod(ResultName);
 
@@ -318,16 +318,16 @@ namespace Microsoft.Contracts.Foxtrot
                             assemblyContainingContractClass.GetType(Identifier.For("System.Collections.Generic"),
                                 Identifier.For("IEnumerable" + TargetPlatform.GenericTypeNamesMangleChar + "1"));
 
-                        ForAllGenericTemplate = ContractClass.GetMethod(Identifier.For("ForAll"), genericIEnum, GenericPredicate);
-                        ExistsGenericTemplate = ContractClass.GetMethod(Identifier.For("Exists"), genericIEnum, GenericPredicate);
+                        ForAllGenericTemplate = ContractClass.GetMethod(ForallName, genericIEnum, GenericPredicate);
+                        ExistsGenericTemplate = ContractClass.GetMethod(ExistsName, genericIEnum, GenericPredicate);
                     }
                 }
 
                 TypeNode PredicateOfInt = GenericPredicate.GetTemplateInstance(ContractClass, SystemTypes.Int32);
                 if (PredicateOfInt != null)
                 {
-                    ForAllTemplate = ContractClass.GetMethod(Identifier.For("ForAll"), SystemTypes.Int32, SystemTypes.Int32, PredicateOfInt);
-                    ExistsTemplate = ContractClass.GetMethod(Identifier.For("Exists"), SystemTypes.Int32, SystemTypes.Int32, PredicateOfInt);
+                    ForAllTemplate = ContractClass.GetMethod(ForallName, SystemTypes.Int32, SystemTypes.Int32, PredicateOfInt);
+                    ExistsTemplate = ContractClass.GetMethod(ExistsName, SystemTypes.Int32, SystemTypes.Int32, PredicateOfInt);
                 }
             }
 
@@ -355,7 +355,7 @@ namespace Microsoft.Contracts.Foxtrot
                 }
             }
 
-            EndContract = ContractClass.GetMethod(Identifier.For("EndContractBlock"));
+            EndContract = ContractClass.GetMethod(EndContractBlockName);
             if (this.ContractFailureKind != null)
             {
                 if (ContractHelperClass != null)
@@ -434,9 +434,9 @@ namespace Microsoft.Contracts.Foxtrot
 
             // Check that ContractFailureKind is okay
 
-            if (this.ContractFailureKind.GetField(Identifier.For("Assert")) == null
-                || this.ContractFailureKind.GetField(Identifier.For("Assume")) == null
-                || this.ContractFailureKind.GetField(Identifier.For("Invariant")) == null
+            if (this.ContractFailureKind.GetField(AssertName) == null
+                || this.ContractFailureKind.GetField(AssumeName) == null
+                || this.ContractFailureKind.GetField(InvariantName) == null
                 || this.ContractFailureKind.GetField(Identifier.For("Postcondition")) == null
                 || this.ContractFailureKind.GetField(Identifier.For("Precondition")) == null
                 )

--- a/Foxtrot/Foxtrot/ContractNodes.cs
+++ b/Foxtrot/Foxtrot/ContractNodes.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Contracts.Foxtrot
         public static readonly Identifier RaiseContractFailedEventName = Identifier.For("RaiseContractFailedEvent");
         public static readonly Identifier TriggerFailureName = Identifier.For("TriggerFailure");
         public static readonly Identifier ReportFailureName = Identifier.For("ReportFailure");
+        public static readonly Identifier AssertName = Identifier.For("Assert");
+        public static readonly Identifier AssumeName = Identifier.For("Assume");
         public static readonly Identifier RequiresName = Identifier.For("Requires");
         public static readonly Identifier RequiresAlwaysName = Identifier.For("RequiresAlways");
         public static readonly Identifier EnsuresName = Identifier.For("Ensures");
@@ -66,6 +68,7 @@ namespace Microsoft.Contracts.Foxtrot
         public static readonly Identifier ValueAtReturnName = Identifier.For("ValueAtReturn");
         public static readonly Identifier ForallName = Identifier.For("ForAll");
         public static readonly Identifier ExistsName = Identifier.For("Exists");
+        public static readonly Identifier EndContractBlockName = Identifier.For("EndContractBlock");
         public static readonly Identifier ValidatorAttributeName = Identifier.For("ContractArgumentValidatorAttribute");
         public static readonly Identifier AbbreviatorAttributeName = Identifier.For("ContractAbbreviatorAttribute");
         public static readonly Identifier ContractOptionAttributeName = Identifier.For("ContractOptionAttribute");

--- a/Foxtrot/Foxtrot/Extraction/ExtractorVisitor.cs
+++ b/Foxtrot/Foxtrot/Extraction/ExtractorVisitor.cs
@@ -1453,6 +1453,33 @@ namespace Microsoft.Contracts.Foxtrot
                 }
             }
 
+            public override void VisitReturn(Return Return)
+            {
+                Expression source = Return.Expression;
+                Construct sourceConstruct = source as Construct;
+
+                if (sourceConstruct != null)
+                {
+                    if (sourceConstruct.Type != null && sourceConstruct.Type.Name.Name.StartsWith(this.closureTag))
+                    {
+                        if (sourceConstruct.Type.Template != null)
+                        {
+                            TypeNode template = sourceConstruct.Type.Template;
+                            while (template.Template != null)
+                            {
+                                template = template.Template;
+                            }
+
+                            this.closureClass = (Class)template;
+                        }
+                        else
+                        {
+                            this.closureClass = (Class)sourceConstruct.Type;
+                        }
+                    }
+                }
+            }
+
             public override void VisitExpressionStatement(ExpressionStatement estmt)
             {
                 Expression source = estmt.Expression;

--- a/Foxtrot/Tests/FoxtrotTests10.csproj
+++ b/Foxtrot/Tests/FoxtrotTests10.csproj
@@ -115,6 +115,7 @@
     <TestSources Include="Sources\InterleavedValidationsInherit.cs" />
     <TestSources Include="Sources\IteratorWithLegacyPrecondition.cs" />
     <TestSources Include="Sources\DefaultExpression.cs" />
+    <TestSources Include="Sources\OptimizedIterator.cs" />
     <Compile Include="TestDriver.cs" />
     <TestSources Include="Sources\InheritExists.cs" />
     <TestSources Include="Sources\InheritGenericExists.cs" />

--- a/Foxtrot/Tests/Options.cs
+++ b/Foxtrot/Tests/Options.cs
@@ -232,7 +232,10 @@ namespace Tests
             string compilerCode,
             bool useBinDir,
             bool useExe,
-            bool mustSucceed)
+            bool mustSucceed,
+            bool optimize,
+            bool releaseMode,
+            bool pdbOnly)
         {
             this.SourceFile = sourceFile;
             this.FoxtrotOptions = foxtrotOptions;
@@ -245,11 +248,45 @@ namespace Tests
             this.UseBinDir = useBinDir;
             this.UseExe = useExe;
             this.MustSucceed = mustSucceed;
+            this.Optimize = optimize;
+            this.ReleaseMode = releaseMode;
+            this.PdbOnly = pdbOnly;
 
             this.RootDirectory = Path.GetFullPath(RelativeRoot);
         }
+        public Options(
+            string sourceFile,
+            string foxtrotOptions,
+            bool useContractReferenceAssemblies,
+            string compilerOptions,
+            string[] references,
+            string[] libPaths,
+            string compilerCode,
+            bool useBinDir,
+            bool useExe,
+            bool mustSucceed)
+            : this(
+            sourceFile,
+            foxtrotOptions,
+            useContractReferenceAssemblies,
+            compilerOptions,
+            references,
+            libPaths,
+            compilerCode,
+            useBinDir,
+            useExe,
+            mustSucceed,
+            false,
+            false,
+            false)
+        {
+        }
 
         public bool ReleaseMode { get; set; }
+
+        public bool Optimize { get; set; }
+
+        public bool PdbOnly { get; set; }
 
         private static string LoadString(System.Data.DataRow dataRow, string name)
         {

--- a/Foxtrot/Tests/RewriterTests.cs
+++ b/Foxtrot/Tests/RewriterTests.cs
@@ -1120,6 +1120,20 @@ namespace Tests
                     useBinDir: false,
                     useExe: true,
                     mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\OptimizedIterator.cs",
+                    foxtrotOptions: @"",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: null,
+                    references: new string[0],
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true,
+                    optimize: true,
+                    releaseMode: true,
+                    pdbOnly: false);
             }
         }
 

--- a/Foxtrot/Tests/Sources/OptimizedIterator.cs
+++ b/Foxtrot/Tests/Sources/OptimizedIterator.cs
@@ -1,0 +1,67 @@
+﻿// CodeContracts
+// 
+// Copyright (c) Microsoft Corporation
+// 
+// All rights reserved. 
+// 
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Diagnostics.Contracts;
+
+namespace Tests.Sources
+{
+
+    partial class TestMain
+    {
+        public static class Things
+        {
+            public static class LeastFavourite
+            {
+                // With credits to The Chaser's War on Everything
+                public static IEnumerable<string> AFewOfMyLeastFavouriteThings
+                {
+                    get
+                    {
+                        Contract.Ensures(Contract.Result<IEnumerable<string>>() != null);
+
+                        yield return "Prim Julie Andrews";
+                        yield return "Cute Singing Kiddies";
+                    }
+                }
+            }
+        }
+
+        private static void Test(object value)
+        {
+            Contract.Requires(value != null);
+        }
+        
+        partial void Run()
+        {
+            if (behave)
+            {
+                foreach (string thing in Things.LeastFavourite.AFewOfMyLeastFavouriteThings)
+                {
+                    Test(thing);
+                }
+            }
+            else
+            {
+                Test(null);
+            }
+        }
+
+        public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Precondition;
+        // Condition is expected to be null because there is no pdb generated for the test assembly.
+        public string NegativeExpectedCondition = null;
+    }
+}

--- a/Foxtrot/Tests/TestDriver.cs
+++ b/Foxtrot/Tests/TestDriver.cs
@@ -285,7 +285,19 @@ namespace Tests
 
                 if (!options.ReleaseMode)
                 {
-                    arguments = "/debug " + arguments;
+                    if (options.PdbOnly)
+                    {
+                        arguments = "/debug:pdbonly " + arguments;
+                    }
+                    else
+                    {
+                        arguments = "/debug:full " + arguments;
+                    }
+                }
+
+                if (options.Optimize)
+                {
+                    arguments = "/optimize " + arguments;
                 }
 
                 var exitCode = RunProcess(testOutputHelper, sourcedir, compilerPath, arguments, true);


### PR DESCRIPTION
Problem described in the issue could be reproduced only when compiled with optimizations enabled on the Roslyn compiler. Test infrastructure was extended to allow specifying optimization and debug type in the test. Additionally, a new check was introduced in the rewriter that makes sure all contract methods were rewritten.

[Test results](https://ci.appveyor.com/project/hubuk/codecontracts/build/1.9.10112.121)