### PR TITLE
Enable automated execution of all unit tests in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ test:
   assemblies:
   - '**\FoxtrotTests.dll'
   - '**\UnitTests.dll'
-#  - '**\ClousotCacheTests\bin\Debug\ClousotCacheTests.dll'
-#  - '**\ClousotTests\bin\Debug\ClousotTests.dll'
+  - '**\ClousotCacheTests\bin\Debug\ClousotCacheTests.dll'
+  - '**\ClousotTests\bin\Debug\ClousotTests.dll'
 artifacts:
 - path: '**\ManagedContract.Setup\devlab9ts\Microsoft.Contracts.*.nupkg'
 - path: '**\ManagedContract.Setup\devlab9ts\msi\Contracts.devlab9ts.msi'


### PR DESCRIPTION
You need additional configure AppVeyor account with at least Basic plan (Free plan has a limits, what prevents test successful execution) to enable automated execution