### PR TITLE
Forced AssemblyRef flags to be ECMA compatible when writing output

### DIFF
--- a/System.Compiler/Writer.cs
+++ b/System.Compiler/Writer.cs
@@ -616,6 +616,10 @@ namespace System.Compiler{
           aref.HashValue = null;
           aref.Flags = aref.Flags & ~AssemblyFlags.PublicKey;
         }
+
+        // make sure that written flags are ECMA compatible
+        aref.Flags = aref.Flags & (AssemblyFlags.PublicKey | AssemblyFlags.Retargetable | AssemblyFlags.DisableJITcompileOptimizer | AssemblyFlags.EnableJITcompileTracking);
+
         this.assemblyRefEntries.Add(aref);
         this.assemblyRefIndex[assembly.UniqueKey] = index;
       }


### PR DESCRIPTION
This pull request is related to issue #450 (https://github.com/Microsoft/CodeContracts/issues/450).
My suggested fix is to force the assembly reference flags to be ECMA compatible just before writing the new assembly 