### PR TITLE
For 64-bit assemblies, preserve the imagebase value when rewriting.

### DIFF
--- a/System.Compiler/Metadata.cs
+++ b/System.Compiler/Metadata.cs
@@ -318,7 +318,7 @@ namespace System.Compiler.Metadata{
     internal int   addressOfEntryPoint;
     internal int   baseOfCode;
     internal int   baseOfData;
-    internal long   imageBase;
+    internal ulong imageBase;
     internal int   sectionAlignment;
     internal int   fileAlignment;
     internal ushort majorOperatingSystemVersion;
@@ -365,7 +365,7 @@ namespace System.Compiler.Metadata{
       this.magic = 0x10B;
       this.majorLinkerVersion = 6;
       this.baseOfCode = 0x2000;
-      this.imageBase = 0x400000; //TODO: make this settable
+      this.imageBase = 0x400000;
       this.sectionAlignment = 8192;
       this.fileAlignment = 512;
       this.majorOperatingSystemVersion = 4;
@@ -523,6 +523,8 @@ namespace System.Compiler.Metadata{
     readonly private MemoryCursor/*!*/ cursor;
     internal int entryPointToken;
     internal int fileAlignment;
+    internal ulong baseAddress;
+    internal long sizeOfStackReserve;
     internal ModuleKindFlags moduleKind;
     internal PEKindFlags peKind;
     internal bool TrackDebugData;
@@ -924,6 +926,8 @@ namespace System.Compiler.Metadata{
       this.linkerMajorVersion = ntHeader.majorLinkerVersion;
       this.linkerMinorVersion = ntHeader.minorLinkerVersion;
       this.fileAlignment = ntHeader.fileAlignment;
+      this.baseAddress = ntHeader.imageBase;
+      this.sizeOfStackReserve = ntHeader.sizeOfStackReserve;
       if ((ntHeader.characteristics & 0x2000) != 0)
         this.moduleKind = ModuleKindFlags.DynamicallyLinkedLibrary;
       else
@@ -2058,10 +2062,10 @@ namespace System.Compiler.Metadata{
       header.baseOfCode                  = c.ReadInt32();
       if (header.magic == 0x10B){
         header.baseOfData                = c.ReadInt32();
-        header.imageBase                 = c.ReadInt32();
+        header.imageBase                 = c.ReadUInt32();
       }else{
         header.baseOfData                = 0;
-        header.imageBase                 = c.ReadInt64();
+        header.imageBase                 = c.ReadUInt64();
       }
       header.sectionAlignment            = c.ReadInt32();
       header.fileAlignment               = c.ReadInt32();
@@ -2208,6 +2212,8 @@ namespace System.Compiler.Metadata{
     internal TypeSpecRow[] typeSpecTable;
     internal int entryPointToken;
     internal int fileAlignment;
+    internal ulong baseAddress;
+    internal long sizeOfStackReserve;
     internal ModuleKindFlags moduleKind;
     internal ushort dllCharacteristics;
     internal PEKindFlags peKind;
@@ -3414,9 +3420,9 @@ namespace System.Compiler.Metadata{
           writer.Write(this.sectionHeaders[1].virtualAddress);  //baseOfData
         else
           writer.Write((int)0);
-        writer.Write((int)ntHeader.imageBase);
+        writer.Write((int)this.baseAddress); // imageBase
       }else{
-        writer.Write(ntHeader.imageBase);
+        writer.Write(this.baseAddress); // imageBase
       }
       writer.Write(ntHeader.sectionAlignment);
       writer.Write(this.fileAlignment);
@@ -3435,12 +3441,12 @@ namespace System.Compiler.Metadata{
       writer.Write(ntHeader.subsystem);
       writer.Write(ntHeader.dllCharacteristics);
       if (ntHeader.magic == 0x10B){
-        writer.Write((int)ntHeader.sizeOfStackReserve);
+        writer.Write((int)this.sizeOfStackReserve);
         writer.Write((int)ntHeader.sizeOfStackCommit);
         writer.Write((int)ntHeader.sizeOfHeapReserve);
         writer.Write((int)ntHeader.sizeOfHeapCommit);
       }else{
-        writer.Write(ntHeader.sizeOfStackReserve);
+        writer.Write(this.sizeOfStackReserve);
         writer.Write(ntHeader.sizeOfStackCommit);
         writer.Write(ntHeader.sizeOfHeapReserve);
         writer.Write(ntHeader.sizeOfHeapCommit);

--- a/System.Compiler/Metadata.cs
+++ b/System.Compiler/Metadata.cs
@@ -365,7 +365,7 @@ namespace System.Compiler.Metadata{
       this.magic = 0x10B;
       this.majorLinkerVersion = 6;
       this.baseOfCode = 0x2000;
-      this.imageBase = 0x400000;
+      this.imageBase = 0x400000; //TODO: make this settable
       this.sectionAlignment = 8192;
       this.fileAlignment = 512;
       this.majorOperatingSystemVersion = 4;
@@ -3420,7 +3420,7 @@ namespace System.Compiler.Metadata{
           writer.Write(this.sectionHeaders[1].virtualAddress);  //baseOfData
         else
           writer.Write((int)0);
-        writer.Write((int)this.baseAddress); // imageBase
+        writer.Write((int)ntHeader.imageBase); // don't use the imageBase read in from the input assembly: it creates bad modules.
       }else{
         writer.Write(this.baseAddress); // imageBase
       }

--- a/System.Compiler/Nodes.cs
+++ b/System.Compiler/Nodes.cs
@@ -5452,6 +5452,8 @@ namespace System.Compiler{
     public bool UsePublicKeyTokensForAssemblyReferences = true;
 #endif
     internal int FileAlignment = 512;
+    internal ulong BaseAddress;
+    internal long SizeOfStackReserve;
     internal readonly static object GlobalLock = new object();
 #if !NoWriter
     public bool StripOptionalModifiersFromLocals = true;

--- a/System.Compiler/Reader.cs
+++ b/System.Compiler/Reader.cs
@@ -639,6 +639,8 @@ namespace System.Compiler.Metadata{
       module.reader = this;
       module.DllCharacteristics = this.tables.dllCharacteristics;
       module.FileAlignment = this.tables.fileAlignment;
+      module.BaseAddress = this.tables.baseAddress;
+      module.SizeOfStackReserve = this.tables.sizeOfStackReserve;
       module.HashValue = this.tables.HashValue;
       module.Kind = this.tables.moduleKind;
       module.Location = this.fileName;

--- a/System.Compiler/Writer.cs
+++ b/System.Compiler/Writer.cs
@@ -556,6 +556,8 @@ namespace System.Compiler{
       writer.peKind = module.PEKind;
       writer.TrackDebugData = module.TrackDebugData;
       writer.fileAlignment = module.FileAlignment;
+      writer.baseAddress = module.BaseAddress;
+      writer.sizeOfStackReserve = module.SizeOfStackReserve;
       if (writer.fileAlignment < 512) writer.fileAlignment = 512;
       writer.PublicKey = this.PublicKey;
       writer.SignatureKeyLength = this.SignatureKeyLength;


### PR DESCRIPTION
Up until now, the .imagebase value written into assemblies was 0x400000. This works for 32-bit assemblies, but not for 64-bit assemblies. So I tried to preserve the value read in on an assembly and use that when writing it. This seems to work for 64-bit assemblies, but for some reason can create a bad 32-bit assembly if the input assembly had a value greater than the default. I tried to debug this, but the header values written by CCI1 and CCI2 are different and it isn't clear to me how they are computed. So I left the old behavior for 32-bit assemblies and have the new behavior only for 64-bit assemblies.