### PR TITLE
Fixes for various issues

### DIFF
--- a/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.cs
+++ b/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.cs
@@ -11,6 +11,7 @@
 namespace System.Diagnostics.Contracts
 {
     [AttributeUsage(global::System.AttributeTargets.Assembly)]
+    [ContractVerification(false)]
     internal sealed class ContractDeclarativeAssemblyAttribute : global::System.Attribute
     {
     }

--- a/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.vb
+++ b/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.vb
@@ -5,9 +5,9 @@
 '  This file is included when building a contract declarative assembly
 '  in order to mark it as such for recognition by the tools
 '
-<Assembly: ContractDeclarativeAssemblyAttribute()> 
+<Assembly: ContractDeclarativeAssemblyAttribute()>
 
-<ContractVerification(False)>
+<System.Diagnostics.Contracts.ContractVerification(False)>
 NotInheritable Class ContractDeclarativeAssemblyAttribute
     Inherits Global.System.Attribute
 End Class

--- a/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.vb
+++ b/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.vb
@@ -7,6 +7,7 @@
 '
 <Assembly: ContractDeclarativeAssemblyAttribute()> 
 
+<ContractVerification(False)>
 NotInheritable Class ContractDeclarativeAssemblyAttribute
     Inherits Global.System.Attribute
 End Class

--- a/Microsoft.Research/Contracts/MsCorlib/System.Type.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.Type.cs
@@ -870,6 +870,7 @@ namespace System
     public virtual MethodInfo[] GetMethods(BindingFlags arg0)
     {
       Contract.Ensures(Contract.Result<MethodInfo[]>() != null);
+      Contract.Ensures(Contract.ForAll(Contract.Result<MethodInfo[]>(), el => el != null));
 
       return default(MethodInfo[]);
     }

--- a/Microsoft.Research/Contracts/MsCorlib/System.Type.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.Type.cs
@@ -888,7 +888,7 @@ namespace System
       Contract.Ensures(Contract.Result<MethodInfo[]>() != null);
       Contract.Ensures(Contract.ForAll(Contract.Result<MethodInfo[]>(), el => el != null));
 
-      return default( MethodInfo[]);
+      return default(MethodInfo[]);
     }
 
     [Pure]
@@ -896,7 +896,7 @@ namespace System
     {
       Contract.Requires(name != null);
 
-      return default( MethodInfo);
+      return default(MethodInfo);
     }
 
     [Pure]
@@ -904,7 +904,7 @@ namespace System
     {
       Contract.Requires(name != null);
 
-      return default( MethodInfo);
+      return default(MethodInfo);
     }
 
     [Pure]
@@ -913,7 +913,7 @@ namespace System
       Contract.Requires(name != null);
       Contract.Requires(types != null);
 
-      return default( MethodInfo);
+      return default(MethodInfo);
     }
     //public  MethodInfo GetMethod(string name, Type[] types,  ParameterModifier[] modifiers)
     //{
@@ -942,7 +942,7 @@ namespace System
     {
       Contract.Ensures(Contract.Result< ConstructorInfo[]>() != null);
 
-      return default( ConstructorInfo[]);
+      return default(ConstructorInfo[]);
     }
 
     [Pure]
@@ -951,14 +951,14 @@ namespace System
       Contract.Ensures(Contract.Result< ConstructorInfo[]>() != null);
       Contract.Ensures(Contract.ForAll(Contract.Result<ConstructorInfo[]>(), el => el != null));
 
-      return default( ConstructorInfo[]);
+      return default(ConstructorInfo[]);
     }
 
     [Pure]
     public virtual ConstructorInfo GetConstructor(Type[] types)
     {
 
-      return default( ConstructorInfo);
+      return default(ConstructorInfo);
     }
 
 #if false

--- a/Microsoft.Research/Contracts/System.Core.Contracts/System.Linq.Expressions.Expression.cs
+++ b/Microsoft.Research/Contracts/System.Core.Contracts/System.Linq.Expressions.Expression.cs
@@ -7666,7 +7666,6 @@ namespace System.Linq.Expressions
     {
       Contract.Requires(type != null);
       Contract.Requires(initializers != null);
-      Contract.Requires(initializers.Length >= 1);
       Contract.Ensures(Contract.Result<NewArrayExpression>() != null);
       return default(NewArrayExpression);
     }

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -59,7 +59,18 @@
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
-        </When>        <Otherwise>
+        </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.1'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -70,6 +70,11 @@
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.1'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
         <Otherwise>
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>


### PR DESCRIPTION
Fixes for:

* .NET 4.6.1 in VS2015, .NET 4.6 and 4.6.1 in VS2013 (also PR #359, fixes #339)
* Add missing postcondition to `System.Type.GetMethods(BindingFlags)`. (fixes #414)
* Remove invalid precondition on `System.Linq.Expression.Expression.NewArrayInit` (fixes #424)
* Disable static checking on `ContractDeclarativeAssemblyAttribute` in an attempt to improve performance (see #423).