### PR TITLE
Add a test case and revert changes in reader as it breaks the tests.

### DIFF
--- a/Foxtrot/Tests/RewriterTests/RewriterTest.cs
+++ b/Foxtrot/Tests/RewriterTests/RewriterTest.cs
@@ -1001,6 +1001,17 @@ namespace Tests
                     useBinDir: false,
                     useExe: true,
                     mustSucceed: true);
+                yield return new Options(
+                    sourceFile: @"Foxtrot\Tests\Sources\SystemCompilerReadGenericTypeAttributes.cs",
+                    foxtrotOptions: @"-assemblyMode standard",
+                    useContractReferenceAssemblies: true,
+                    compilerOptions: @"",
+                    references: new[] { @"System.Core.dll" },
+                    libPaths: new[] { @"Microsoft.Research\RegressionTest\ClousotTestHarness\bin\debug" },
+                    compilerCode: "CS",
+                    useBinDir: false,
+                    useExe: true,
+                    mustSucceed: true);
             }
         }
 

--- a/Foxtrot/Tests/Sources/SystemCompilerReadGenericTypeAttributes.cs
+++ b/Foxtrot/Tests/Sources/SystemCompilerReadGenericTypeAttributes.cs
@@ -1,0 +1,89 @@
+// CodeContracts
+// 
+// Copyright (c) Microsoft Corporation
+// 
+// All rights reserved. 
+// 
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Text;
+using System.Threading;
+
+namespace Tests.Sources
+{
+    // a dummy class, just to make the test framework happy 
+    public class Foo
+    {
+        public void Method(params string[] strings)
+        {
+            Contract.Requires(Contract.ForAll(strings, s => s.Length > 0));
+            Console.WriteLine("Method");
+        }
+    } 
+    
+    public class C1
+    {
+    }
+    public class C2
+    {
+    }
+    public class C3
+    {
+    }
+    
+    public interface I1<T1, T2, T3>
+    {
+    }
+    
+    public class A1 : System.Attribute
+    {
+        public A1(Type t)
+        {
+            T = t;
+        }
+        
+        public Type T {get;set;}
+    }
+
+  partial class TestMain
+  {
+    partial void Run()
+    {
+      if (behave)
+      {
+        new Foo().Method("1", "2", "3");
+      }
+      else
+      {
+        new Foo().Method("1", "");
+      }
+    }
+    
+    private interface I2<T1, T2, T3>
+    {
+    }
+    
+    [A1(typeof(I1<C1, C2, C3>))]
+    private class Inner1 : I1<C1, C2, C3>
+    {
+    }
+    
+    [A1(typeof(I2<C1, C2, C3>))]
+    private class Inner2 : I2<C1, C2, C3>
+    {
+    }
+
+    public ContractFailureKind NegativeExpectedKind = ContractFailureKind.Precondition;
+    public string NegativeExpectedCondition = "Contract.ForAll(strings, s => s.Length > 0)";
+  }
+}

--- a/System.Compiler/Reader.cs
+++ b/System.Compiler/Reader.cs
@@ -4259,20 +4259,6 @@ namespace System.Compiler.Metadata{
             this.currentItr++;
             switch (c) {
               case ',':
-                    // A comma may separate a type name from its assembly name or a type argument from
-                    // another type argument.
-                    // If processing non-type argument or a type argument with assembly name,
-                    // process the characters after the comma as an assembly name.
-                    //
-                    // Only continue parsing the string if the next chunk of the string is the name of a type argument.
-                    // If the next character is not a literal, it is not a type argument, so
-                    // end the current identifier by going to done label.
-                    if (this.currentItr < this.typeNameString.Length) {
-                      var next = this.typeNameString[this.currentItr];
-                      if (char.IsWhiteSpace(next) || IsTypeNameReservedChar(next))
-                        goto done;
-                    }
-                    break;
               case '[':
               case ']':
               case '&':


### PR DESCRIPTION
After adding a test case I could not reproduce the issue described in #340, but only found that the reader failed all cases with the changes.