### PR TITLE
Remove invalid precondition on System.Xml.XmlSchemaSet

### DIFF
--- a/Microsoft.Research/Contracts/System.Xml/System.Xml.XmlSchemaSet.cs
+++ b/Microsoft.Research/Contracts/System.Xml/System.Xml.XmlSchemaSet.cs
@@ -236,8 +236,6 @@ namespace System.Xml.Schema
     //     The URL passed as a parameter is null or System.String.Empty.
     public XmlSchema Add(string targetNamespace, string schemaUri)
     {
-      Contract.Requires(!String.IsNullOrEmpty(targetNamespace));
-
       return default(XmlSchema);
     }
     //

--- a/Microsoft.Research/Contracts/System.Xml/System.Xml10.csproj
+++ b/Microsoft.Research/Contracts/System.Xml/System.Xml10.csproj
@@ -205,7 +205,6 @@
     <Compile Include="System.Xml.Schema.XmlSchemaComplexType.cs" />
     <Compile Include="System.Xml.Schema.XmlSchemaGroupBase.cs" />
     <Compile Include="System.Xml.Schema.XmlSchemaObjectCollection.cs" />
-    <Compile Include="System.Xml.SchemaSet.cs" />
     <Compile Include="System.Xml.Serialization.IXmlSerializable.cs" />
     <Compile Include="System.Xml.XmlAttribute.cs" />
     <Compile Include="System.Xml.XmlCDataSection.cs" />
@@ -232,6 +231,7 @@
     <Compile Include="System.Xml.XmlReaderSettings.cs" />
     <Compile Include="System.Xml.XmlResolver.cs" />
     <Compile Include="System.Xml.XmlSchemaObjectTable.cs" />
+    <Compile Include="System.Xml.XmlSchemaSet.cs" />
     <Compile Include="System.Xml.XmlSignificantWhiteSpace.cs" />
     <Compile Include="System.Xml.XmlText.cs" />
     <Compile Include="System.Xml.XmlWhiteSpace.cs" />


### PR DESCRIPTION
Remove invalid precondition on System.Xml.XmlSchemaSet
Renamed file to match class name.

Fixes #346.