### PR TITLE
Fix for #340.

### DIFF
--- a/System.Compiler/Reader.cs
+++ b/System.Compiler/Reader.cs
@@ -4257,6 +4257,18 @@ namespace System.Compiler.Metadata{
             this.currentItr++;
             switch (c) {
               case ',':
+                    // A comma may separate a type name from its assembly name or a type argument from
+                    // another type argument.
+                    // If processing non-type argument or a type argument with assembly name,
+                    // process the characters after the comma as an assembly name.
+                    //
+                    // If the next character is whitespace, assume that it delineates the start of an assembly name so
+                    // end the current identifier by going to done label.
+                    if (this.currentItr < this.typeNameString.Length && char.IsWhiteSpace(this.typeNameString[this.currentItr]))
+                    {
+                        goto done;
+                    }
+                    break;
               case '[':
               case ']':
               case '&':


### PR DESCRIPTION
ccrewrite will not fail if metadata has non-escaped comma in the type name.

As I mentioned in bug #340 this bug is tightly related to #186.

Per internal documentation, comma (`,`) can be used in two different cases in the type names: to separate assembly name or to separate generic type arguments. Here is a comment from MetadataReader codebase:

```c#
// A comma may separate a type name from its assembly name or a type argument from
// another type argument.
// If processing non-type argument or a type argument with assembly name,
// process the characters after the comma as an assembly name.
```

So this fix allows ccrewrite to read the metadata that has unescaped commas in type names.