### PR TITLE
Remove invalid precondition from System.Dynamic.BindingRestrictions.GetInstanceRestriction.

### DIFF
--- a/Microsoft.Research/Contracts/System.Core.Contracts/System.Dynamic.BindingRestrictions.cs
+++ b/Microsoft.Research/Contracts/System.Core.Contracts/System.Dynamic.BindingRestrictions.cs
@@ -83,7 +83,6 @@ namespace System.Dynamic
     public static BindingRestrictions GetInstanceRestriction(Expression expression, object instance)
     {
       Contract.Requires(expression != null);
-      Contract.Requires(instance != null);
 
       Contract.Ensures(Contract.Result<BindingRestrictions>() != null);
 


### PR DESCRIPTION
Remove invalid precondition from System.Dynamic.BindingRestrictions.GetInstanceRestriction.

Fixes #351.