### PR TITLE
Output declarative assemblies to output directory

### DIFF
--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -9,7 +9,7 @@
   ======================================================================-->
 
   <PropertyGroup>
-    <CodeContractsDeclDir>$(IntermediateOutputPath)Decl\</CodeContractsDeclDir>
+    <CodeContractsDeclDir>$(OutDir)Decl\</CodeContractsDeclDir>
     <CodeContractsContractSubDir>CodeContracts\</CodeContractsContractSubDir>
     <CodeContractsCCRefgenCommand>$(CodeContractsInstallDir)Bin\ccrefgen.exe</CodeContractsCCRefgenCommand>
   </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -9,7 +9,7 @@
   ======================================================================-->
 
   <PropertyGroup>
-    <CodeContractsDeclDir>$(OutDir)Decl\</CodeContractsDeclDir>
+    <CodeContractsDeclDir>$(OutDir)CodeContractsDeclarative\</CodeContractsDeclDir>
     <CodeContractsContractSubDir>CodeContracts\</CodeContractsContractSubDir>
     <CodeContractsCCRefgenCommand>$(CodeContractsInstallDir)Bin\ccrefgen.exe</CodeContractsCCRefgenCommand>
   </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -9,7 +9,7 @@
   ======================================================================-->
 
   <PropertyGroup>
-    <CodeContractsDeclDir>$(IntermediateOutputPath)Decl\</CodeContractsDeclDir>
+    <CodeContractsDeclDir>$(OutDir)Decl\</CodeContractsDeclDir>
     <CodeContractsContractSubDir>CodeContracts\</CodeContractsContractSubDir>
     <CodeContractsCCRefgenCommand>$(CodeContractsInstallDir)Bin\ccrefgen.exe</CodeContractsCCRefgenCommand>
   </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -9,7 +9,7 @@
   ======================================================================-->
 
   <PropertyGroup>
-    <CodeContractsDeclDir>$(OutDir)Decl\</CodeContractsDeclDir>
+    <CodeContractsDeclDir>$(OutDir)CodeContractsDeclarative\</CodeContractsDeclDir>
     <CodeContractsContractSubDir>CodeContracts\</CodeContractsContractSubDir>
     <CodeContractsCCRefgenCommand>$(CodeContractsInstallDir)Bin\ccrefgen.exe</CodeContractsCCRefgenCommand>
   </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v3.5/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v3.5/Microsoft.CodeContracts.targets
@@ -9,7 +9,7 @@
   ======================================================================-->
 
   <PropertyGroup>
-    <CodeContractsDeclDir>$(IntermediateOutputPath)Decl\</CodeContractsDeclDir>
+    <CodeContractsDeclDir>$(OutDir)Decl\</CodeContractsDeclDir>
     <CodeContractsContractSubDir>CodeContracts\</CodeContractsContractSubDir>
     <CodeContractsCCRefgenCommand>$(CodeContractsInstallDir)Bin\ccrefgen.exe</CodeContractsCCRefgenCommand>
   </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v3.5/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v3.5/Microsoft.CodeContracts.targets
@@ -9,7 +9,7 @@
   ======================================================================-->
 
   <PropertyGroup>
-    <CodeContractsDeclDir>$(OutDir)Decl\</CodeContractsDeclDir>
+    <CodeContractsDeclDir>$(OutDir)CodeContractsDeclarative\</CodeContractsDeclDir>
     <CodeContractsContractSubDir>CodeContracts\</CodeContractsContractSubDir>
     <CodeContractsCCRefgenCommand>$(CodeContractsInstallDir)Bin\ccrefgen.exe</CodeContractsCCRefgenCommand>
   </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v4.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v4.0/Microsoft.CodeContracts.targets
@@ -9,7 +9,7 @@
   ======================================================================-->
 
   <PropertyGroup>
-    <CodeContractsDeclDir>$(IntermediateOutputPath)Decl\</CodeContractsDeclDir>
+    <CodeContractsDeclDir>$(OutDir)Decl\</CodeContractsDeclDir>
     <CodeContractsContractSubDir>CodeContracts\</CodeContractsContractSubDir>
     <CodeContractsCCRefgenCommand>$(CodeContractsInstallDir)Bin\ccrefgen.exe</CodeContractsCCRefgenCommand>
   </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v4.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v4.0/Microsoft.CodeContracts.targets
@@ -9,7 +9,7 @@
   ======================================================================-->
 
   <PropertyGroup>
-    <CodeContractsDeclDir>$(OutDir)Decl\</CodeContractsDeclDir>
+    <CodeContractsDeclDir>$(OutDir)CodeContractsDeclarative\</CodeContractsDeclDir>
     <CodeContractsContractSubDir>CodeContracts\</CodeContractsContractSubDir>
     <CodeContractsCCRefgenCommand>$(CodeContractsInstallDir)Bin\ccrefgen.exe</CodeContractsCCRefgenCommand>
   </PropertyGroup>


### PR DESCRIPTION
Old behaviour: Declarative assemblies live in obj\ somewhere
New behaviour: Declarative assemblies live in bin\ somewhere
(subject to OutputPath being customized by the user)

This is the simplest way to fix #348. Another options would be making this configurable via the properties pane, but I'm not sure how to go about that.