### PR TITLE
Replaced "did you meant" with "did you mean".

### DIFF
--- a/Microsoft.Research/Analyzers/Inference/CodeFixesInference.cs
+++ b/Microsoft.Research/Analyzers/Inference/CodeFixesInference.cs
@@ -1657,7 +1657,7 @@ namespace Microsoft.Research.CodeAnalysis
 
       public override string SuggestMessage()
       {
-        return string.Format("Did you meant {1} instead of {0}?", this.OriginalExp, this.FixedExp);
+        return string.Format("Did you mean {1} instead of {0}?", this.OriginalExp, this.FixedExp);
       }
 
       public override string SuggestCode()
@@ -1688,7 +1688,7 @@ namespace Microsoft.Research.CodeAnalysis
 
       public override string SuggestMessage()
       {
-        return string.Format("Possible off-by one: did you meant indexing with {1} instead of {0}?", this.OriginalExp, this.FixedExp);
+        return string.Format("Possible off-by one: did you mean indexing with {1} instead of {0}?", this.OriginalExp, this.FixedExp);
       }
 
       public override string SuggestCode()
@@ -1698,7 +1698,7 @@ namespace Microsoft.Research.CodeAnalysis
 
       public override string GetMessageForSourceObligation()
       {
-        return string.Format("Did you meant {1} instead of {0}?", this.OriginalExp, this.FixedExp);
+        return string.Format("Did you mean {1} instead of {0}?", this.OriginalExp, this.FixedExp);
       }
       
       public override CodeFixKind Kind

--- a/Microsoft.Research/RegressionTest/ClousotTests/Sources/CodeFixes/CodeFixes.cs
+++ b/Microsoft.Research/RegressionTest/ClousotTests/Sources/CodeFixes/CodeFixes.cs
@@ -470,14 +470,14 @@ namespace CodeFixes
   {    
 
     [ClousotRegressionTest]
-    [RegressionOutcome(Outcome=ProofOutcome.False,Message="Array access IS above the upper bound. Did you meant 0 instead of 1? ",PrimaryILOffset=21,MethodILOffset=0)]
+    [RegressionOutcome(Outcome=ProofOutcome.False,Message="Array access IS above the upper bound. Did you mean 0 instead of 1? ",PrimaryILOffset=21,MethodILOffset=0)]
     [RegressionOutcome("Contract.Ensures(Contract.Result<System.String>() != null);")]
 #if SHORTCODEFIXES
     [RegressionOutcome("0")]
     [RegressionOutcome("2")]
 #else
     [RegressionOutcome("Consider initializing the array with a value larger than 1. Fix: 2")]
-    [RegressionOutcome("Possible off-by one: did you meant indexing with 0 instead of 1?. Fix: 0")]
+    [RegressionOutcome("Possible off-by one: did you mean indexing with 0 instead of 1?. Fix: 0")]
  #endif
     public static string GetString(string key)    
     {
@@ -1154,7 +1154,7 @@ namespace CodeFixes
     }
 
     [ClousotRegressionTest]
-    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you meant index - 1 instead of index? ",PrimaryILOffset=28,MethodILOffset=0)]
+    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you mean index - 1 instead of index? ",PrimaryILOffset=28,MethodILOffset=0)]
     [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Possible use of a null array 'b'",PrimaryILOffset=14,MethodILOffset=0)]
     [RegressionOutcome("Contract.Requires(b != null);")]
     [RegressionOutcome("Contract.Requires(index < b.Length);")]
@@ -1162,7 +1162,7 @@ namespace CodeFixes
 #if SHORTCODEFIXES
     [RegressionOutcome("index - 1")]
 #else         
-    [RegressionOutcome("Possible off-by one: did you meant indexing with index - 1 instead of index?. Fix: index - 1")]
+    [RegressionOutcome("Possible off-by one: did you mean indexing with index - 1 instead of index?. Fix: index - 1")]
 #endif
     public bool Simple_Ok(bool[] b, int index)
     {
@@ -1180,14 +1180,14 @@ namespace CodeFixes
 
     [ClousotRegressionTest]
 #if SHORTCODEFIXES
-    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you meant 0 instead of 1? Or, Maybe the guard a.Length > 0 is too weak? ",PrimaryILOffset=21,MethodILOffset=0)]
+    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you mean 0 instead of 1? Or, Maybe the guard a.Length > 0 is too weak? ",PrimaryILOffset=21,MethodILOffset=0)]
     [RegressionOutcome("Contract.Requires((a.Length <= 0 || 1 < a.Length));")]
     [RegressionOutcome("0")]
     [RegressionOutcome("a.Length > 1")]
 #else
-    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you meant 0 instead of 1? Or, Maybe the guard a.Length > 0 is too weak? ",PrimaryILOffset=21,MethodILOffset=0)]
+    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you mean 0 instead of 1? Or, Maybe the guard a.Length > 0 is too weak? ",PrimaryILOffset=21,MethodILOffset=0)]
     [RegressionOutcome("Contract.Requires((a.Length <= 0 || 1 < a.Length));")] // makes sense: if a.Length > 0 ==> a.Length > 1
-    [RegressionOutcome("Possible off-by one: did you meant indexing with 0 instead of 1?. Fix: 0")]
+    [RegressionOutcome("Possible off-by one: did you mean indexing with 0 instead of 1?. Fix: 0")]
     [RegressionOutcome("Consider replacing a.Length > 0. Fix: a.Length > 1")]
 #endif    
     public void Arrays(int[] a)

--- a/Microsoft.Research/RegressionTest/ClousotTests/Sources/Inference/Preconditions-Backwards.cs
+++ b/Microsoft.Research/RegressionTest/ClousotTests/Sources/Inference/Preconditions-Backwards.cs
@@ -91,7 +91,7 @@ namespace PreInference
     [RegressionOutcome("Contract.Requires(arr != null);")]
     [RegressionOutcome("Contract.Requires(0 <= k);")]
     [RegressionOutcome("Contract.Requires((k + 2) < arr.Length);")]
-    [RegressionOutcome("Possible off-by one: did you meant indexing with k instead of k + 1?. Fix: k")]
+    [RegressionOutcome("Possible off-by one: did you mean indexing with k instead of k + 1?. Fix: k")]
     public void RedundantWithPostfixIncrement(byte[] arr, int k)
     {
       arr[k] = 1;
@@ -561,7 +561,7 @@ namespace mscorlib
 	[RegressionOutcome("This condition should hold: ((mscorlib.MyAppDomainSetup)info).Value != null. Add an assume, a postcondition to method get_Value, or consider a different initialization. Fix: Add (after) Contract.Assume(((mscorlib.MyAppDomainSetup)info).Value != null);")]
     // When we infer a test strengthening, we check that at least one of the vars in the fix is in the condition. We do not extend this for accesspaths
     //[RegressionOutcome("Consider strengthening the guard. Fix: Add && 1 < info.Value.Length")]
-    [RegressionOutcome("Possible off-by one: did you meant indexing with 0 instead of 1?. Fix: 0")]
+    [RegressionOutcome("Possible off-by one: did you mean indexing with 0 instead of 1?. Fix: 0")]
     private void SetupFusionStore(MyAppDomainSetup info, MyAppDomainSetup oldInfo)
     {
       if (oldInfo == null)
@@ -816,7 +816,7 @@ namespace mscorlib
 //    [RegressionOutcome("Contract.Requires((length + offset) <= str.Length);")] // Now we have a better requires
 
     // This is wrong!!! We should not correct the preconditions for the callers
-	//[RegressionOutcome("Did you meant i <= str.Length instead of i < str.Length?. Fix: i <= str.Length")]
+	//[RegressionOutcome("Did you mean i <= str.Length instead of i < str.Length?. Fix: i <= str.Length")]
 
 	[RegressionOutcome("Contract.Requires((offset >= (length + offset) || (length + offset) <= str.Length));")]
 	[RegressionOutcome("Consider adding the assumption (length + offset) <= str.Length. Fix: Add Contract.Assume((length + offset) <= str.Length);")]

--- a/Microsoft.Research/RegressionTest/ClousotTests/Sources/TestWarningMasking/TestFilteringWithScore.cs
+++ b/Microsoft.Research/RegressionTest/ClousotTests/Sources/TestWarningMasking/TestFilteringWithScore.cs
@@ -529,9 +529,9 @@ namespace RoslynCSharpCompiler
     // We want to mask the array accesses via fields but keep them in the medium warning
     [ClousotRegressionTest]
 #if MEDIUM || FULL
-    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you meant 0 instead of 1? ",PrimaryILOffset=97,MethodILOffset=0)]
-    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you meant 1 instead of 2? ",PrimaryILOffset=105,MethodILOffset=0)]
-    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you meant 0 instead of 1? ",PrimaryILOffset=73,MethodILOffset=0)]
+    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you mean 0 instead of 1? ",PrimaryILOffset=97,MethodILOffset=0)]
+    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you mean 1 instead of 2? ",PrimaryILOffset=105,MethodILOffset=0)]
+    [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. Did you mean 0 instead of 1? ",PrimaryILOffset=73,MethodILOffset=0)]
 #endif
 #if FULL
     [RegressionOutcome(Outcome=ProofOutcome.Top,Message="Array access might be above the upper bound. The static checker determined that the condition '0 < this.nodes.Length' should hold on entry. Nevertheless, the condition may be too strong for the callers. If you think it is ok, add an explicit assumption at entry to document it: Contract.Assume(0 < this.nodes.Length);",PrimaryILOffset=89,MethodILOffset=0)]


### PR DESCRIPTION
The current version reads "Did you meant" in a bunch of places, which isn't proper English and makes Code Contracts look like a work in progress :)

The phrase "Did you mean indexing with x instead of y" still sounds odd, though. Maybe "Did you mean to index with" or "Did you mean index" would work better?