### PR TITLE
Remove invalid postcondition in System.Linq.Expression.NewExpression.Members

### DIFF
--- a/Microsoft.Research/Contracts/System.Core.Contracts/System.Linq.Expressions.NewExpression.cs
+++ b/Microsoft.Research/Contracts/System.Core.Contracts/System.Linq.Expressions.NewExpression.cs
@@ -68,7 +68,6 @@ namespace System.Linq.Expressions
     {
       get
       {
-        Contract.Ensures(Contract.Result<ReadOnlyCollection<MemberInfo>>() != null);
         return default(ReadOnlyCollection<MemberInfo>);
       }
     }


### PR DESCRIPTION
Remove invalid postcondition in System.Linq.Expression.NewExpression.Members

Fixes #349.