### PR TITLE
Add preconditions to System.Text.Encoding

### DIFF
--- a/Microsoft.Research/Contracts/MsCorlib/System.Text.Encoding.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.Text.Encoding.cs
@@ -158,6 +158,8 @@ namespace System.Text
     public virtual string GetString(byte[] bytes, int index, int count)
     {
       Contract.Requires(bytes != null);
+      Contract.Requires(index >= 0 && index <= bytes.Length);
+      Contract.Requires(count >= 0 && index + count <= bytes.Length);
       Contract.Ensures(Contract.Result<string>() != null);
 
       return default(string);
@@ -173,14 +175,16 @@ namespace System.Text
     }
 #endif
     [Pure]
-    public virtual int GetMaxCharCount(int arg0)
+    public virtual int GetMaxCharCount(int byteCount)
     {
+      Contract.Requires(byteCount >= 0);
       Contract.Ensures(Contract.Result<int>() >= 0);
       return default(int);
     }
     [Pure]
-    public virtual int GetMaxByteCount(int arg0)
+    public virtual int GetMaxByteCount(int charCount)
     {
+      Contract.Requires(charCount >= 0);
       Contract.Ensures(Contract.Result<int>() >= 0);
       return default(int);
     }
@@ -199,12 +203,10 @@ namespace System.Text
     public virtual int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
     {
       Contract.Requires(bytes != null);
+      Contract.Requires(byteIndex >= 0 && byteIndex <= bytes.Length);
+      Contract.Requires(byteCount >= 0 && byteIndex + byteCount <= bytes.Length);
       Contract.Requires(chars != null);
-      Contract.Requires(byteIndex >= 0);
-      Contract.Requires(byteCount >= 0);
-      Contract.Requires(charIndex >= 0);
-      Contract.Requires(byteIndex + byteCount <= bytes.Length);
-      Contract.Requires(charIndex <= chars.Length);
+      Contract.Requires(charIndex >= 0 && charIndex <= chars.Length);
 
       Contract.Ensures(Contract.Result<int>() >= 0);
 
@@ -214,9 +216,8 @@ namespace System.Text
     public virtual char[] GetChars(byte[] bytes, int index, int count)
     {
       Contract.Requires(bytes != null);
-      Contract.Requires(index >= 0);
-      Contract.Requires(count >= 0);
-      Contract.Requires(index + count <= bytes.Length);
+      Contract.Requires(index >= 0 && index <= bytes.Length);
+      Contract.Requires(count >= 0 && index + count <= bytes.Length);
       Contract.Ensures(Contract.Result<char[]>() != null);
 
       return default(char[]);
@@ -233,10 +234,8 @@ namespace System.Text
     public virtual int GetCharCount(byte[] bytes, int index, int count)
     {
       Contract.Requires(bytes != null);
-      Contract.Requires(index >= 0);
-      Contract.Requires(count >= 0);
-      Contract.Requires(index + count <= bytes.Length);
-
+      Contract.Requires(index >= 0 && index <= bytes.Length);
+      Contract.Requires(count >= 0 && index + count <= bytes.Length);
       Contract.Ensures(Contract.Result<int>() >= 0);
 
       return default(int);
@@ -252,6 +251,11 @@ namespace System.Text
     public virtual int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex)
     {
       Contract.Requires(s != null);
+      Contract.Requires(charIndex >= 0 && charIndex <= s.Length);
+      Contract.Requires(charCount >= 0 && charIndex + charCount <= s.Length);
+      Contract.Requires(bytes != null);
+      Contract.Requires(byteIndex >= 0 && byteIndex <= bytes.Length);
+
       Contract.Ensures(Contract.Result<int>() >= 0);
 
       return default(int);
@@ -267,6 +271,11 @@ namespace System.Text
     public virtual int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
     {
       Contract.Requires(chars != null);
+      Contract.Requires(charIndex >= 0 && charIndex <= chars.Length);
+      Contract.Requires(charCount >= 0 && charIndex + charCount <= chars.Length);
+      Contract.Requires(bytes != null);
+      Contract.Requires(byteIndex >= 0 && byteIndex <= bytes.Length);
+
       Contract.Ensures(Contract.Result<int>() >= 0);
 
       return default(int);
@@ -275,6 +284,8 @@ namespace System.Text
     public virtual byte[] GetBytes(char[] chars, int index, int count)
     {
       Contract.Requires(chars != null);
+      Contract.Requires(index >= 0 && index <= chars.Length);
+      Contract.Requires(count >= 0 && index + count <= chars.Length);
       Contract.Ensures(Contract.Result<byte[]>() != null);
 
       return default(byte[]);
@@ -291,6 +302,8 @@ namespace System.Text
     public virtual int GetByteCount(char[] chars, int index, int count)
     {
       Contract.Requires(chars != null);
+      Contract.Requires(index >= 0 && index <= chars.Length);
+      Contract.Requires(count >= 0 && index + count <= chars.Length);
       Contract.Ensures(Contract.Result<int>() >= 0);
 
       return default(int);
@@ -340,6 +353,8 @@ namespace System.Text
       Contract.Requires(srcEncoding != null);
       Contract.Requires(dstEncoding != null);
       Contract.Requires(bytes != null);
+      Contract.Requires(index >= 0 && index <= bytes.Length);
+      Contract.Requires(count >= 0 && index + count <= bytes.Length);
       Contract.Ensures(Contract.Result<byte[]>() != null);
       return default(byte[]);
     }

--- a/Microsoft.Research/Contracts/MsCorlib/System.Text.Encoding.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.Text.Encoding.cs
@@ -159,7 +159,7 @@ namespace System.Text
     {
       Contract.Requires(bytes != null);
       Contract.Requires(index >= 0 && index <= bytes.Length);
-      Contract.Requires(count >= 0 && index + count <= bytes.Length);
+      Contract.Requires(count >= 0 && count <= bytes.Length - index);
       Contract.Ensures(Contract.Result<string>() != null);
 
       return default(string);
@@ -203,9 +203,9 @@ namespace System.Text
     public virtual int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
     {
       Contract.Requires(bytes != null);
-      Contract.Requires(byteIndex >= 0 && byteIndex <= bytes.Length);
-      Contract.Requires(byteCount >= 0 && byteIndex + byteCount <= bytes.Length);
       Contract.Requires(chars != null);
+      Contract.Requires(byteIndex >= 0 && byteIndex <= bytes.Length);
+      Contract.Requires(byteCount >= 0 && byteCount <= bytes.Length - byteIndex);
       Contract.Requires(charIndex >= 0 && charIndex <= chars.Length);
 
       Contract.Ensures(Contract.Result<int>() >= 0);
@@ -217,7 +217,7 @@ namespace System.Text
     {
       Contract.Requires(bytes != null);
       Contract.Requires(index >= 0 && index <= bytes.Length);
-      Contract.Requires(count >= 0 && index + count <= bytes.Length);
+      Contract.Requires(count >= 0 && count <= bytes.Length - index);
       Contract.Ensures(Contract.Result<char[]>() != null);
 
       return default(char[]);
@@ -235,7 +235,7 @@ namespace System.Text
     {
       Contract.Requires(bytes != null);
       Contract.Requires(index >= 0 && index <= bytes.Length);
-      Contract.Requires(count >= 0 && index + count <= bytes.Length);
+      Contract.Requires(count >= 0 && count <= bytes.Length - index);
       Contract.Ensures(Contract.Result<int>() >= 0);
 
       return default(int);
@@ -251,9 +251,9 @@ namespace System.Text
     public virtual int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex)
     {
       Contract.Requires(s != null);
-      Contract.Requires(charIndex >= 0 && charIndex <= s.Length);
-      Contract.Requires(charCount >= 0 && charIndex + charCount <= s.Length);
       Contract.Requires(bytes != null);
+      Contract.Requires(charIndex >= 0 && charIndex <= s.Length);
+      Contract.Requires(charCount >= 0 && charCount <= s.Length - charIndex);
       Contract.Requires(byteIndex >= 0 && byteIndex <= bytes.Length);
 
       Contract.Ensures(Contract.Result<int>() >= 0);
@@ -271,9 +271,9 @@ namespace System.Text
     public virtual int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
     {
       Contract.Requires(chars != null);
-      Contract.Requires(charIndex >= 0 && charIndex <= chars.Length);
-      Contract.Requires(charCount >= 0 && charIndex + charCount <= chars.Length);
       Contract.Requires(bytes != null);
+      Contract.Requires(charIndex >= 0 && charIndex <= chars.Length);
+      Contract.Requires(charCount >= 0 && charCount <= chars.Length - charIndex);
       Contract.Requires(byteIndex >= 0 && byteIndex <= bytes.Length);
 
       Contract.Ensures(Contract.Result<int>() >= 0);
@@ -285,7 +285,7 @@ namespace System.Text
     {
       Contract.Requires(chars != null);
       Contract.Requires(index >= 0 && index <= chars.Length);
-      Contract.Requires(count >= 0 && index + count <= chars.Length);
+      Contract.Requires(count >= 0 && count <= chars.Length - index);
       Contract.Ensures(Contract.Result<byte[]>() != null);
 
       return default(byte[]);
@@ -303,7 +303,7 @@ namespace System.Text
     {
       Contract.Requires(chars != null);
       Contract.Requires(index >= 0 && index <= chars.Length);
-      Contract.Requires(count >= 0 && index + count <= chars.Length);
+      Contract.Requires(count >= 0 && count <= chars.Length - index);
       Contract.Ensures(Contract.Result<int>() >= 0);
 
       return default(int);
@@ -354,7 +354,7 @@ namespace System.Text
       Contract.Requires(dstEncoding != null);
       Contract.Requires(bytes != null);
       Contract.Requires(index >= 0 && index <= bytes.Length);
-      Contract.Requires(count >= 0 && index + count <= bytes.Length);
+      Contract.Requires(count >= 0 && count <= bytes.Length - index);
       Contract.Ensures(Contract.Result<byte[]>() != null);
       return default(byte[]);
     }


### PR DESCRIPTION
The intent is to comply with the public documentation for `System.Text.Encoding` as well as what existing implementations actually do.

As this class is abstract and CC doesn't allow adding preconditions in overrides, this helps those who implement encodings (especially for cases where the precondition is entirely missing but the postcondition is present, like `GetMaxByteCount` and `GetMaxCharCount`).