### PR TITLE
Fixed typo: undestand -> understand

### DIFF
--- a/Microsoft.Research/ManagedContractsVSPropertyPane/PropertyPane.resx
+++ b/Microsoft.Research/ManagedContractsVSPropertyPane/PropertyPane.resx
@@ -943,7 +943,7 @@
     <value>91</value>
   </data>
   <data name="linkUnderstandingTheStaticChecker.Text" xml:space="preserve">
-    <value>Undestanding the static checker</value>
+    <value>Understanding the static checker</value>
   </data>
   <data name="&gt;&gt;linkUnderstandingTheStaticChecker.Name" xml:space="preserve">
     <value>linkUnderstandingTheStaticChecker</value>

--- a/Microsoft.Research/RegressionTest/ClousotTests/Sources/FrameworkTests/StringBuilder_Vance.cs
+++ b/Microsoft.Research/RegressionTest/ClousotTests/Sources/FrameworkTests/StringBuilder_Vance.cs
@@ -1043,7 +1043,7 @@ namespace MyStringBuilder
     // Appends all of the characters in value to the current instance.
     unsafe public StringBuilder Append(char[] value)
     {
-      // F: Split the test in two tests, as Clousot does not undestand it yet
+      // F: Split the test in two tests, as Clousot does not understand it yet
       // Begin Old
       // if (null != value && value.Length > 0)
       // End Old


### PR DESCRIPTION
This typo bothered me, so I fixed it. Also, reported in #397 (but not by me).