### PR TITLE
Comment out statically-unprovable contracts.

### DIFF
--- a/Microsoft.Research/Contracts/System.Core.Contracts/System.Linq.Expressions.Expression.cs
+++ b/Microsoft.Research/Contracts/System.Core.Contracts/System.Linq.Expressions.Expression.cs
@@ -3567,8 +3567,10 @@ namespace System.Linq.Expressions
     public static MemberExpression Field(Expression expression, FieldInfo field)
     {
       Contract.Requires(field != null);
-      Contract.Requires(field.IsStatic || expression != null);
-      Contract.Requires(!field.IsStatic || expression == null);
+      // Commented out as this breaks static checking for Linq expressions
+      // When the compiler sets up the constructions of Expressions.
+      //// Contract.Requires(field.IsStatic || expression != null);
+      //// Contract.Requires(!field.IsStatic || expression == null);
       Contract.Ensures(Contract.Result<MemberExpression>() != null);
       return default(MemberExpression);
     }


### PR DESCRIPTION
The static analyzer cannot prove anything about `field` when the
compiler has generated the call to Expression.Field when translating
Linq expressions into code.

Fixes #301.


Using the same test code from #301, I get the following build output:

```
1>------ Build started: Project: Contract461Test, Configuration: Debug Any CPU ------
CodeContracts: Contract461Test: Schedule static contract analysis.
CodeContracts: Contract461Test: Background contract analysis started.
1>  elapsed time: 746.9456ms
1>  elapsed time: 540.9022ms
1>  Contract461Test -> C:\Temp\Contract461Test\Contract461Test\bin\Debug\Contract461Test.exe
========== Build: 1 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
CodeContracts: Contract461Test: Time spent connecting to the cache: 00:00:02.2712966
CodeContracts: Contract461Test: Cache used: (LocalDb)\MSSQLLocalDB
CodeContracts: Contract461Test: Validated: 98.0 %
CodeContracts: Contract461Test: Checked 50 assertions: 49 correct 1 unknown
CodeContracts: Contract461Test: Contract density: 3.12
CodeContracts: Contract461Test: Total methods analyzed 7
CodeContracts: Contract461Test: Methods analyzed with a faster abstract domain 0
CodeContracts: Contract461Test: Method analyses read from the cache 0
CodeContracts: Contract461Test: Methods not found in the cache 7
CodeContracts: Contract461Test: Methods with 0 warnings 6
CodeContracts: Contract461Test: Time spent in internal, potentially costly, operations
CodeContracts: Contract461Test: Overall time spent performing action #KarrPutIntoRowEchelonForm: 00:00:00.0329602 (invoked 8642 times)
Overall time spent performing action #KarrIsBottom: 00:00:00.0120002 (invoked 4478 times)
Overall time spent performing action #ArraysAssignInParallel: 00:00:00.5720789 (invoked 95 times)
Overall time spent performing action #ArraysJoin: 00:00:00.0968824 (invoked 51 times)
Overall time spent performing action #CheckIfEqual: 00:00:00.2300083 (invoked 2266 times)
Overall time spent performing action #WP: 00:00:00.4709740 (invoked 3 times)
CodeContracts: Contract461Test: Total time 6.388sec. 912ms/method
CodeContracts: Contract461Test: Generated 1 callee assume(s)
CodeContracts: Contract461Test: Retained 0 preconditions after filtering
CodeContracts: Contract461Test: Inferred 0 object invariants
CodeContracts: Contract461Test: Retained 0 object invariants after filtering
CodeContracts: Contract461Test: Detected 1 code fixes
CodeContracts: Contract461Test: Proof obligations with a code fix: 1
C:\Temp\Contract461Test\Contract461Test\Program.cs(13,4): warning : CodeContracts: requires unproven: year <= 0x270f. Are you making some assumption on System.DateTime.get_Year that the static checker is unaware of? . Is it an off-by-one? The static checker can prove (((System.DateTime)local3).Year + 1) <= (9999 + 1) instead
C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Contract461Test.exe(1,1): message : CodeContracts: Checked 50 assertions: 49 correct 1 unknown
CodeContracts: Contract461Test: 
CodeContracts: Contract461Test: Background contract analysis done.
```

The unprovable requires is gone, and there's a new unrelated warning but that's not an issue.

I believe that given the code the compiler has translated Linq into, the static analyzer can prove that `expression != null` is true, but it cannot prove anything about `field.IsStatic` so the second commented-out precondition fails.

I've removed both preconditions since they're mirrors of eachother.