### PR TITLE
Use .NET 4.6 reference assemblies for 4.6.1

### DIFF
--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -59,7 +59,18 @@
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
-        </When>        <Otherwise>
+        </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.1'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -70,6 +70,11 @@
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.1'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
         <Otherwise>
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>


### PR DESCRIPTION
Also use .NET 4.6 reference assemblies when targetting 4.6/4.6.1 with Visual Studio 2013