### PR TITLE
Add flag to generate cccheck RSP at build time

### DIFF
--- a/Foxtrot/Driver/Rewriting/EmitAsyncClosure.cs
+++ b/Foxtrot/Driver/Rewriting/EmitAsyncClosure.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Contracts.Foxtrot
             // Mapping between enclosing generic type and closure generic type.
             // This is a simple list not a dictionary, because number of generic arguments is very small.
             // So linear complexity will not harm performance.
-            private List<TypeNodePair> typeParametersMapping = new List<TypeNodePair>();
+            readonly List<TypeNodePair> typeParametersMapping = new List<TypeNodePair>();
 
             public bool IsEmpty { get { return typeParametersMapping.Count == 0; } }
 

--- a/Foxtrot/Driver/Rewriting/PostRewriteChecker.cs
+++ b/Foxtrot/Driver/Rewriting/PostRewriteChecker.cs
@@ -141,10 +141,7 @@ namespace Microsoft.Contracts.Foxtrot
                 methodName.Matches(ContractNodes.EndContractBlockName))
             {
                 string message = string.Format(Resources.Error_ContractNotRewritten_ContractName_MemberName, method.FullName, this.visitedMembers.Peek().FullName);
-                if (this.handleError != null)
-                {
-                    this.handleError(new Error(1080, message, binding.SourceContext));
-                }
+                this.handleError(new Error(1080, message, binding.SourceContext));
             }
         }
         

--- a/Microsoft.Research/DataStructures/OptionParsing.cs
+++ b/Microsoft.Research/DataStructures/OptionParsing.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Research.DataStructures
             return true;
         }
 
-        // Also add '!' as synonim for '=', as cmd.exe performs fuzzy things with '='
+        // Also add '!' as synonym for '=', as cmd.exe performs fuzzy things with '='
         private static readonly char[] equalChars = new char[] { ':', '=', '!' };
         private static readonly char[] quoteChars = new char[] { '\'', '"' };
 

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContractAnalysis.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContractAnalysis.targets
@@ -23,11 +23,11 @@
   <!--=====================================================================
         Running Static Code Analysis
     ======================================================================-->
-
+    
   <Target
     Name="CodeContractsPerformCodeAnalysis"
-    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true'"
-    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsRunCodeAnalysis">
+    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true' or '$(CodeContractsDeferCodeAnalysis)' == 'true'"
+    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsCodeAnalysisWriteRSPFile;CodeContractsRunCodeAnalysis">
   </Target>
 
   <Target
@@ -61,7 +61,7 @@
 
   <Target
     Name="CodeContractsRunCodeAnalysis"
-    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true' and '$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetProjectGuid`))' == '' and '$(BuildingProject)'=='true'"
+    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true' and '$(CodeContractsDeferCodeAnalysis)' != 'true' and '$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetProjectGuid`))' == '' and '$(BuildingProject)'=='true'"
     Inputs="@(CodeContractsCodeAnalysisInput)"
     Outputs="$(CodeContractsCodeAnalysisOutput)"
     >
@@ -101,14 +101,14 @@
         <CodeContractsAnalysisWarning>medium</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </When>
-	 <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='3'">
+     <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='3'">
       <PropertyGroup>
         <CodeContractsAnalysisWarning>full</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-	<CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
+    <CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -129,11 +129,9 @@
   </Choose>
 
   <Target
-    Name="CodeContractsRunCodeAnalysisInternal"
+    Name="CodeContractsCodeAnalysisWriteRSPFile"
     DependsOnTargets="CodeContractsComputeAllLibPaths;EnsureContractReferenceAssemblyOfDependeeProjects;CodeContractsLoadEnvVars"
     >
-    <Message Text="Run Contract Code Analysis on project guid $(ProjectGuid)" Importance="Low"/>
-
     <PropertyGroup>
       <DeclarativeAssemblyDir>@(ContractDeclarativeAssembly->'%(RootDir)')@(ContractDeclarativeAssembly->'%(Directory)')</DeclarativeAssemblyDir>
       <DeclarativeAssemblyPath>@(ContractDeclarativeAssembly->'%(FullPath)')</DeclarativeAssemblyPath>
@@ -160,15 +158,15 @@
         Condition="'$(CodeContractsRedundantAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -check assumptions</CodeContractCodeAnalysisOptions>        
      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsAssertsToContractsCheckBox)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest asserttocontracts</CodeContractCodeAnalysisOptions>        
-		<CodeContractCodeAnalysisOptions
+        <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsRedundantTests)' == 'true'">$(CodeContractCodeAnalysisOptions) -check conditionsvalidity</CodeContractCodeAnalysisOptions>        		
-	  <CodeContractCodeAnalysisOptions
-	    Condition="'$(CodeContractsMissingPublicRequiresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicRequiresAreErrors</CodeContractCodeAnalysisOptions>
-	  <CodeContractCodeAnalysisOptions
-	    Condition="'$(CodeContractsMissingPublicEnsuresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicEnsuresAreErrors</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsMissingPublicRequiresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicRequiresAreErrors</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsMissingPublicEnsuresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicEnsuresAreErrors</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestAssumptionsForCallees)' == 'true'">$(CodeContractCodeAnalysisOptions)  -suggest calleeassumes</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest assumes</CodeContractCodeAnalysisOptions>
     <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestRequires)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest requires</CodeContractCodeAnalysisOptions>
@@ -176,7 +174,7 @@
         Condition="'$(CodeContractsSuggestEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest methodensures -suggest propertyensures</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsNecessaryEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest necessaryensures</CodeContractCodeAnalysisOptions>
-		<CodeContractCodeAnalysisOptions
+        <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestObjectInvariants)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest objectinvariants</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestReadonly)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest readonlyfields</CodeContractCodeAnalysisOptions>
@@ -190,7 +188,7 @@
         Condition="'$(CodeContractsInferObjectInvariants)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer objectinvariants</CodeContractCodeAnalysisOptions>     
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsCacheAnalysisResults)' == 'true'">$(CodeContractCodeAnalysisOptions) -cache</CodeContractCodeAnalysisOptions>
- 	<CodeContractCodeAnalysisOptions
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSkipAnalysisIfCannotConnectToCache)' == 'true'">$(CodeContractCodeAnalysisOptions) -forcecacheserver=true</CodeContractCodeAnalysisOptions>
      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsFailBuildOnWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -failOnWarnings</CodeContractCodeAnalysisOptions>
@@ -230,10 +228,18 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(DeclarativeAssemblyDir)$(ProjectName)cccheck.rsp"
+      File="$(DeclarativeAssemblyDir)$(AssemblyName).cccheck.rsp"
       Lines="@(_CodeContractsCCCheckArgumentLines, ';')"
       Overwrite="true"
       />
+      
+  </Target>
+    
+  <Target
+      Name="CodeContractsRunCodeAnalysisInternal"
+      DependsOnTargets="CodeContractsCodeAnalysisWriteRSPFile">
+      
+    <Message Text="Run Contract Code Analysis on project guid $(ProjectGuid)" Importance="Low"/>
 
     <CodeContractsAnalysis
       Verbose="false"
@@ -246,7 +252,7 @@
       KeepErrors="$(CodeContractsFailBuildOnWarnings)"
       OutputPrefix="CodeContracts: "
       Command='$(CodeContractRunCodeAnalysisCommand)'
-      CommandOptions='"@$(ProjectName)cccheck.rsp"'
+      CommandOptions='"@$(AssemblyName).cccheck.rsp"'
       />
   </Target>
 

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -257,14 +257,14 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccrewrite.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrewrite.rsp"
       Lines="@(_CodeContractsCCRewriteArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
        WorkingDirectory="$(IntermediateOutputPath)"
-       Command='"$(CodeContractRewriteCommand)" "@$(ProjectName)ccrewrite.rsp"'
+       Command='"$(CodeContractRewriteCommand)" "@$(AssemblyName).ccrewrite.rsp"'
        />
 
     <CallTarget Targets="CodeContractReSign"/>
@@ -291,7 +291,7 @@
     <PropertyGroup>
       <!-- SN is in the Framework SDK tools path, but TargetFrameworkSDKToolsDirectory isn't always available  -->
       <CodeContractsSnExe Condition=" '$(TargetFrameworkSDKToolsDirectory)' != '' ">$(TargetFrameworkSDKToolsDirectory)sn.exe</CodeContractsSnExe>
-      <CodeContractsSnExe Condition=" '$(TargetFrameworkSDKToolsDirectory)' == '' ">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\sn.exe</CodeContractsSnExe>
+			<CodeContractsSnExe Condition=" '$(TargetFrameworkSDKToolsDirectory)' == '' ">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\sn.exe</CodeContractsSnExe>
     </PropertyGroup>
     <Exec
        Condition="'$(KeyOriginatorFile)' != ''"   
@@ -348,19 +348,19 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"
       Lines="@(_CodeContractsCCRefGenArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
        Condition="Exists('@(ContractDeclarativeAssembly)')"
-       Command='"$(CodeContractsCCRefgenCommand)" "@$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"'
+       Command='"$(CodeContractsCCRefgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"'
        />
     <ItemGroup
        Condition="Exists('@(ContractReferenceAssemblyAbsolute)')">
       <FileWrites
-         Include="@(ContractReferenceAssemblies);$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"/>
+         Include="@(ContractReferenceAssemblies);$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"/>
     </ItemGroup>
 
   </Target>
@@ -586,7 +586,7 @@
   <Target
      Name="CodeContractsComputeAllLibPaths"
      DependsOnTargets="CodeContractsComputeReferencedLibPaths"
-	 >
+     >
     <Message Text="CodeContractsComputeAllLibPaths" Importance="low"/>
     <RemoveDuplicates
        Inputs="@(CodeContractsBuildLibPaths);$(CodeContractsReferenceAssemblyLibPath);$(CodeContractsLibPaths)">
@@ -634,13 +634,13 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccdocgen.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"
       Lines="@(_CodeContractsCCDocGenArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
-       Command='"$(CodeContractsCCdocgenCommand)" "@$(IntermediateOutputPath)$(ProjectName)ccdocgen.rsp"' 
+       Command='"$(CodeContractsCCdocgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"' 
        />
   </Target>
 

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContractAnalysis.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContractAnalysis.targets
@@ -23,11 +23,11 @@
   <!--=====================================================================
         Running Static Code Analysis
     ======================================================================-->
-
+    
   <Target
     Name="CodeContractsPerformCodeAnalysis"
     Condition="'$(CodeContractsRunCodeAnalysis)' == 'true'"
-    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsRunCodeAnalysis">
+    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsCodeAnalysisWriteRSPFile;CodeContractsRunCodeAnalysis">
   </Target>
 
   <Target
@@ -61,7 +61,7 @@
 
   <Target
     Name="CodeContractsRunCodeAnalysis"
-    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true' and '$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetProjectGuid`))' == '' and '$(BuildingProject)'=='true'"
+    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true' and '$(CodeContractsDeferCodeAnalysis)' != 'true' and '$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetProjectGuid`))' == '' and '$(BuildingProject)'=='true'"
     Inputs="@(CodeContractsCodeAnalysisInput)"
     Outputs="$(CodeContractsCodeAnalysisOutput)"
     >
@@ -101,14 +101,14 @@
         <CodeContractsAnalysisWarning>medium</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </When>
-	 <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='3'">
+     <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='3'">
       <PropertyGroup>
         <CodeContractsAnalysisWarning>full</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-	<CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
+    <CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -129,11 +129,9 @@
   </Choose>
 
   <Target
-    Name="CodeContractsRunCodeAnalysisInternal"
+    Name="CodeContractsCodeAnalysisWriteRSPFile"
     DependsOnTargets="CodeContractsComputeAllLibPaths;EnsureContractReferenceAssemblyOfDependeeProjects;CodeContractsLoadEnvVars"
     >
-    <Message Text="Run Contract Code Analysis on project guid $(ProjectGuid)" Importance="Low"/>
-
     <PropertyGroup>
       <DeclarativeAssemblyDir>@(ContractDeclarativeAssembly->'%(RootDir)')@(ContractDeclarativeAssembly->'%(Directory)')</DeclarativeAssemblyDir>
       <DeclarativeAssemblyPath>@(ContractDeclarativeAssembly->'%(FullPath)')</DeclarativeAssemblyPath>
@@ -160,15 +158,15 @@
         Condition="'$(CodeContractsRedundantAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -check assumptions</CodeContractCodeAnalysisOptions>        
      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsAssertsToContractsCheckBox)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest asserttocontracts</CodeContractCodeAnalysisOptions>        
-		<CodeContractCodeAnalysisOptions
+        <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsRedundantTests)' == 'true'">$(CodeContractCodeAnalysisOptions) -check conditionsvalidity</CodeContractCodeAnalysisOptions>        		
-	  <CodeContractCodeAnalysisOptions
-	    Condition="'$(CodeContractsMissingPublicRequiresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicRequiresAreErrors</CodeContractCodeAnalysisOptions>
-	  <CodeContractCodeAnalysisOptions
-	    Condition="'$(CodeContractsMissingPublicEnsuresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicEnsuresAreErrors</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsMissingPublicRequiresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicRequiresAreErrors</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsMissingPublicEnsuresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicEnsuresAreErrors</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestAssumptionsForCallees)' == 'true'">$(CodeContractCodeAnalysisOptions)  -suggest calleeassumes</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest assumes</CodeContractCodeAnalysisOptions>
     <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestRequires)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest requires</CodeContractCodeAnalysisOptions>
@@ -176,7 +174,7 @@
         Condition="'$(CodeContractsSuggestEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest methodensures -suggest propertyensures</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsNecessaryEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest necessaryensures</CodeContractCodeAnalysisOptions>
-		<CodeContractCodeAnalysisOptions
+        <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestObjectInvariants)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest objectinvariants</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestReadonly)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest readonlyfields</CodeContractCodeAnalysisOptions>
@@ -190,7 +188,7 @@
         Condition="'$(CodeContractsInferObjectInvariants)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer objectinvariants</CodeContractCodeAnalysisOptions>     
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsCacheAnalysisResults)' == 'true'">$(CodeContractCodeAnalysisOptions) -cache</CodeContractCodeAnalysisOptions>
- 	<CodeContractCodeAnalysisOptions
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSkipAnalysisIfCannotConnectToCache)' == 'true'">$(CodeContractCodeAnalysisOptions) -forcecacheserver=true</CodeContractCodeAnalysisOptions>
      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsFailBuildOnWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -failOnWarnings</CodeContractCodeAnalysisOptions>
@@ -230,10 +228,18 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(DeclarativeAssemblyDir)$(ProjectName)cccheck.rsp"
+      File="$(DeclarativeAssemblyDir)$(AssemblyName).cccheck.rsp"
       Lines="@(_CodeContractsCCCheckArgumentLines, ';')"
       Overwrite="true"
       />
+      
+  </Target>
+    
+  <Target
+      Name="CodeContractsRunCodeAnalysisInternal"
+      DependsOnTargets="CodeContractsCodeAnalysisWriteRSPFile">
+      
+    <Message Text="Run Contract Code Analysis on project guid $(ProjectGuid)" Importance="Low"/>
 
     <CodeContractsAnalysis
       Verbose="false"
@@ -246,7 +252,7 @@
       KeepErrors="$(CodeContractsFailBuildOnWarnings)"
       OutputPrefix="CodeContracts: "
       Command='$(CodeContractRunCodeAnalysisCommand)'
-      CommandOptions='"@$(ProjectName)cccheck.rsp"'
+      CommandOptions='"@$(AssemblyName).cccheck.rsp"'
       />
   </Target>
 

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -262,14 +262,14 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccrewrite.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrewrite.rsp"
       Lines="@(_CodeContractsCCRewriteArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
        WorkingDirectory="$(IntermediateOutputPath)"
-       Command='"$(CodeContractRewriteCommand)" "@$(ProjectName)ccrewrite.rsp"'
+       Command='"$(CodeContractRewriteCommand)" "@$(AssemblyName).ccrewrite.rsp"'
        />
 
     <CallTarget Targets="CodeContractReSign"/>
@@ -353,19 +353,19 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"
       Lines="@(_CodeContractsCCRefGenArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
        Condition="Exists('@(ContractDeclarativeAssembly)')"
-       Command='"$(CodeContractsCCRefgenCommand)" "@$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"'
+       Command='"$(CodeContractsCCRefgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"'
        />
     <ItemGroup
        Condition="Exists('@(ContractReferenceAssemblyAbsolute)')">
       <FileWrites
-         Include="@(ContractReferenceAssemblies);$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"/>
+         Include="@(ContractReferenceAssemblies);$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"/>
     </ItemGroup>
 
   </Target>
@@ -591,7 +591,7 @@
   <Target
      Name="CodeContractsComputeAllLibPaths"
      DependsOnTargets="CodeContractsComputeReferencedLibPaths"
-	 >
+     >
     <Message Text="CodeContractsComputeAllLibPaths" Importance="low"/>
     <RemoveDuplicates
        Inputs="@(CodeContractsBuildLibPaths);$(CodeContractsReferenceAssemblyLibPath);$(CodeContractsLibPaths)">
@@ -639,13 +639,13 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccdocgen.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"
       Lines="@(_CodeContractsCCDocGenArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
-       Command='"$(CodeContractsCCdocgenCommand)" "@$(IntermediateOutputPath)$(ProjectName)ccdocgen.rsp"' 
+       Command='"$(CodeContractsCCdocgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"' 
        />
   </Target>
 

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v3.5/Microsoft.CodeContractAnalysis.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v3.5/Microsoft.CodeContractAnalysis.targets
@@ -23,11 +23,11 @@
   <!--=====================================================================
         Running Static Code Analysis
     ======================================================================-->
-
+    
   <Target
     Name="CodeContractsPerformCodeAnalysis"
     Condition="'$(CodeContractsRunCodeAnalysis)' == 'true'"
-    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsRunCodeAnalysis">
+    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsCodeAnalysisWriteRSPFile;CodeContractsRunCodeAnalysis">
   </Target>
 
   <Target
@@ -45,7 +45,7 @@
 
   <Target
     Name="CodeContractsRunCodeAnalysis"
-    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true'"
+    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true' and '$(CodeContractsDeferCodeAnalysis)' != 'true'"
     Inputs="@(CodeContractsCodeAnalysisInput)"
     Outputs="$(CodeContractsCodeAnalysisOutput)"
     >
@@ -85,14 +85,14 @@
         <CodeContractsAnalysisWarning>medium</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </When>
-	 <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='3'">
+     <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='3'">
       <PropertyGroup>
         <CodeContractsAnalysisWarning>full</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-	<CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
+    <CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -113,11 +113,9 @@
   </Choose>
 
   <Target
-    Name="CodeContractsRunCodeAnalysisInternal"
+    Name="CodeContractsCodeAnalysisWriteRSPFile"
     DependsOnTargets="CodeContractsComputeAllLibPaths;EnsureContractReferenceAssemblyOfDependeeProjects"
     >
-    <Message Text="Run Contract Code Analysis" Importance="Low"/>
-
     <PropertyGroup>
       <DeclarativeAssemblyDir>@(ContractDeclarativeAssembly->'%(RootDir)')@(ContractDeclarativeAssembly->'%(Directory)')</DeclarativeAssemblyDir>
       <DeclarativeAssemblyPath>@(ContractDeclarativeAssembly->'%(FullPath)')</DeclarativeAssemblyPath>
@@ -142,41 +140,41 @@
         Condition="'$(CodeContractsEnumObligations)' == 'true'">$(CodeContractCodeAnalysisOptions) -enum</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsRedundantAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -check assumptions</CodeContractCodeAnalysisOptions>        
-    <CodeContractCodeAnalysisOptions
-        Condition="'$(CodeContractsRedundantTests)' == 'true'">$(CodeContractCodeAnalysisOptions) -check conditionsvalidity</CodeContractCodeAnalysisOptions>        		
-	<CodeContractCodeAnalysisOptions
-	    Condition="'$(CodeContractsMissingPublicRequiresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicRequiresAreErrors</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
-	    Condition="'$(CodeContractsMissingPublicEnsuresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicEnsuresAreErrors</CodeContractCodeAnalysisOptions>
      <CodeContractCodeAnalysisOptions
-        Condition="'$(CodeContractsAssertsToContractsCheckBox)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest asserttocontracts</CodeContractCodeAnalysisOptions>        
-	<CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsRedundantTests)' == 'true'">$(CodeContractCodeAnalysisOptions) -check conditionsvalidity</CodeContractCodeAnalysisOptions>        		
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsMissingPublicRequiresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicRequiresAreErrors</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsMissingPublicEnsuresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicEnsuresAreErrors</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsAssertsToContractsCheckBox)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest asserttocontracts</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest assumes</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestAssumptionsForCallees)' == 'true'">$(CodeContractCodeAnalysisOptions)  -suggest calleeassumes</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestRequires)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest requires</CodeContractCodeAnalysisOptions>
     <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest methodensures -suggest propertyensures</CodeContractCodeAnalysisOptions>
-    <CodeContractCodeAnalysisOptions
+      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsNecessaryEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest necessaryensures</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
+        <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestObjectInvariants)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest objectinvariants</CodeContractCodeAnalysisOptions>
-    <CodeContractCodeAnalysisOptions
+      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsInferRequires)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer requires</CodeContractCodeAnalysisOptions>
-    <CodeContractCodeAnalysisOptions
+      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsInferEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer methodensures</CodeContractCodeAnalysisOptions>
-    <CodeContractCodeAnalysisOptions
+      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsInferEnsuresAutoProperties)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer autopropertiesensures</CodeContractCodeAnalysisOptions>
     <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsInferObjectInvariants)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer objectinvariants</CodeContractCodeAnalysisOptions>     
-    <CodeContractCodeAnalysisOptions
-        Condition="'$(CodeContractsSuggestReadonly)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest readonlyfields </CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
-        Condition="'$(CodeContractsCacheAnalysisResults)' == 'true'">$(CodeContractCodeAnalysisOptions) -cache</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
-        Condition="'$(CodeContractsSkipAnalysisIfCannotConnectToCache)' == 'true'">$(CodeContractCodeAnalysisOptions) -forcecacheserver=true</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestReadonly)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest readonlyfields </CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsCacheAnalysisResults)' == 'true'">$(CodeContractCodeAnalysisOptions) -cache</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSkipAnalysisIfCannotConnectToCache)' == 'true'">$(CodeContractCodeAnalysisOptions) -forcecacheserver=true</CodeContractCodeAnalysisOptions>
+     <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsFailBuildOnWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -failOnWarnings</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsCacheDirectory)' != ''">$(CodeContractCodeAnalysisOptions) -cacheFileDirectory "$(CodeContractsCacheDirectory)"</CodeContractCodeAnalysisOptions>
@@ -190,7 +188,7 @@
         Condition="'$(CodeContractsTargetType)' != ''">$(CodeContractCodeAnalysisOptions) -typeNameSelect:$(CodeContractsTargetType)</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsBeingOptimisticOnExternal)' == 'false'">$(CodeContractCodeAnalysisOptions)  -lowScoreForExternal=false</CodeContractCodeAnalysisOptions>
-		<CodeContractCodeAnalysisOptions
+     <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsTargetNamespace)' != ''">$(CodeContractCodeAnalysisOptions) -namespaceSelect:$(CodeContractsTargetNamespace)</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsUseBaseLine)' == 'true' and '$(CodeContractsBaseLineFile)' != ''">$(CodeContractCodeAnalysisOptions) -baseline "$(CodeContractsBaseLineFile)"</CodeContractCodeAnalysisOptions>
@@ -214,10 +212,18 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(DeclarativeAssemblyDir)$(ProjectName)cccheck.rsp"
+      File="$(DeclarativeAssemblyDir)$(AssemblyName).cccheck.rsp"
       Lines="@(_CodeContractsCCCheckArgumentLines, ';')"
       Overwrite="true"
       />
+      
+  </Target>
+    
+  <Target
+      Name="CodeContractsRunCodeAnalysisInternal"
+      DependsOnTargets="CodeContractsCodeAnalysisWriteRSPFile">
+      
+    <Message Text="Run Contract Code Analysis on project guid $(ProjectGuid)" Importance="Low"/>
 
     <CodeContractsAnalysis
       Verbose="false"
@@ -230,7 +236,7 @@
       KeepErrors="$(CodeContractsFailBuildOnWarnings)"
       OutputPrefix="CodeContracts: "
       Command='$(CodeContractRunCodeAnalysisCommand)'
-      CommandOptions='"@$(ProjectName)cccheck.rsp"'
+      CommandOptions='"@$(AssemblyName).cccheck.rsp"'
       />
   </Target>
 

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v3.5/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v3.5/Microsoft.CodeContracts.targets
@@ -16,14 +16,14 @@
 
   <Choose>
     <When Condition="'$(TargetFrameworkIdentifier)' == 'Silverlight'">
-      <PropertyGroup>
-        <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\Silverlight\v3.0</CodeContractsReferenceAssemblyLibPath>
-      </PropertyGroup>
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\Silverlight\v3.0</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
     </When>
     <Otherwise>
-      <PropertyGroup>
-        <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
-      </PropertyGroup>
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
     </Otherwise>
   </Choose>
 
@@ -205,14 +205,14 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccrewrite.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrewrite.rsp"
       Lines="@(_CodeContractsCCRewriteArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
        WorkingDirectory="$(IntermediateOutputPath)"
-       Command='"$(CodeContractRewriteCommand)" "@$(ProjectName)ccrewrite.rsp"'
+       Command='"$(CodeContractRewriteCommand)" "@$(AssemblyName).ccrewrite.rsp"'
        />
 
     <CallTarget Targets="CodeContractReSign"/>
@@ -240,10 +240,10 @@
       <CodeContractsSnExe>"$(CodeContractsSdkPath)Bin\sn.exe"</CodeContractsSnExe>
     </PropertyGroup>
     <Exec
-       Condition="'$(KeyOriginatorFile)' != ''"   
+       Condition="'$(KeyOriginatorFile)' != ''"
        Command='$(CodeContractsSnExe) /R "@(IntermediateAssembly)" "$(KeyOriginatorFile)"' />
     <Exec
-       Condition="'$(KeyContainerName)' != ''"   
+       Condition="'$(KeyContainerName)' != ''"
        Command='$(CodeContractsSnExe) /Rc "@(IntermediateAssembly)" "$(KeyContainerName)"' />
   </Target>
   
@@ -294,19 +294,19 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"
       Lines="@(_CodeContractsCCRefGenArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
        Condition="Exists('@(ContractDeclarativeAssembly)')"
-       Command='"$(CodeContractsCCRefgenCommand)" "@$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"'
+       Command='"$(CodeContractsCCRefgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"'
        />
     <ItemGroup
        Condition="Exists('@(ContractReferenceAssemblyAbsolute)')">
       <FileWrites
-         Include="@(ContractReferenceAssemblies);$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"/>
+         Include="@(ContractReferenceAssemblies);$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"/>
     </ItemGroup>
 
   </Target>
@@ -531,7 +531,7 @@
   <Target
      Name="CodeContractsComputeAllLibPaths"
      DependsOnTargets="CodeContractsComputeReferencedLibPaths"
-	 >
+     >
     <Message Text="CodeContractsComputeAllLibPaths" Importance="low"/>
     <RemoveDuplicates
        Inputs="@(CodeContractsBuildLibPaths);$(CodeContractsReferenceAssemblyLibPath);$(CodeContractsLibPaths)">
@@ -579,13 +579,13 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccdocgen.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"
       Lines="@(_CodeContractsCCDocGenArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
-       Command='"$(CodeContractsCCdocgenCommand)" "@$(IntermediateOutputPath)$(ProjectName)ccdocgen.rsp"' 
+       Command='"$(CodeContractsCCdocgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"' 
        />
   </Target>
 

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v4.0/Microsoft.CodeContractAnalysis.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v4.0/Microsoft.CodeContractAnalysis.targets
@@ -23,11 +23,11 @@
   <!--=====================================================================
         Running Static Code Analysis
     ======================================================================-->
-
+    
   <Target
     Name="CodeContractsPerformCodeAnalysis"
     Condition="'$(CodeContractsRunCodeAnalysis)' == 'true'"
-    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsRunCodeAnalysis">
+    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsCodeAnalysisWriteRSPFile;CodeContractsRunCodeAnalysis">
   </Target>
 
   <Target
@@ -61,7 +61,7 @@
 
   <Target
     Name="CodeContractsRunCodeAnalysis"
-    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true' and '$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetProjectGuid`))' == '' and '$(BuildingProject)'=='true'"
+    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true' and '$(CodeContractsDeferCodeAnalysis)' != 'true' and '$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetProjectGuid`))' == '' and '$(BuildingProject)'=='true'"
     Inputs="@(CodeContractsCodeAnalysisInput)"
     Outputs="$(CodeContractsCodeAnalysisOutput)"
     >
@@ -101,14 +101,14 @@
         <CodeContractsAnalysisWarning>medium</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </When>
-	 <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='3'">
+     <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='3'">
       <PropertyGroup>
         <CodeContractsAnalysisWarning>full</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-	<CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
+    <CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -129,11 +129,9 @@
   </Choose>
 
   <Target
-    Name="CodeContractsRunCodeAnalysisInternal"
+    Name="CodeContractsCodeAnalysisWriteRSPFile"
     DependsOnTargets="CodeContractsComputeAllLibPaths;EnsureContractReferenceAssemblyOfDependeeProjects;CodeContractsLoadEnvVars"
     >
-    <Message Text="Run Contract Code Analysis on project guid $(ProjectGuid)" Importance="Low"/>
-
     <PropertyGroup>
       <DeclarativeAssemblyDir>@(ContractDeclarativeAssembly->'%(RootDir)')@(ContractDeclarativeAssembly->'%(Directory)')</DeclarativeAssemblyDir>
       <DeclarativeAssemblyPath>@(ContractDeclarativeAssembly->'%(FullPath)')</DeclarativeAssemblyPath>
@@ -160,25 +158,25 @@
         Condition="'$(CodeContractsRedundantAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -check assumptions</CodeContractCodeAnalysisOptions>        
      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsAssertsToContractsCheckBox)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest asserttocontracts</CodeContractCodeAnalysisOptions>        
-    	<CodeContractCodeAnalysisOptions
+        <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsRedundantTests)' == 'true'">$(CodeContractCodeAnalysisOptions) -check conditionsvalidity</CodeContractCodeAnalysisOptions>        		
-	  <CodeContractCodeAnalysisOptions
-	    Condition="'$(CodeContractsMissingPublicRequiresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicRequiresAreErrors</CodeContractCodeAnalysisOptions>
-	  <CodeContractCodeAnalysisOptions
-	    Condition="'$(CodeContractsMissingPublicEnsuresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicEnsuresAreErrors</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
-        Condition="'$(CodeContractsSuggestAssumptionsForCallees)' == 'true'">$(CodeContractCodeAnalysisOptions)  -suggest calleeassumes</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
-        Condition="'$(CodeContractsSuggestAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest assumes</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
-        Condition="'$(CodeContractsSuggestRequires)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest requires</CodeContractCodeAnalysisOptions>
+        Condition="'$(CodeContractsMissingPublicRequiresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicRequiresAreErrors</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
-        Condition="'$(CodeContractsSuggestEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest methodensures -suggest propertyensures</CodeContractCodeAnalysisOptions>
+        Condition="'$(CodeContractsMissingPublicEnsuresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicEnsuresAreErrors</CodeContractCodeAnalysisOptions>
     <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestAssumptionsForCallees)' == 'true'">$(CodeContractCodeAnalysisOptions)  -suggest calleeassumes</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest assumes</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestRequires)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest requires</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest methodensures -suggest propertyensures</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsInferEnsuresAutoProperties)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer autopropertiesensures</CodeContractCodeAnalysisOptions>
-		<CodeContractCodeAnalysisOptions
+        <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsNecessaryEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest necessaryensures</CodeContractCodeAnalysisOptions>
-	<CodeContractCodeAnalysisOptions
+    <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestObjectInvariants)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest objectinvariants</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSuggestReadonly)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest readonlyfields </CodeContractCodeAnalysisOptions>
@@ -192,7 +190,7 @@
         Condition="'$(CodeContractsCacheAnalysisResults)' == 'true'">$(CodeContractCodeAnalysisOptions) -cache</CodeContractCodeAnalysisOptions>
     <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsSkipAnalysisIfCannotConnectToCache)' == 'true'">$(CodeContractCodeAnalysisOptions) -forcecacheserver=true</CodeContractCodeAnalysisOptions>
-   <CodeContractCodeAnalysisOptions
+     <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsFailBuildOnWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -failOnWarnings</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsCacheDirectory)' != ''">$(CodeContractCodeAnalysisOptions) -cacheFileDirectory "$(CodeContractsCacheDirectory)"</CodeContractCodeAnalysisOptions>
@@ -206,7 +204,7 @@
         Condition="'$(CodeContractsTargetType)' != ''">$(CodeContractCodeAnalysisOptions) -typeNameSelect:$(CodeContractsTargetType)</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsBeingOptimisticOnExternal)' == 'false'">$(CodeContractCodeAnalysisOptions)  -lowScoreForExternal=false</CodeContractCodeAnalysisOptions>
-		<CodeContractCodeAnalysisOptions
+     <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsTargetNamespace)' != ''">$(CodeContractCodeAnalysisOptions) -namespaceSelect:$(CodeContractsTargetNamespace)</CodeContractCodeAnalysisOptions>
       <CodeContractCodeAnalysisOptions
         Condition="'$(CodeContractsUseBaseLine)' == 'true' and '$(CodeContractsBaseLineFile)' != ''">$(CodeContractCodeAnalysisOptions) -baseline "$(CodeContractsBaseLineFile)"</CodeContractCodeAnalysisOptions>
@@ -230,10 +228,18 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(DeclarativeAssemblyDir)$(ProjectName)cccheck.rsp"
+      File="$(DeclarativeAssemblyDir)$(AssemblyName).cccheck.rsp"
       Lines="@(_CodeContractsCCCheckArgumentLines, ';')"
       Overwrite="true"
       />
+      
+  </Target>
+    
+  <Target
+      Name="CodeContractsRunCodeAnalysisInternal"
+      DependsOnTargets="CodeContractsCodeAnalysisWriteRSPFile">
+      
+    <Message Text="Run Contract Code Analysis on project guid $(ProjectGuid)" Importance="Low"/>
 
     <CodeContractsAnalysis
       Verbose="false"
@@ -246,7 +252,7 @@
       KeepErrors="$(CodeContractsFailBuildOnWarnings)"
       OutputPrefix="CodeContracts: "
       Command='$(CodeContractRunCodeAnalysisCommand)'
-      CommandOptions='"@$(ProjectName)cccheck.rsp"'
+      CommandOptions='"@$(AssemblyName).cccheck.rsp"'
       />
   </Target>
 

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v4.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v4.0/Microsoft.CodeContracts.targets
@@ -247,14 +247,14 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccrewrite.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrewrite.rsp"
       Lines="@(_CodeContractsCCRewriteArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
        WorkingDirectory="$(IntermediateOutputPath)"
-       Command='"$(CodeContractRewriteCommand)" "@$(ProjectName)ccrewrite.rsp"'
+       Command='"$(CodeContractRewriteCommand)" "@$(AssemblyName).ccrewrite.rsp"'
        />
 
     <CallTarget Targets="CodeContractReSign"/>
@@ -336,19 +336,19 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"
       Lines="@(_CodeContractsCCRefGenArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
        Condition="Exists('@(ContractDeclarativeAssembly)')"
-       Command='"$(CodeContractsCCRefgenCommand)" "@$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"'
+       Command='"$(CodeContractsCCRefgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"'
        />
     <ItemGroup
        Condition="Exists('@(ContractReferenceAssemblyAbsolute)')">
       <FileWrites
-         Include="@(ContractReferenceAssemblies);$(IntermediateOutputPath)$(ProjectName)ccrefgen.rsp"/>
+         Include="@(ContractReferenceAssemblies);$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"/>
     </ItemGroup>
 
   </Target>
@@ -574,7 +574,7 @@
   <Target
      Name="CodeContractsComputeAllLibPaths"
      DependsOnTargets="CodeContractsComputeReferencedLibPaths"
-	 >
+     >
     <Message Text="CodeContractsComputeAllLibPaths" Importance="low"/>
     <RemoveDuplicates
        Inputs="@(CodeContractsBuildLibPaths);$(CodeContractsReferenceAssemblyLibPath);$(CodeContractsLibPaths)">
@@ -622,13 +622,13 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ProjectName)ccdocgen.rsp"
+      File="$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"
       Lines="@(_CodeContractsCCDocGenArgumentLines, ';')"
       Overwrite="true"
       />
 
     <Exec
-       Command='"$(CodeContractsCCdocgenCommand)" "@$(IntermediateOutputPath)$(ProjectName)ccdocgen.rsp"' 
+       Command='"$(CodeContractsCCdocgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"' 
        />
   </Target>
 

--- a/Microsoft.Research/ManagedContractsVSPropertyPane/PropertyPane.Designer.cs
+++ b/Microsoft.Research/ManagedContractsVSPropertyPane/PropertyPane.Designer.cs
@@ -39,627 +39,636 @@ namespace Microsoft.Contracts.VisualStudio {
     /// </summary>
     private void InitializeComponent()
     {
-      this.components = new System.ComponentModel.Container();
-      System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PropertyPane));
-      this.EnableRuntimeCheckingBox = new System.Windows.Forms.CheckBox();
-      this.EnableStaticCheckingBox = new System.Windows.Forms.CheckBox();
-      this.LibPathTextBox = new System.Windows.Forms.TextBox();
-      this.LibPathLabel = new System.Windows.Forms.Label();
-      this.ExtraRuntimeCheckerOptionsLabel = new System.Windows.Forms.Label();
-      this.ExtraRuntimeCheckingOptionsBox = new System.Windows.Forms.TextBox();
-      this.CustomRewriterMethodsClassTextBox = new System.Windows.Forms.TextBox();
-      this.CustomRewriterMethodsClassLabel = new System.Windows.Forms.Label();
-      this.CustomRewriterMethodsAssemblyLabel = new System.Windows.Forms.Label();
-      this.CustomRewriterMethodsAssemblyTextBox = new System.Windows.Forms.TextBox();
-      this.CustomRewriterMethodsLabel = new System.Windows.Forms.Label();
-      this.RuntimeCheckingGroup = new System.Windows.Forms.GroupBox();
-      this.SkipQuantifiersBox = new System.Windows.Forms.CheckBox();
-      this.CallSiteRequiresBox = new System.Windows.Forms.CheckBox();
-      this.AssertOnFailureBox = new System.Windows.Forms.CheckBox();
-      this.OnlyPublicSurfaceContractsBox = new System.Windows.Forms.CheckBox();
-      this.RuntimeCheckingLevelDropDown = new System.Windows.Forms.ComboBox();
-      this.AdvancedGroup = new System.Windows.Forms.GroupBox();
-      this.ExtraCodeAnalysisOptionsBox = new System.Windows.Forms.TextBox();
-      this.AdditionalCodeAnalysisOptionsLabel = new System.Windows.Forms.Label();
-      this.StaticCheckingGroup = new System.Windows.Forms.GroupBox();
-      this.SuggestCalleeAssumptionsCheckBox = new System.Windows.Forms.CheckBox();
-      this.skipAnalysisIfCannotConnectToCache = new System.Windows.Forms.CheckBox();
-      this.checkMissingPublicEnsures = new System.Windows.Forms.CheckBox();
-      this.linkUnderstandingTheStaticChecker = new System.Windows.Forms.LinkLabel();
-      this.NecessaryEnsuresCheckBox = new System.Windows.Forms.CheckBox();
-      this.AssertsToContractsCheckBox = new System.Windows.Forms.CheckBox();
-      this.RedundantTestsCheckBox = new System.Windows.Forms.CheckBox();
-      this.SuggestReadonlyCheckBox = new System.Windows.Forms.CheckBox();
-      this.BeingOptmisticOnExternalCheckBox = new System.Windows.Forms.CheckBox();
-      this.missingPublicRequiresAsWarningsCheckBox = new System.Windows.Forms.CheckBox();
-      this.SQLServerLabel = new System.Windows.Forms.Label();
-      this.SQLServerTextBox = new System.Windows.Forms.TextBox();
-      this.CacheResultsCheckBox = new System.Windows.Forms.CheckBox();
-      this.SuggestAssumptionsCheckBox = new System.Windows.Forms.CheckBox();
-      this.InferObjectInvariantsCheckBox = new System.Windows.Forms.CheckBox();
-      this.SuggestObjectInvariantsCheckBox = new System.Windows.Forms.CheckBox();
-      this.WarningFullLabel = new System.Windows.Forms.Label();
-      this.WarningLowLabel = new System.Windows.Forms.Label();
-      this.WarningLevelTrackBar = new System.Windows.Forms.TrackBar();
-      this.WarningLevelLabel = new System.Windows.Forms.Label();
-      this.redundantAssumptionsCheckBox = new System.Windows.Forms.CheckBox();
-      this.InferRequiresCheckBox = new System.Windows.Forms.CheckBox();
-      this.InferEnsuresCheckBox = new System.Windows.Forms.CheckBox();
-      this.SuggestRequiresCheckBox = new System.Windows.Forms.CheckBox();
-      this.BaseLineUpdateButton = new System.Windows.Forms.Button();
-      this.ImplicitArithmeticObligationsBox = new System.Windows.Forms.CheckBox();
-      this.FailBuildOnWarningsCheckBox = new System.Windows.Forms.CheckBox();
-      this.ShowSquiggliesBox = new System.Windows.Forms.CheckBox();
-      this.RunInBackgroundBox = new System.Windows.Forms.CheckBox();
-      this.BaseLineBox = new System.Windows.Forms.CheckBox();
-      this.BaseLineTextBox = new System.Windows.Forms.TextBox();
-      this.ImplicitArrayBoundObligationsBox = new System.Windows.Forms.CheckBox();
-      this.ImplicitNonNullObligationsBox = new System.Windows.Forms.CheckBox();
-      this.ImplicitEnumWritesBox = new System.Windows.Forms.CheckBox();
-      this.WarningLevelToolTip = new System.Windows.Forms.ToolTip(this.components);
-      this.EmitContractDocumentationCheckBox = new System.Windows.Forms.CheckBox();
-      this.ContractReferenceAssemblySelection = new System.Windows.Forms.ComboBox();
-      this.VersionLabel = new System.Windows.Forms.LinkLabel();
-      this.contractReferenceAssemblyGroup = new System.Windows.Forms.GroupBox();
-      this.AssemblyModeLabel = new System.Windows.Forms.Label();
-      this.AssemblyModeDropDown = new System.Windows.Forms.ComboBox();
-      this.PrecisionLevelToolTip = new System.Windows.Forms.ToolTip(this.components);
-      this.docLink = new System.Windows.Forms.LinkLabel();
-      this.help_Link = new System.Windows.Forms.LinkLabel();
-      this.InferEnsuresAutoPropertiesCheckBox = new System.Windows.Forms.CheckBox();
-      this.RuntimeCheckingGroup.SuspendLayout();
-      this.AdvancedGroup.SuspendLayout();
-      this.StaticCheckingGroup.SuspendLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.WarningLevelTrackBar)).BeginInit();
-      this.contractReferenceAssemblyGroup.SuspendLayout();
-      this.SuspendLayout();
-      // 
-      // EnableRuntimeCheckingBox
-      // 
-      resources.ApplyResources(this.EnableRuntimeCheckingBox, "EnableRuntimeCheckingBox");
-      this.EnableRuntimeCheckingBox.Name = "EnableRuntimeCheckingBox";
-      this.EnableRuntimeCheckingBox.UseVisualStyleBackColor = true;
-      this.EnableRuntimeCheckingBox.CheckedChanged += new System.EventHandler(this.EnableContractCheckingBox_CheckedChanged);
-      // 
-      // EnableStaticCheckingBox
-      // 
-      resources.ApplyResources(this.EnableStaticCheckingBox, "EnableStaticCheckingBox");
-      this.EnableStaticCheckingBox.Name = "EnableStaticCheckingBox";
-      this.EnableStaticCheckingBox.UseVisualStyleBackColor = true;
-      this.EnableStaticCheckingBox.CheckedChanged += new System.EventHandler(this.EnableStaticCheckingBox_CheckedChanged);
-      // 
-      // LibPathTextBox
-      // 
-      resources.ApplyResources(this.LibPathTextBox, "LibPathTextBox");
-      this.LibPathTextBox.Name = "LibPathTextBox";
-      this.LibPathTextBox.TextChanged += new System.EventHandler(this.LibPathTextBox_TextChanged);
-      // 
-      // LibPathLabel
-      // 
-      resources.ApplyResources(this.LibPathLabel, "LibPathLabel");
-      this.LibPathLabel.Name = "LibPathLabel";
-      // 
-      // ExtraRuntimeCheckerOptionsLabel
-      // 
-      resources.ApplyResources(this.ExtraRuntimeCheckerOptionsLabel, "ExtraRuntimeCheckerOptionsLabel");
-      this.ExtraRuntimeCheckerOptionsLabel.Name = "ExtraRuntimeCheckerOptionsLabel";
-      // 
-      // ExtraRuntimeCheckingOptionsBox
-      // 
-      resources.ApplyResources(this.ExtraRuntimeCheckingOptionsBox, "ExtraRuntimeCheckingOptionsBox");
-      this.ExtraRuntimeCheckingOptionsBox.Name = "ExtraRuntimeCheckingOptionsBox";
-      this.ExtraRuntimeCheckingOptionsBox.TextChanged += new System.EventHandler(this.PlatformTextBox_TextChanged);
-      // 
-      // CustomRewriterMethodsClassTextBox
-      // 
-      resources.ApplyResources(this.CustomRewriterMethodsClassTextBox, "CustomRewriterMethodsClassTextBox");
-      this.CustomRewriterMethodsClassTextBox.Name = "CustomRewriterMethodsClassTextBox";
-      this.CustomRewriterMethodsClassTextBox.TextChanged += new System.EventHandler(this.CustomRewriterMethodsClassTextBox_TextChanged);
-      // 
-      // CustomRewriterMethodsClassLabel
-      // 
-      resources.ApplyResources(this.CustomRewriterMethodsClassLabel, "CustomRewriterMethodsClassLabel");
-      this.CustomRewriterMethodsClassLabel.Name = "CustomRewriterMethodsClassLabel";
-      // 
-      // CustomRewriterMethodsAssemblyLabel
-      // 
-      resources.ApplyResources(this.CustomRewriterMethodsAssemblyLabel, "CustomRewriterMethodsAssemblyLabel");
-      this.CustomRewriterMethodsAssemblyLabel.Name = "CustomRewriterMethodsAssemblyLabel";
-      // 
-      // CustomRewriterMethodsAssemblyTextBox
-      // 
-      resources.ApplyResources(this.CustomRewriterMethodsAssemblyTextBox, "CustomRewriterMethodsAssemblyTextBox");
-      this.CustomRewriterMethodsAssemblyTextBox.Name = "CustomRewriterMethodsAssemblyTextBox";
-      this.CustomRewriterMethodsAssemblyTextBox.TextChanged += new System.EventHandler(this.CustomRewriterMethodsAssemblyTextBox_TextChanged);
-      // 
-      // CustomRewriterMethodsLabel
-      // 
-      resources.ApplyResources(this.CustomRewriterMethodsLabel, "CustomRewriterMethodsLabel");
-      this.CustomRewriterMethodsLabel.Name = "CustomRewriterMethodsLabel";
-      // 
-      // RuntimeCheckingGroup
-      // 
-      this.RuntimeCheckingGroup.Controls.Add(this.SkipQuantifiersBox);
-      this.RuntimeCheckingGroup.Controls.Add(this.CallSiteRequiresBox);
-      this.RuntimeCheckingGroup.Controls.Add(this.AssertOnFailureBox);
-      this.RuntimeCheckingGroup.Controls.Add(this.OnlyPublicSurfaceContractsBox);
-      this.RuntimeCheckingGroup.Controls.Add(this.RuntimeCheckingLevelDropDown);
-      this.RuntimeCheckingGroup.Controls.Add(this.EnableRuntimeCheckingBox);
-      this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsLabel);
-      this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsClassTextBox);
-      this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsAssemblyTextBox);
-      this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsAssemblyLabel);
-      this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsClassLabel);
-      resources.ApplyResources(this.RuntimeCheckingGroup, "RuntimeCheckingGroup");
-      this.RuntimeCheckingGroup.Name = "RuntimeCheckingGroup";
-      this.RuntimeCheckingGroup.TabStop = false;
-      // 
-      // SkipQuantifiersBox
-      // 
-      resources.ApplyResources(this.SkipQuantifiersBox, "SkipQuantifiersBox");
-      this.SkipQuantifiersBox.Name = "SkipQuantifiersBox";
-      this.SkipQuantifiersBox.UseVisualStyleBackColor = true;
-      this.SkipQuantifiersBox.CheckedChanged += new System.EventHandler(this.SkipQuantifiersBox_CheckedChanged);
-      // 
-      // CallSiteRequiresBox
-      // 
-      resources.ApplyResources(this.CallSiteRequiresBox, "CallSiteRequiresBox");
-      this.CallSiteRequiresBox.Name = "CallSiteRequiresBox";
-      this.CallSiteRequiresBox.UseVisualStyleBackColor = true;
-      this.CallSiteRequiresBox.CheckedChanged += new System.EventHandler(this.CallSiteRequiresBox_CheckedChanged);
-      // 
-      // AssertOnFailureBox
-      // 
-      resources.ApplyResources(this.AssertOnFailureBox, "AssertOnFailureBox");
-      this.AssertOnFailureBox.Name = "AssertOnFailureBox";
-      this.AssertOnFailureBox.UseVisualStyleBackColor = true;
-      this.AssertOnFailureBox.CheckedChanged += new System.EventHandler(this.AssertOnFailureBox_CheckedChanged);
-      // 
-      // OnlyPublicSurfaceContractsBox
-      // 
-      resources.ApplyResources(this.OnlyPublicSurfaceContractsBox, "OnlyPublicSurfaceContractsBox");
-      this.OnlyPublicSurfaceContractsBox.Name = "OnlyPublicSurfaceContractsBox";
-      this.OnlyPublicSurfaceContractsBox.UseVisualStyleBackColor = true;
-      this.OnlyPublicSurfaceContractsBox.CheckedChanged += new System.EventHandler(this.OnlyPublicSurfaceContractsBox_CheckedChanged_1);
-      // 
-      // RuntimeCheckingLevelDropDown
-      // 
-      this.RuntimeCheckingLevelDropDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      resources.ApplyResources(this.RuntimeCheckingLevelDropDown, "RuntimeCheckingLevelDropDown");
-      this.RuntimeCheckingLevelDropDown.FormattingEnabled = true;
-      this.RuntimeCheckingLevelDropDown.Items.AddRange(new object[] {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PropertyPane));
+            this.EnableRuntimeCheckingBox = new System.Windows.Forms.CheckBox();
+            this.EnableStaticCheckingBox = new System.Windows.Forms.CheckBox();
+            this.LibPathTextBox = new System.Windows.Forms.TextBox();
+            this.LibPathLabel = new System.Windows.Forms.Label();
+            this.ExtraRuntimeCheckerOptionsLabel = new System.Windows.Forms.Label();
+            this.ExtraRuntimeCheckingOptionsBox = new System.Windows.Forms.TextBox();
+            this.CustomRewriterMethodsClassTextBox = new System.Windows.Forms.TextBox();
+            this.CustomRewriterMethodsClassLabel = new System.Windows.Forms.Label();
+            this.CustomRewriterMethodsAssemblyLabel = new System.Windows.Forms.Label();
+            this.CustomRewriterMethodsAssemblyTextBox = new System.Windows.Forms.TextBox();
+            this.CustomRewriterMethodsLabel = new System.Windows.Forms.Label();
+            this.RuntimeCheckingGroup = new System.Windows.Forms.GroupBox();
+            this.SkipQuantifiersBox = new System.Windows.Forms.CheckBox();
+            this.CallSiteRequiresBox = new System.Windows.Forms.CheckBox();
+            this.AssertOnFailureBox = new System.Windows.Forms.CheckBox();
+            this.OnlyPublicSurfaceContractsBox = new System.Windows.Forms.CheckBox();
+            this.RuntimeCheckingLevelDropDown = new System.Windows.Forms.ComboBox();
+            this.AdvancedGroup = new System.Windows.Forms.GroupBox();
+            this.ExtraCodeAnalysisOptionsBox = new System.Windows.Forms.TextBox();
+            this.AdditionalCodeAnalysisOptionsLabel = new System.Windows.Forms.Label();
+            this.StaticCheckingGroup = new System.Windows.Forms.GroupBox();
+            this.InferEnsuresAutoPropertiesCheckBox = new System.Windows.Forms.CheckBox();
+            this.SuggestCalleeAssumptionsCheckBox = new System.Windows.Forms.CheckBox();
+            this.skipAnalysisIfCannotConnectToCache = new System.Windows.Forms.CheckBox();
+            this.checkMissingPublicEnsures = new System.Windows.Forms.CheckBox();
+            this.linkUnderstandingTheStaticChecker = new System.Windows.Forms.LinkLabel();
+            this.NecessaryEnsuresCheckBox = new System.Windows.Forms.CheckBox();
+            this.AssertsToContractsCheckBox = new System.Windows.Forms.CheckBox();
+            this.RedundantTestsCheckBox = new System.Windows.Forms.CheckBox();
+            this.SuggestReadonlyCheckBox = new System.Windows.Forms.CheckBox();
+            this.BeingOptmisticOnExternalCheckBox = new System.Windows.Forms.CheckBox();
+            this.missingPublicRequiresAsWarningsCheckBox = new System.Windows.Forms.CheckBox();
+            this.SQLServerLabel = new System.Windows.Forms.Label();
+            this.SQLServerTextBox = new System.Windows.Forms.TextBox();
+            this.CacheResultsCheckBox = new System.Windows.Forms.CheckBox();
+            this.SuggestAssumptionsCheckBox = new System.Windows.Forms.CheckBox();
+            this.InferObjectInvariantsCheckBox = new System.Windows.Forms.CheckBox();
+            this.SuggestObjectInvariantsCheckBox = new System.Windows.Forms.CheckBox();
+            this.WarningFullLabel = new System.Windows.Forms.Label();
+            this.WarningLowLabel = new System.Windows.Forms.Label();
+            this.WarningLevelTrackBar = new System.Windows.Forms.TrackBar();
+            this.WarningLevelLabel = new System.Windows.Forms.Label();
+            this.redundantAssumptionsCheckBox = new System.Windows.Forms.CheckBox();
+            this.InferRequiresCheckBox = new System.Windows.Forms.CheckBox();
+            this.InferEnsuresCheckBox = new System.Windows.Forms.CheckBox();
+            this.SuggestRequiresCheckBox = new System.Windows.Forms.CheckBox();
+            this.BaseLineUpdateButton = new System.Windows.Forms.Button();
+            this.ImplicitArithmeticObligationsBox = new System.Windows.Forms.CheckBox();
+            this.FailBuildOnWarningsCheckBox = new System.Windows.Forms.CheckBox();
+            this.ShowSquiggliesBox = new System.Windows.Forms.CheckBox();
+            this.RunInBackgroundBox = new System.Windows.Forms.CheckBox();
+            this.BaseLineBox = new System.Windows.Forms.CheckBox();
+            this.BaseLineTextBox = new System.Windows.Forms.TextBox();
+            this.ImplicitArrayBoundObligationsBox = new System.Windows.Forms.CheckBox();
+            this.ImplicitNonNullObligationsBox = new System.Windows.Forms.CheckBox();
+            this.ImplicitEnumWritesBox = new System.Windows.Forms.CheckBox();
+            this.WarningLevelToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.EmitContractDocumentationCheckBox = new System.Windows.Forms.CheckBox();
+            this.ContractReferenceAssemblySelection = new System.Windows.Forms.ComboBox();
+            this.VersionLabel = new System.Windows.Forms.LinkLabel();
+            this.contractReferenceAssemblyGroup = new System.Windows.Forms.GroupBox();
+            this.AssemblyModeLabel = new System.Windows.Forms.Label();
+            this.AssemblyModeDropDown = new System.Windows.Forms.ComboBox();
+            this.PrecisionLevelToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.docLink = new System.Windows.Forms.LinkLabel();
+            this.help_Link = new System.Windows.Forms.LinkLabel();
+            this.DeferAnalysisCheckBox = new System.Windows.Forms.CheckBox();
+            this.RuntimeCheckingGroup.SuspendLayout();
+            this.AdvancedGroup.SuspendLayout();
+            this.StaticCheckingGroup.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.WarningLevelTrackBar)).BeginInit();
+            this.contractReferenceAssemblyGroup.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // EnableRuntimeCheckingBox
+            // 
+            resources.ApplyResources(this.EnableRuntimeCheckingBox, "EnableRuntimeCheckingBox");
+            this.EnableRuntimeCheckingBox.Name = "EnableRuntimeCheckingBox";
+            this.EnableRuntimeCheckingBox.UseVisualStyleBackColor = true;
+            this.EnableRuntimeCheckingBox.CheckedChanged += new System.EventHandler(this.EnableContractCheckingBox_CheckedChanged);
+            // 
+            // EnableStaticCheckingBox
+            // 
+            resources.ApplyResources(this.EnableStaticCheckingBox, "EnableStaticCheckingBox");
+            this.EnableStaticCheckingBox.Name = "EnableStaticCheckingBox";
+            this.EnableStaticCheckingBox.UseVisualStyleBackColor = true;
+            this.EnableStaticCheckingBox.CheckedChanged += new System.EventHandler(this.EnableStaticCheckingBox_CheckedChanged);
+            // 
+            // LibPathTextBox
+            // 
+            resources.ApplyResources(this.LibPathTextBox, "LibPathTextBox");
+            this.LibPathTextBox.Name = "LibPathTextBox";
+            this.LibPathTextBox.TextChanged += new System.EventHandler(this.LibPathTextBox_TextChanged);
+            // 
+            // LibPathLabel
+            // 
+            resources.ApplyResources(this.LibPathLabel, "LibPathLabel");
+            this.LibPathLabel.Name = "LibPathLabel";
+            // 
+            // ExtraRuntimeCheckerOptionsLabel
+            // 
+            resources.ApplyResources(this.ExtraRuntimeCheckerOptionsLabel, "ExtraRuntimeCheckerOptionsLabel");
+            this.ExtraRuntimeCheckerOptionsLabel.Name = "ExtraRuntimeCheckerOptionsLabel";
+            // 
+            // ExtraRuntimeCheckingOptionsBox
+            // 
+            resources.ApplyResources(this.ExtraRuntimeCheckingOptionsBox, "ExtraRuntimeCheckingOptionsBox");
+            this.ExtraRuntimeCheckingOptionsBox.Name = "ExtraRuntimeCheckingOptionsBox";
+            this.ExtraRuntimeCheckingOptionsBox.TextChanged += new System.EventHandler(this.PlatformTextBox_TextChanged);
+            // 
+            // CustomRewriterMethodsClassTextBox
+            // 
+            resources.ApplyResources(this.CustomRewriterMethodsClassTextBox, "CustomRewriterMethodsClassTextBox");
+            this.CustomRewriterMethodsClassTextBox.Name = "CustomRewriterMethodsClassTextBox";
+            this.CustomRewriterMethodsClassTextBox.TextChanged += new System.EventHandler(this.CustomRewriterMethodsClassTextBox_TextChanged);
+            // 
+            // CustomRewriterMethodsClassLabel
+            // 
+            resources.ApplyResources(this.CustomRewriterMethodsClassLabel, "CustomRewriterMethodsClassLabel");
+            this.CustomRewriterMethodsClassLabel.Name = "CustomRewriterMethodsClassLabel";
+            // 
+            // CustomRewriterMethodsAssemblyLabel
+            // 
+            resources.ApplyResources(this.CustomRewriterMethodsAssemblyLabel, "CustomRewriterMethodsAssemblyLabel");
+            this.CustomRewriterMethodsAssemblyLabel.Name = "CustomRewriterMethodsAssemblyLabel";
+            // 
+            // CustomRewriterMethodsAssemblyTextBox
+            // 
+            resources.ApplyResources(this.CustomRewriterMethodsAssemblyTextBox, "CustomRewriterMethodsAssemblyTextBox");
+            this.CustomRewriterMethodsAssemblyTextBox.Name = "CustomRewriterMethodsAssemblyTextBox";
+            this.CustomRewriterMethodsAssemblyTextBox.TextChanged += new System.EventHandler(this.CustomRewriterMethodsAssemblyTextBox_TextChanged);
+            // 
+            // CustomRewriterMethodsLabel
+            // 
+            resources.ApplyResources(this.CustomRewriterMethodsLabel, "CustomRewriterMethodsLabel");
+            this.CustomRewriterMethodsLabel.Name = "CustomRewriterMethodsLabel";
+            // 
+            // RuntimeCheckingGroup
+            // 
+            this.RuntimeCheckingGroup.Controls.Add(this.SkipQuantifiersBox);
+            this.RuntimeCheckingGroup.Controls.Add(this.CallSiteRequiresBox);
+            this.RuntimeCheckingGroup.Controls.Add(this.AssertOnFailureBox);
+            this.RuntimeCheckingGroup.Controls.Add(this.OnlyPublicSurfaceContractsBox);
+            this.RuntimeCheckingGroup.Controls.Add(this.RuntimeCheckingLevelDropDown);
+            this.RuntimeCheckingGroup.Controls.Add(this.EnableRuntimeCheckingBox);
+            this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsLabel);
+            this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsClassTextBox);
+            this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsAssemblyTextBox);
+            this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsAssemblyLabel);
+            this.RuntimeCheckingGroup.Controls.Add(this.CustomRewriterMethodsClassLabel);
+            resources.ApplyResources(this.RuntimeCheckingGroup, "RuntimeCheckingGroup");
+            this.RuntimeCheckingGroup.Name = "RuntimeCheckingGroup";
+            this.RuntimeCheckingGroup.TabStop = false;
+            // 
+            // SkipQuantifiersBox
+            // 
+            resources.ApplyResources(this.SkipQuantifiersBox, "SkipQuantifiersBox");
+            this.SkipQuantifiersBox.Name = "SkipQuantifiersBox";
+            this.SkipQuantifiersBox.UseVisualStyleBackColor = true;
+            this.SkipQuantifiersBox.CheckedChanged += new System.EventHandler(this.SkipQuantifiersBox_CheckedChanged);
+            // 
+            // CallSiteRequiresBox
+            // 
+            resources.ApplyResources(this.CallSiteRequiresBox, "CallSiteRequiresBox");
+            this.CallSiteRequiresBox.Name = "CallSiteRequiresBox";
+            this.CallSiteRequiresBox.UseVisualStyleBackColor = true;
+            this.CallSiteRequiresBox.CheckedChanged += new System.EventHandler(this.CallSiteRequiresBox_CheckedChanged);
+            // 
+            // AssertOnFailureBox
+            // 
+            resources.ApplyResources(this.AssertOnFailureBox, "AssertOnFailureBox");
+            this.AssertOnFailureBox.Name = "AssertOnFailureBox";
+            this.AssertOnFailureBox.UseVisualStyleBackColor = true;
+            this.AssertOnFailureBox.CheckedChanged += new System.EventHandler(this.AssertOnFailureBox_CheckedChanged);
+            // 
+            // OnlyPublicSurfaceContractsBox
+            // 
+            resources.ApplyResources(this.OnlyPublicSurfaceContractsBox, "OnlyPublicSurfaceContractsBox");
+            this.OnlyPublicSurfaceContractsBox.Name = "OnlyPublicSurfaceContractsBox";
+            this.OnlyPublicSurfaceContractsBox.UseVisualStyleBackColor = true;
+            this.OnlyPublicSurfaceContractsBox.CheckedChanged += new System.EventHandler(this.OnlyPublicSurfaceContractsBox_CheckedChanged_1);
+            // 
+            // RuntimeCheckingLevelDropDown
+            // 
+            this.RuntimeCheckingLevelDropDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            resources.ApplyResources(this.RuntimeCheckingLevelDropDown, "RuntimeCheckingLevelDropDown");
+            this.RuntimeCheckingLevelDropDown.FormattingEnabled = true;
+            this.RuntimeCheckingLevelDropDown.Items.AddRange(new object[] {
             resources.GetString("RuntimeCheckingLevelDropDown.Items"),
             resources.GetString("RuntimeCheckingLevelDropDown.Items1"),
             resources.GetString("RuntimeCheckingLevelDropDown.Items2"),
             resources.GetString("RuntimeCheckingLevelDropDown.Items3"),
             resources.GetString("RuntimeCheckingLevelDropDown.Items4")});
-      this.RuntimeCheckingLevelDropDown.Name = "RuntimeCheckingLevelDropDown";
-      this.RuntimeCheckingLevelDropDown.SelectedIndexChanged += new System.EventHandler(this.runtimeCheckingLevel_SelectedIndexChanged);
-      // 
-      // AdvancedGroup
-      // 
-      this.AdvancedGroup.Controls.Add(this.ExtraCodeAnalysisOptionsBox);
-      this.AdvancedGroup.Controls.Add(this.AdditionalCodeAnalysisOptionsLabel);
-      this.AdvancedGroup.Controls.Add(this.LibPathLabel);
-      this.AdvancedGroup.Controls.Add(this.ExtraRuntimeCheckingOptionsBox);
-      this.AdvancedGroup.Controls.Add(this.LibPathTextBox);
-      this.AdvancedGroup.Controls.Add(this.ExtraRuntimeCheckerOptionsLabel);
-      resources.ApplyResources(this.AdvancedGroup, "AdvancedGroup");
-      this.AdvancedGroup.Name = "AdvancedGroup";
-      this.AdvancedGroup.TabStop = false;
-      // 
-      // ExtraCodeAnalysisOptionsBox
-      // 
-      resources.ApplyResources(this.ExtraCodeAnalysisOptionsBox, "ExtraCodeAnalysisOptionsBox");
-      this.ExtraCodeAnalysisOptionsBox.Name = "ExtraCodeAnalysisOptionsBox";
-      this.ExtraCodeAnalysisOptionsBox.TextChanged += new System.EventHandler(this.ExtraCodeAnalysisOptionsBox_TextChanged);
-      // 
-      // AdditionalCodeAnalysisOptionsLabel
-      // 
-      resources.ApplyResources(this.AdditionalCodeAnalysisOptionsLabel, "AdditionalCodeAnalysisOptionsLabel");
-      this.AdditionalCodeAnalysisOptionsLabel.Name = "AdditionalCodeAnalysisOptionsLabel";
-      // 
-      // StaticCheckingGroup
-      // 
-      this.StaticCheckingGroup.Controls.Add(this.InferEnsuresAutoPropertiesCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.SuggestCalleeAssumptionsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.skipAnalysisIfCannotConnectToCache);
-      this.StaticCheckingGroup.Controls.Add(this.checkMissingPublicEnsures);
-      this.StaticCheckingGroup.Controls.Add(this.linkUnderstandingTheStaticChecker);
-      this.StaticCheckingGroup.Controls.Add(this.NecessaryEnsuresCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.AssertsToContractsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.RedundantTestsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.SuggestReadonlyCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.BeingOptmisticOnExternalCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.missingPublicRequiresAsWarningsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.SQLServerLabel);
-      this.StaticCheckingGroup.Controls.Add(this.SQLServerTextBox);
-      this.StaticCheckingGroup.Controls.Add(this.SuggestAssumptionsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.InferObjectInvariantsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.SuggestObjectInvariantsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.WarningFullLabel);
-      this.StaticCheckingGroup.Controls.Add(this.WarningLowLabel);
-      this.StaticCheckingGroup.Controls.Add(this.WarningLevelTrackBar);
-      this.StaticCheckingGroup.Controls.Add(this.WarningLevelLabel);
-      this.StaticCheckingGroup.Controls.Add(this.CacheResultsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.redundantAssumptionsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.InferRequiresCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.InferEnsuresCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.SuggestRequiresCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.BaseLineUpdateButton);
-      this.StaticCheckingGroup.Controls.Add(this.ImplicitArithmeticObligationsBox);
-      this.StaticCheckingGroup.Controls.Add(this.FailBuildOnWarningsCheckBox);
-      this.StaticCheckingGroup.Controls.Add(this.ShowSquiggliesBox);
-      this.StaticCheckingGroup.Controls.Add(this.RunInBackgroundBox);
-      this.StaticCheckingGroup.Controls.Add(this.BaseLineBox);
-      this.StaticCheckingGroup.Controls.Add(this.BaseLineTextBox);
-      this.StaticCheckingGroup.Controls.Add(this.ImplicitArrayBoundObligationsBox);
-      this.StaticCheckingGroup.Controls.Add(this.ImplicitNonNullObligationsBox);
-      this.StaticCheckingGroup.Controls.Add(this.ImplicitEnumWritesBox);
-      this.StaticCheckingGroup.Controls.Add(this.EnableStaticCheckingBox);
-      resources.ApplyResources(this.StaticCheckingGroup, "StaticCheckingGroup");
-      this.StaticCheckingGroup.Name = "StaticCheckingGroup";
-      this.StaticCheckingGroup.TabStop = false;
-      // 
-      // SuggestCalleeAssumptionsCheckBox
-      // 
-      resources.ApplyResources(this.SuggestCalleeAssumptionsCheckBox, "SuggestCalleeAssumptionsCheckBox");
-      this.SuggestCalleeAssumptionsCheckBox.Name = "SuggestCalleeAssumptionsCheckBox";
-      this.SuggestCalleeAssumptionsCheckBox.UseVisualStyleBackColor = true;
-      this.SuggestCalleeAssumptionsCheckBox.CheckedChanged += new System.EventHandler(this.SuggestCalleeAssumptionsCheckBox_CheckedChanged);
-      // 
-      // skipAnalysisIfCannotConnectToCache
-      // 
-      resources.ApplyResources(this.skipAnalysisIfCannotConnectToCache, "skipAnalysisIfCannotConnectToCache");
-      this.skipAnalysisIfCannotConnectToCache.Name = "skipAnalysisIfCannotConnectToCache";
-      this.skipAnalysisIfCannotConnectToCache.UseVisualStyleBackColor = true;
-      this.skipAnalysisIfCannotConnectToCache.CheckedChanged += new System.EventHandler(this.skipAnalysisIfCannotConnectToCache_CheckedChanged);
-      // 
-      // checkMissingPublicEnsures
-      // 
-      resources.ApplyResources(this.checkMissingPublicEnsures, "checkMissingPublicEnsures");
-      this.checkMissingPublicEnsures.Name = "checkMissingPublicEnsures";
-      this.checkMissingPublicEnsures.UseVisualStyleBackColor = true;
-      this.checkMissingPublicEnsures.CheckedChanged += new System.EventHandler(this.checkMissingPublicEnsures_CheckedChanged);
-      // 
-      // linkUnderstandingTheStaticChecker
-      // 
-      resources.ApplyResources(this.linkUnderstandingTheStaticChecker, "linkUnderstandingTheStaticChecker");
-      this.linkUnderstandingTheStaticChecker.Name = "linkUnderstandingTheStaticChecker";
-      this.linkUnderstandingTheStaticChecker.TabStop = true;
-      this.linkUnderstandingTheStaticChecker.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkUnderstandingTheStaticChecker_LinkClicked);
-      // 
-      // NecessaryEnsuresCheckBox
-      // 
-      resources.ApplyResources(this.NecessaryEnsuresCheckBox, "NecessaryEnsuresCheckBox");
-      this.NecessaryEnsuresCheckBox.Checked = true;
-      this.NecessaryEnsuresCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.NecessaryEnsuresCheckBox.Name = "NecessaryEnsuresCheckBox";
-      this.NecessaryEnsuresCheckBox.UseVisualStyleBackColor = true;
-      this.NecessaryEnsuresCheckBox.CheckedChanged += new System.EventHandler(this.NecessaryEnsuresCheckBox_CheckedChanged);
-      // 
-      // AssertsToContractsCheckBox
-      // 
-      resources.ApplyResources(this.AssertsToContractsCheckBox, "AssertsToContractsCheckBox");
-      this.AssertsToContractsCheckBox.Checked = true;
-      this.AssertsToContractsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.AssertsToContractsCheckBox.Name = "AssertsToContractsCheckBox";
-      this.AssertsToContractsCheckBox.UseVisualStyleBackColor = true;
-      this.AssertsToContractsCheckBox.CheckedChanged += new System.EventHandler(this.AssertsToContractsCheckBox_CheckedChanged);
-      // 
-      // RedundantTestsCheckBox
-      // 
-      resources.ApplyResources(this.RedundantTestsCheckBox, "RedundantTestsCheckBox");
-      this.RedundantTestsCheckBox.Checked = true;
-      this.RedundantTestsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.RedundantTestsCheckBox.Name = "RedundantTestsCheckBox";
-      this.RedundantTestsCheckBox.UseVisualStyleBackColor = true;
-      this.RedundantTestsCheckBox.CheckedChanged += new System.EventHandler(this.RedundantTestsCheckBox_CheckedChanged);
-      // 
-      // SuggestReadonlyCheckBox
-      // 
-      resources.ApplyResources(this.SuggestReadonlyCheckBox, "SuggestReadonlyCheckBox");
-      this.SuggestReadonlyCheckBox.Checked = true;
-      this.SuggestReadonlyCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.SuggestReadonlyCheckBox.Name = "SuggestReadonlyCheckBox";
-      this.SuggestReadonlyCheckBox.UseVisualStyleBackColor = true;
-      // 
-      // BeingOptmisticOnExternalCheckBox
-      // 
-      resources.ApplyResources(this.BeingOptmisticOnExternalCheckBox, "BeingOptmisticOnExternalCheckBox");
-      this.BeingOptmisticOnExternalCheckBox.Checked = true;
-      this.BeingOptmisticOnExternalCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.BeingOptmisticOnExternalCheckBox.Name = "BeingOptmisticOnExternalCheckBox";
-      this.BeingOptmisticOnExternalCheckBox.UseVisualStyleBackColor = true;
-      this.BeingOptmisticOnExternalCheckBox.CheckedChanged += new System.EventHandler(this.BeingOptmisticOnExternalCheckBox_CheckedChanged);
-      // 
-      // missingPublicRequiresAsWarningsCheckBox
-      // 
-      resources.ApplyResources(this.missingPublicRequiresAsWarningsCheckBox, "missingPublicRequiresAsWarningsCheckBox");
-      this.missingPublicRequiresAsWarningsCheckBox.Checked = true;
-      this.missingPublicRequiresAsWarningsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.missingPublicRequiresAsWarningsCheckBox.Name = "missingPublicRequiresAsWarningsCheckBox";
-      this.missingPublicRequiresAsWarningsCheckBox.UseVisualStyleBackColor = true;
-      this.missingPublicRequiresAsWarningsCheckBox.CheckedChanged += new System.EventHandler(this.missingPublicRequiresAsWarningsCheckBox_CheckedChanged);
-      // 
-      // SQLServerLabel
-      // 
-      resources.ApplyResources(this.SQLServerLabel, "SQLServerLabel");
-      this.SQLServerLabel.Name = "SQLServerLabel";
-      // 
-      // SQLServerTextBox
-      // 
-      this.SQLServerTextBox.Enabled = this.CacheResultsCheckBox.Enabled;
-      resources.ApplyResources(this.SQLServerTextBox, "SQLServerTextBox");
-      this.SQLServerTextBox.Name = "SQLServerTextBox";
-      this.SQLServerTextBox.TextChanged += new System.EventHandler(this.SQLServerTextBox_TextChanged);
-      // 
-      // CacheResultsCheckBox
-      // 
-      resources.ApplyResources(this.CacheResultsCheckBox, "CacheResultsCheckBox");
-      this.CacheResultsCheckBox.Checked = true;
-      this.CacheResultsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.CacheResultsCheckBox.Name = "CacheResultsCheckBox";
-      this.CacheResultsCheckBox.UseVisualStyleBackColor = true;
-      this.CacheResultsCheckBox.CheckedChanged += new System.EventHandler(this.CacheResultsCheckBox_CheckedChanged);
-      // 
-      // SuggestAssumptionsCheckBox
-      // 
-      resources.ApplyResources(this.SuggestAssumptionsCheckBox, "SuggestAssumptionsCheckBox");
-      this.SuggestAssumptionsCheckBox.Name = "SuggestAssumptionsCheckBox";
-      this.SuggestAssumptionsCheckBox.UseVisualStyleBackColor = true;
-      this.SuggestAssumptionsCheckBox.CheckedChanged += new System.EventHandler(this.SuggestAssumptions_CheckedChanged);
-      // 
-      // InferObjectInvariantsCheckBox
-      // 
-      resources.ApplyResources(this.InferObjectInvariantsCheckBox, "InferObjectInvariantsCheckBox");
-      this.InferObjectInvariantsCheckBox.Name = "InferObjectInvariantsCheckBox";
-      this.InferObjectInvariantsCheckBox.UseVisualStyleBackColor = true;
-      this.InferObjectInvariantsCheckBox.CheckedChanged += new System.EventHandler(this.InferObjectInvariantsCheckBox_CheckedChanged);
-      // 
-      // SuggestObjectInvariantsCheckBox
-      // 
-      resources.ApplyResources(this.SuggestObjectInvariantsCheckBox, "SuggestObjectInvariantsCheckBox");
-      this.SuggestObjectInvariantsCheckBox.Name = "SuggestObjectInvariantsCheckBox";
-      this.SuggestObjectInvariantsCheckBox.UseVisualStyleBackColor = true;
-      this.SuggestObjectInvariantsCheckBox.CheckedChanged += new System.EventHandler(this.SuggestObjectInvariantsCheckBox_CheckedChanged);
-      // 
-      // WarningFullLabel
-      // 
-      resources.ApplyResources(this.WarningFullLabel, "WarningFullLabel");
-      this.WarningFullLabel.Name = "WarningFullLabel";
-      // 
-      // WarningLowLabel
-      // 
-      resources.ApplyResources(this.WarningLowLabel, "WarningLowLabel");
-      this.WarningLowLabel.Name = "WarningLowLabel";
-      // 
-      // WarningLevelTrackBar
-      // 
-      this.WarningLevelTrackBar.LargeChange = 1;
-      resources.ApplyResources(this.WarningLevelTrackBar, "WarningLevelTrackBar");
-      this.WarningLevelTrackBar.Maximum = 3;
-      this.WarningLevelTrackBar.Name = "WarningLevelTrackBar";
-      this.WarningLevelTrackBar.Scroll += new System.EventHandler(this.WarningLevelTrackBar_Scroll);
-      // 
-      // WarningLevelLabel
-      // 
-      resources.ApplyResources(this.WarningLevelLabel, "WarningLevelLabel");
-      this.WarningLevelLabel.Name = "WarningLevelLabel";
-      // 
-      // redundantAssumptionsCheckBox
-      // 
-      resources.ApplyResources(this.redundantAssumptionsCheckBox, "redundantAssumptionsCheckBox");
-      this.redundantAssumptionsCheckBox.Checked = true;
-      this.redundantAssumptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.redundantAssumptionsCheckBox.Name = "redundantAssumptionsCheckBox";
-      this.redundantAssumptionsCheckBox.UseVisualStyleBackColor = true;
-      this.redundantAssumptionsCheckBox.CheckedChanged += new System.EventHandler(this.redundantAssumptionsCheckBox_CheckedChanged);
-      // 
-      // InferRequiresCheckBox
-      // 
-      resources.ApplyResources(this.InferRequiresCheckBox, "InferRequiresCheckBox");
-      this.InferRequiresCheckBox.Checked = true;
-      this.InferRequiresCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.InferRequiresCheckBox.Name = "InferRequiresCheckBox";
-      this.InferRequiresCheckBox.UseVisualStyleBackColor = true;
-      this.InferRequiresCheckBox.CheckedChanged += new System.EventHandler(this.InferRequires_CheckedChanged);
-      // 
-      // InferEnsuresCheckBox
-      // 
-      resources.ApplyResources(this.InferEnsuresCheckBox, "InferEnsuresCheckBox");
-      this.InferEnsuresCheckBox.Name = "InferEnsuresCheckBox";
-      this.InferEnsuresCheckBox.UseVisualStyleBackColor = true;
-      this.InferEnsuresCheckBox.CheckedChanged += new System.EventHandler(this.InferEnsuresCheckBox_CheckedChanged);
-      // 
-      // SuggestRequiresCheckBox
-      // 
-      resources.ApplyResources(this.SuggestRequiresCheckBox, "SuggestRequiresCheckBox");
-      this.SuggestRequiresCheckBox.Name = "SuggestRequiresCheckBox";
-      this.SuggestRequiresCheckBox.UseVisualStyleBackColor = true;
-      this.SuggestRequiresCheckBox.CheckedChanged += new System.EventHandler(this.SuggestRequiresCheckBox_CheckedChanged);
-      // 
-      // BaseLineUpdateButton
-      // 
-      resources.ApplyResources(this.BaseLineUpdateButton, "BaseLineUpdateButton");
-      this.BaseLineUpdateButton.Name = "BaseLineUpdateButton";
-      this.BaseLineUpdateButton.UseVisualStyleBackColor = true;
-      this.BaseLineUpdateButton.Click += new System.EventHandler(this.updateBaselineButton_Click);
-      // 
-      // ImplicitArithmeticObligationsBox
-      // 
-      resources.ApplyResources(this.ImplicitArithmeticObligationsBox, "ImplicitArithmeticObligationsBox");
-      this.ImplicitArithmeticObligationsBox.Checked = true;
-      this.ImplicitArithmeticObligationsBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.ImplicitArithmeticObligationsBox.Name = "ImplicitArithmeticObligationsBox";
-      this.ImplicitArithmeticObligationsBox.UseVisualStyleBackColor = true;
-      this.ImplicitArithmeticObligationsBox.CheckedChanged += new System.EventHandler(this.ImplicitArithmeticObligationsBox_CheckedChanged);
-      // 
-      // FailBuildOnWarningsCheckBox
-      // 
-      resources.ApplyResources(this.FailBuildOnWarningsCheckBox, "FailBuildOnWarningsCheckBox");
-      this.FailBuildOnWarningsCheckBox.Name = "FailBuildOnWarningsCheckBox";
-      this.FailBuildOnWarningsCheckBox.UseVisualStyleBackColor = true;
-      this.FailBuildOnWarningsCheckBox.CheckedChanged += new System.EventHandler(this.FailBuildOnWarningsCheckBox_CheckedChanged);
-      // 
-      // ShowSquiggliesBox
-      // 
-      resources.ApplyResources(this.ShowSquiggliesBox, "ShowSquiggliesBox");
-      this.ShowSquiggliesBox.Checked = true;
-      this.ShowSquiggliesBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.ShowSquiggliesBox.Name = "ShowSquiggliesBox";
-      this.ShowSquiggliesBox.UseVisualStyleBackColor = true;
-      this.ShowSquiggliesBox.CheckedChanged += new System.EventHandler(this.SquiggliesBox_CheckedChanged);
-      // 
-      // RunInBackgroundBox
-      // 
-      resources.ApplyResources(this.RunInBackgroundBox, "RunInBackgroundBox");
-      this.RunInBackgroundBox.Checked = true;
-      this.RunInBackgroundBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.RunInBackgroundBox.Name = "RunInBackgroundBox";
-      this.RunInBackgroundBox.UseVisualStyleBackColor = true;
-      this.RunInBackgroundBox.CheckedChanged += new System.EventHandler(this.RunInBackgroundBox_CheckedChanged);
-      // 
-      // BaseLineBox
-      // 
-      resources.ApplyResources(this.BaseLineBox, "BaseLineBox");
-      this.BaseLineBox.AccessibleRole = System.Windows.Forms.AccessibleRole.ToolTip;
-      this.BaseLineBox.Name = "BaseLineBox";
-      this.BaseLineBox.UseVisualStyleBackColor = true;
-      this.BaseLineBox.CheckedChanged += new System.EventHandler(this.BaseLineBox_CheckedChanged);
-      // 
-      // BaseLineTextBox
-      // 
-      resources.ApplyResources(this.BaseLineTextBox, "BaseLineTextBox");
-      this.BaseLineTextBox.Name = "BaseLineTextBox";
-      this.BaseLineTextBox.TextChanged += new System.EventHandler(this.BaseLineTextBox_TextChanged);
-      // 
-      // ImplicitArrayBoundObligationsBox
-      // 
-      resources.ApplyResources(this.ImplicitArrayBoundObligationsBox, "ImplicitArrayBoundObligationsBox");
-      this.ImplicitArrayBoundObligationsBox.Checked = true;
-      this.ImplicitArrayBoundObligationsBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.ImplicitArrayBoundObligationsBox.Name = "ImplicitArrayBoundObligationsBox";
-      this.ImplicitArrayBoundObligationsBox.UseVisualStyleBackColor = true;
-      this.ImplicitArrayBoundObligationsBox.CheckedChanged += new System.EventHandler(this.ImplicitArrayBoundObligationsBox_CheckedChanged);
-      // 
-      // ImplicitNonNullObligationsBox
-      // 
-      resources.ApplyResources(this.ImplicitNonNullObligationsBox, "ImplicitNonNullObligationsBox");
-      this.ImplicitNonNullObligationsBox.Checked = true;
-      this.ImplicitNonNullObligationsBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.ImplicitNonNullObligationsBox.Name = "ImplicitNonNullObligationsBox";
-      this.ImplicitNonNullObligationsBox.UseVisualStyleBackColor = true;
-      this.ImplicitNonNullObligationsBox.CheckedChanged += new System.EventHandler(this.ImplicitNonNullObligationsBox_CheckedChanged);
-      // 
-      // ImplicitEnumWritesBox
-      // 
-      resources.ApplyResources(this.ImplicitEnumWritesBox, "ImplicitEnumWritesBox");
-      this.ImplicitEnumWritesBox.Checked = true;
-      this.ImplicitEnumWritesBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.ImplicitEnumWritesBox.Name = "ImplicitEnumWritesBox";
-      this.ImplicitEnumWritesBox.UseVisualStyleBackColor = true;
-      this.ImplicitEnumWritesBox.CheckedChanged += new System.EventHandler(this.ImplicitEnumWritesBox_CheckedChanged);
-      // 
-      // EmitContractDocumentationCheckBox
-      // 
-      resources.ApplyResources(this.EmitContractDocumentationCheckBox, "EmitContractDocumentationCheckBox");
-      this.EmitContractDocumentationCheckBox.Name = "EmitContractDocumentationCheckBox";
-      this.EmitContractDocumentationCheckBox.UseVisualStyleBackColor = true;
-      this.EmitContractDocumentationCheckBox.CheckedChanged += new System.EventHandler(this.EmitContractDocumentationCheckBox_CheckedChanged);
-      // 
-      // ContractReferenceAssemblySelection
-      // 
-      this.ContractReferenceAssemblySelection.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.ContractReferenceAssemblySelection.FormattingEnabled = true;
-      this.ContractReferenceAssemblySelection.Items.AddRange(new object[] {
+            this.RuntimeCheckingLevelDropDown.Name = "RuntimeCheckingLevelDropDown";
+            this.RuntimeCheckingLevelDropDown.SelectedIndexChanged += new System.EventHandler(this.runtimeCheckingLevel_SelectedIndexChanged);
+            // 
+            // AdvancedGroup
+            // 
+            this.AdvancedGroup.Controls.Add(this.ExtraCodeAnalysisOptionsBox);
+            this.AdvancedGroup.Controls.Add(this.AdditionalCodeAnalysisOptionsLabel);
+            this.AdvancedGroup.Controls.Add(this.LibPathLabel);
+            this.AdvancedGroup.Controls.Add(this.ExtraRuntimeCheckingOptionsBox);
+            this.AdvancedGroup.Controls.Add(this.LibPathTextBox);
+            this.AdvancedGroup.Controls.Add(this.ExtraRuntimeCheckerOptionsLabel);
+            resources.ApplyResources(this.AdvancedGroup, "AdvancedGroup");
+            this.AdvancedGroup.Name = "AdvancedGroup";
+            this.AdvancedGroup.TabStop = false;
+            // 
+            // ExtraCodeAnalysisOptionsBox
+            // 
+            resources.ApplyResources(this.ExtraCodeAnalysisOptionsBox, "ExtraCodeAnalysisOptionsBox");
+            this.ExtraCodeAnalysisOptionsBox.Name = "ExtraCodeAnalysisOptionsBox";
+            this.ExtraCodeAnalysisOptionsBox.TextChanged += new System.EventHandler(this.ExtraCodeAnalysisOptionsBox_TextChanged);
+            // 
+            // AdditionalCodeAnalysisOptionsLabel
+            // 
+            resources.ApplyResources(this.AdditionalCodeAnalysisOptionsLabel, "AdditionalCodeAnalysisOptionsLabel");
+            this.AdditionalCodeAnalysisOptionsLabel.Name = "AdditionalCodeAnalysisOptionsLabel";
+            // 
+            // StaticCheckingGroup
+            // 
+            this.StaticCheckingGroup.Controls.Add(this.InferEnsuresAutoPropertiesCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.SuggestCalleeAssumptionsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.skipAnalysisIfCannotConnectToCache);
+            this.StaticCheckingGroup.Controls.Add(this.checkMissingPublicEnsures);
+            this.StaticCheckingGroup.Controls.Add(this.linkUnderstandingTheStaticChecker);
+            this.StaticCheckingGroup.Controls.Add(this.NecessaryEnsuresCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.AssertsToContractsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.RedundantTestsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.SuggestReadonlyCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.BeingOptmisticOnExternalCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.missingPublicRequiresAsWarningsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.SQLServerLabel);
+            this.StaticCheckingGroup.Controls.Add(this.SQLServerTextBox);
+            this.StaticCheckingGroup.Controls.Add(this.SuggestAssumptionsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.InferObjectInvariantsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.DeferAnalysisCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.SuggestObjectInvariantsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.WarningFullLabel);
+            this.StaticCheckingGroup.Controls.Add(this.WarningLowLabel);
+            this.StaticCheckingGroup.Controls.Add(this.WarningLevelTrackBar);
+            this.StaticCheckingGroup.Controls.Add(this.WarningLevelLabel);
+            this.StaticCheckingGroup.Controls.Add(this.CacheResultsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.redundantAssumptionsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.InferRequiresCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.InferEnsuresCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.SuggestRequiresCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.BaseLineUpdateButton);
+            this.StaticCheckingGroup.Controls.Add(this.ImplicitArithmeticObligationsBox);
+            this.StaticCheckingGroup.Controls.Add(this.FailBuildOnWarningsCheckBox);
+            this.StaticCheckingGroup.Controls.Add(this.ShowSquiggliesBox);
+            this.StaticCheckingGroup.Controls.Add(this.RunInBackgroundBox);
+            this.StaticCheckingGroup.Controls.Add(this.BaseLineBox);
+            this.StaticCheckingGroup.Controls.Add(this.BaseLineTextBox);
+            this.StaticCheckingGroup.Controls.Add(this.ImplicitArrayBoundObligationsBox);
+            this.StaticCheckingGroup.Controls.Add(this.ImplicitNonNullObligationsBox);
+            this.StaticCheckingGroup.Controls.Add(this.ImplicitEnumWritesBox);
+            this.StaticCheckingGroup.Controls.Add(this.EnableStaticCheckingBox);
+            resources.ApplyResources(this.StaticCheckingGroup, "StaticCheckingGroup");
+            this.StaticCheckingGroup.Name = "StaticCheckingGroup";
+            this.StaticCheckingGroup.TabStop = false;
+            // 
+            // InferEnsuresAutoPropertiesCheckBox
+            // 
+            resources.ApplyResources(this.InferEnsuresAutoPropertiesCheckBox, "InferEnsuresAutoPropertiesCheckBox");
+            this.InferEnsuresAutoPropertiesCheckBox.Checked = true;
+            this.InferEnsuresAutoPropertiesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.InferEnsuresAutoPropertiesCheckBox.Name = "InferEnsuresAutoPropertiesCheckBox";
+            this.InferEnsuresAutoPropertiesCheckBox.UseVisualStyleBackColor = true;
+            this.InferEnsuresAutoPropertiesCheckBox.CheckedChanged += new System.EventHandler(this.InferEnsuresAutoPropertiesCheckBox_CheckedChanged);
+            // 
+            // SuggestCalleeAssumptionsCheckBox
+            // 
+            resources.ApplyResources(this.SuggestCalleeAssumptionsCheckBox, "SuggestCalleeAssumptionsCheckBox");
+            this.SuggestCalleeAssumptionsCheckBox.Name = "SuggestCalleeAssumptionsCheckBox";
+            this.SuggestCalleeAssumptionsCheckBox.UseVisualStyleBackColor = true;
+            this.SuggestCalleeAssumptionsCheckBox.CheckedChanged += new System.EventHandler(this.SuggestCalleeAssumptionsCheckBox_CheckedChanged);
+            // 
+            // skipAnalysisIfCannotConnectToCache
+            // 
+            resources.ApplyResources(this.skipAnalysisIfCannotConnectToCache, "skipAnalysisIfCannotConnectToCache");
+            this.skipAnalysisIfCannotConnectToCache.Name = "skipAnalysisIfCannotConnectToCache";
+            this.skipAnalysisIfCannotConnectToCache.UseVisualStyleBackColor = true;
+            this.skipAnalysisIfCannotConnectToCache.CheckedChanged += new System.EventHandler(this.skipAnalysisIfCannotConnectToCache_CheckedChanged);
+            // 
+            // checkMissingPublicEnsures
+            // 
+            resources.ApplyResources(this.checkMissingPublicEnsures, "checkMissingPublicEnsures");
+            this.checkMissingPublicEnsures.Name = "checkMissingPublicEnsures";
+            this.checkMissingPublicEnsures.UseVisualStyleBackColor = true;
+            this.checkMissingPublicEnsures.CheckedChanged += new System.EventHandler(this.checkMissingPublicEnsures_CheckedChanged);
+            // 
+            // linkUnderstandingTheStaticChecker
+            // 
+            resources.ApplyResources(this.linkUnderstandingTheStaticChecker, "linkUnderstandingTheStaticChecker");
+            this.linkUnderstandingTheStaticChecker.Name = "linkUnderstandingTheStaticChecker";
+            this.linkUnderstandingTheStaticChecker.TabStop = true;
+            this.linkUnderstandingTheStaticChecker.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkUnderstandingTheStaticChecker_LinkClicked);
+            // 
+            // NecessaryEnsuresCheckBox
+            // 
+            resources.ApplyResources(this.NecessaryEnsuresCheckBox, "NecessaryEnsuresCheckBox");
+            this.NecessaryEnsuresCheckBox.Checked = true;
+            this.NecessaryEnsuresCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.NecessaryEnsuresCheckBox.Name = "NecessaryEnsuresCheckBox";
+            this.NecessaryEnsuresCheckBox.UseVisualStyleBackColor = true;
+            this.NecessaryEnsuresCheckBox.CheckedChanged += new System.EventHandler(this.NecessaryEnsuresCheckBox_CheckedChanged);
+            // 
+            // AssertsToContractsCheckBox
+            // 
+            resources.ApplyResources(this.AssertsToContractsCheckBox, "AssertsToContractsCheckBox");
+            this.AssertsToContractsCheckBox.Checked = true;
+            this.AssertsToContractsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.AssertsToContractsCheckBox.Name = "AssertsToContractsCheckBox";
+            this.AssertsToContractsCheckBox.UseVisualStyleBackColor = true;
+            this.AssertsToContractsCheckBox.CheckedChanged += new System.EventHandler(this.AssertsToContractsCheckBox_CheckedChanged);
+            // 
+            // RedundantTestsCheckBox
+            // 
+            resources.ApplyResources(this.RedundantTestsCheckBox, "RedundantTestsCheckBox");
+            this.RedundantTestsCheckBox.Checked = true;
+            this.RedundantTestsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.RedundantTestsCheckBox.Name = "RedundantTestsCheckBox";
+            this.RedundantTestsCheckBox.UseVisualStyleBackColor = true;
+            this.RedundantTestsCheckBox.CheckedChanged += new System.EventHandler(this.RedundantTestsCheckBox_CheckedChanged);
+            // 
+            // SuggestReadonlyCheckBox
+            // 
+            resources.ApplyResources(this.SuggestReadonlyCheckBox, "SuggestReadonlyCheckBox");
+            this.SuggestReadonlyCheckBox.Checked = true;
+            this.SuggestReadonlyCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.SuggestReadonlyCheckBox.Name = "SuggestReadonlyCheckBox";
+            this.SuggestReadonlyCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // BeingOptmisticOnExternalCheckBox
+            // 
+            resources.ApplyResources(this.BeingOptmisticOnExternalCheckBox, "BeingOptmisticOnExternalCheckBox");
+            this.BeingOptmisticOnExternalCheckBox.Checked = true;
+            this.BeingOptmisticOnExternalCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.BeingOptmisticOnExternalCheckBox.Name = "BeingOptmisticOnExternalCheckBox";
+            this.BeingOptmisticOnExternalCheckBox.UseVisualStyleBackColor = true;
+            this.BeingOptmisticOnExternalCheckBox.CheckedChanged += new System.EventHandler(this.BeingOptmisticOnExternalCheckBox_CheckedChanged);
+            // 
+            // missingPublicRequiresAsWarningsCheckBox
+            // 
+            resources.ApplyResources(this.missingPublicRequiresAsWarningsCheckBox, "missingPublicRequiresAsWarningsCheckBox");
+            this.missingPublicRequiresAsWarningsCheckBox.Checked = true;
+            this.missingPublicRequiresAsWarningsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.missingPublicRequiresAsWarningsCheckBox.Name = "missingPublicRequiresAsWarningsCheckBox";
+            this.missingPublicRequiresAsWarningsCheckBox.UseVisualStyleBackColor = true;
+            this.missingPublicRequiresAsWarningsCheckBox.CheckedChanged += new System.EventHandler(this.missingPublicRequiresAsWarningsCheckBox_CheckedChanged);
+            // 
+            // SQLServerLabel
+            // 
+            resources.ApplyResources(this.SQLServerLabel, "SQLServerLabel");
+            this.SQLServerLabel.Name = "SQLServerLabel";
+            // 
+            // SQLServerTextBox
+            // 
+            this.SQLServerTextBox.Enabled = this.CacheResultsCheckBox.Enabled;
+            resources.ApplyResources(this.SQLServerTextBox, "SQLServerTextBox");
+            this.SQLServerTextBox.Name = "SQLServerTextBox";
+            this.SQLServerTextBox.TextChanged += new System.EventHandler(this.SQLServerTextBox_TextChanged);
+            // 
+            // CacheResultsCheckBox
+            // 
+            resources.ApplyResources(this.CacheResultsCheckBox, "CacheResultsCheckBox");
+            this.CacheResultsCheckBox.Checked = true;
+            this.CacheResultsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CacheResultsCheckBox.Name = "CacheResultsCheckBox";
+            this.CacheResultsCheckBox.UseVisualStyleBackColor = true;
+            this.CacheResultsCheckBox.CheckedChanged += new System.EventHandler(this.CacheResultsCheckBox_CheckedChanged);
+            // 
+            // SuggestAssumptionsCheckBox
+            // 
+            resources.ApplyResources(this.SuggestAssumptionsCheckBox, "SuggestAssumptionsCheckBox");
+            this.SuggestAssumptionsCheckBox.Name = "SuggestAssumptionsCheckBox";
+            this.SuggestAssumptionsCheckBox.UseVisualStyleBackColor = true;
+            this.SuggestAssumptionsCheckBox.CheckedChanged += new System.EventHandler(this.SuggestAssumptions_CheckedChanged);
+            // 
+            // InferObjectInvariantsCheckBox
+            // 
+            resources.ApplyResources(this.InferObjectInvariantsCheckBox, "InferObjectInvariantsCheckBox");
+            this.InferObjectInvariantsCheckBox.Name = "InferObjectInvariantsCheckBox";
+            this.InferObjectInvariantsCheckBox.UseVisualStyleBackColor = true;
+            this.InferObjectInvariantsCheckBox.CheckedChanged += new System.EventHandler(this.InferObjectInvariantsCheckBox_CheckedChanged);
+            // 
+            // SuggestObjectInvariantsCheckBox
+            // 
+            resources.ApplyResources(this.SuggestObjectInvariantsCheckBox, "SuggestObjectInvariantsCheckBox");
+            this.SuggestObjectInvariantsCheckBox.Name = "SuggestObjectInvariantsCheckBox";
+            this.SuggestObjectInvariantsCheckBox.UseVisualStyleBackColor = true;
+            this.SuggestObjectInvariantsCheckBox.CheckedChanged += new System.EventHandler(this.SuggestObjectInvariantsCheckBox_CheckedChanged);
+            // 
+            // WarningFullLabel
+            // 
+            resources.ApplyResources(this.WarningFullLabel, "WarningFullLabel");
+            this.WarningFullLabel.Name = "WarningFullLabel";
+            // 
+            // WarningLowLabel
+            // 
+            resources.ApplyResources(this.WarningLowLabel, "WarningLowLabel");
+            this.WarningLowLabel.Name = "WarningLowLabel";
+            // 
+            // WarningLevelTrackBar
+            // 
+            this.WarningLevelTrackBar.LargeChange = 1;
+            resources.ApplyResources(this.WarningLevelTrackBar, "WarningLevelTrackBar");
+            this.WarningLevelTrackBar.Maximum = 3;
+            this.WarningLevelTrackBar.Name = "WarningLevelTrackBar";
+            this.WarningLevelTrackBar.Scroll += new System.EventHandler(this.WarningLevelTrackBar_Scroll);
+            // 
+            // WarningLevelLabel
+            // 
+            resources.ApplyResources(this.WarningLevelLabel, "WarningLevelLabel");
+            this.WarningLevelLabel.Name = "WarningLevelLabel";
+            // 
+            // redundantAssumptionsCheckBox
+            // 
+            resources.ApplyResources(this.redundantAssumptionsCheckBox, "redundantAssumptionsCheckBox");
+            this.redundantAssumptionsCheckBox.Checked = true;
+            this.redundantAssumptionsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.redundantAssumptionsCheckBox.Name = "redundantAssumptionsCheckBox";
+            this.redundantAssumptionsCheckBox.UseVisualStyleBackColor = true;
+            this.redundantAssumptionsCheckBox.CheckedChanged += new System.EventHandler(this.redundantAssumptionsCheckBox_CheckedChanged);
+            // 
+            // InferRequiresCheckBox
+            // 
+            resources.ApplyResources(this.InferRequiresCheckBox, "InferRequiresCheckBox");
+            this.InferRequiresCheckBox.Checked = true;
+            this.InferRequiresCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.InferRequiresCheckBox.Name = "InferRequiresCheckBox";
+            this.InferRequiresCheckBox.UseVisualStyleBackColor = true;
+            this.InferRequiresCheckBox.CheckedChanged += new System.EventHandler(this.InferRequires_CheckedChanged);
+            // 
+            // InferEnsuresCheckBox
+            // 
+            resources.ApplyResources(this.InferEnsuresCheckBox, "InferEnsuresCheckBox");
+            this.InferEnsuresCheckBox.Name = "InferEnsuresCheckBox";
+            this.InferEnsuresCheckBox.UseVisualStyleBackColor = true;
+            this.InferEnsuresCheckBox.CheckedChanged += new System.EventHandler(this.InferEnsuresCheckBox_CheckedChanged);
+            // 
+            // SuggestRequiresCheckBox
+            // 
+            resources.ApplyResources(this.SuggestRequiresCheckBox, "SuggestRequiresCheckBox");
+            this.SuggestRequiresCheckBox.Name = "SuggestRequiresCheckBox";
+            this.SuggestRequiresCheckBox.UseVisualStyleBackColor = true;
+            this.SuggestRequiresCheckBox.CheckedChanged += new System.EventHandler(this.SuggestRequiresCheckBox_CheckedChanged);
+            // 
+            // BaseLineUpdateButton
+            // 
+            resources.ApplyResources(this.BaseLineUpdateButton, "BaseLineUpdateButton");
+            this.BaseLineUpdateButton.Name = "BaseLineUpdateButton";
+            this.BaseLineUpdateButton.UseVisualStyleBackColor = true;
+            this.BaseLineUpdateButton.Click += new System.EventHandler(this.updateBaselineButton_Click);
+            // 
+            // ImplicitArithmeticObligationsBox
+            // 
+            resources.ApplyResources(this.ImplicitArithmeticObligationsBox, "ImplicitArithmeticObligationsBox");
+            this.ImplicitArithmeticObligationsBox.Checked = true;
+            this.ImplicitArithmeticObligationsBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ImplicitArithmeticObligationsBox.Name = "ImplicitArithmeticObligationsBox";
+            this.ImplicitArithmeticObligationsBox.UseVisualStyleBackColor = true;
+            this.ImplicitArithmeticObligationsBox.CheckedChanged += new System.EventHandler(this.ImplicitArithmeticObligationsBox_CheckedChanged);
+            // 
+            // FailBuildOnWarningsCheckBox
+            // 
+            resources.ApplyResources(this.FailBuildOnWarningsCheckBox, "FailBuildOnWarningsCheckBox");
+            this.FailBuildOnWarningsCheckBox.Name = "FailBuildOnWarningsCheckBox";
+            this.FailBuildOnWarningsCheckBox.UseVisualStyleBackColor = true;
+            this.FailBuildOnWarningsCheckBox.CheckedChanged += new System.EventHandler(this.FailBuildOnWarningsCheckBox_CheckedChanged);
+            // 
+            // ShowSquiggliesBox
+            // 
+            resources.ApplyResources(this.ShowSquiggliesBox, "ShowSquiggliesBox");
+            this.ShowSquiggliesBox.Checked = true;
+            this.ShowSquiggliesBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ShowSquiggliesBox.Name = "ShowSquiggliesBox";
+            this.ShowSquiggliesBox.UseVisualStyleBackColor = true;
+            this.ShowSquiggliesBox.CheckedChanged += new System.EventHandler(this.SquiggliesBox_CheckedChanged);
+            // 
+            // RunInBackgroundBox
+            // 
+            resources.ApplyResources(this.RunInBackgroundBox, "RunInBackgroundBox");
+            this.RunInBackgroundBox.Checked = true;
+            this.RunInBackgroundBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.RunInBackgroundBox.Name = "RunInBackgroundBox";
+            this.RunInBackgroundBox.UseVisualStyleBackColor = true;
+            this.RunInBackgroundBox.CheckedChanged += new System.EventHandler(this.RunInBackgroundBox_CheckedChanged);
+            // 
+            // BaseLineBox
+            // 
+            resources.ApplyResources(this.BaseLineBox, "BaseLineBox");
+            this.BaseLineBox.AccessibleRole = System.Windows.Forms.AccessibleRole.ToolTip;
+            this.BaseLineBox.Name = "BaseLineBox";
+            this.BaseLineBox.UseVisualStyleBackColor = true;
+            this.BaseLineBox.CheckedChanged += new System.EventHandler(this.BaseLineBox_CheckedChanged);
+            // 
+            // BaseLineTextBox
+            // 
+            resources.ApplyResources(this.BaseLineTextBox, "BaseLineTextBox");
+            this.BaseLineTextBox.Name = "BaseLineTextBox";
+            this.BaseLineTextBox.TextChanged += new System.EventHandler(this.BaseLineTextBox_TextChanged);
+            // 
+            // ImplicitArrayBoundObligationsBox
+            // 
+            resources.ApplyResources(this.ImplicitArrayBoundObligationsBox, "ImplicitArrayBoundObligationsBox");
+            this.ImplicitArrayBoundObligationsBox.Checked = true;
+            this.ImplicitArrayBoundObligationsBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ImplicitArrayBoundObligationsBox.Name = "ImplicitArrayBoundObligationsBox";
+            this.ImplicitArrayBoundObligationsBox.UseVisualStyleBackColor = true;
+            this.ImplicitArrayBoundObligationsBox.CheckedChanged += new System.EventHandler(this.ImplicitArrayBoundObligationsBox_CheckedChanged);
+            // 
+            // ImplicitNonNullObligationsBox
+            // 
+            resources.ApplyResources(this.ImplicitNonNullObligationsBox, "ImplicitNonNullObligationsBox");
+            this.ImplicitNonNullObligationsBox.Checked = true;
+            this.ImplicitNonNullObligationsBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ImplicitNonNullObligationsBox.Name = "ImplicitNonNullObligationsBox";
+            this.ImplicitNonNullObligationsBox.UseVisualStyleBackColor = true;
+            this.ImplicitNonNullObligationsBox.CheckedChanged += new System.EventHandler(this.ImplicitNonNullObligationsBox_CheckedChanged);
+            // 
+            // ImplicitEnumWritesBox
+            // 
+            resources.ApplyResources(this.ImplicitEnumWritesBox, "ImplicitEnumWritesBox");
+            this.ImplicitEnumWritesBox.Checked = true;
+            this.ImplicitEnumWritesBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ImplicitEnumWritesBox.Name = "ImplicitEnumWritesBox";
+            this.ImplicitEnumWritesBox.UseVisualStyleBackColor = true;
+            this.ImplicitEnumWritesBox.CheckedChanged += new System.EventHandler(this.ImplicitEnumWritesBox_CheckedChanged);
+            // 
+            // EmitContractDocumentationCheckBox
+            // 
+            resources.ApplyResources(this.EmitContractDocumentationCheckBox, "EmitContractDocumentationCheckBox");
+            this.EmitContractDocumentationCheckBox.Name = "EmitContractDocumentationCheckBox";
+            this.EmitContractDocumentationCheckBox.UseVisualStyleBackColor = true;
+            this.EmitContractDocumentationCheckBox.CheckedChanged += new System.EventHandler(this.EmitContractDocumentationCheckBox_CheckedChanged);
+            // 
+            // ContractReferenceAssemblySelection
+            // 
+            this.ContractReferenceAssemblySelection.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.ContractReferenceAssemblySelection.FormattingEnabled = true;
+            this.ContractReferenceAssemblySelection.Items.AddRange(new object[] {
             resources.GetString("ContractReferenceAssemblySelection.Items"),
             resources.GetString("ContractReferenceAssemblySelection.Items1"),
             resources.GetString("ContractReferenceAssemblySelection.Items2")});
-      resources.ApplyResources(this.ContractReferenceAssemblySelection, "ContractReferenceAssemblySelection");
-      this.ContractReferenceAssemblySelection.Name = "ContractReferenceAssemblySelection";
-      this.ContractReferenceAssemblySelection.SelectedIndexChanged += new System.EventHandler(this.ContractReferenceAssemblySelection_SelectedIndexChanged);
-      // 
-      // VersionLabel
-      // 
-      resources.ApplyResources(this.VersionLabel, "VersionLabel");
-      this.VersionLabel.Name = "VersionLabel";
-      this.VersionLabel.TabStop = true;
-      this.VersionLabel.Click += new System.EventHandler(this.VersionLabel_Click);
-      // 
-      // contractReferenceAssemblyGroup
-      // 
-      this.contractReferenceAssemblyGroup.Controls.Add(this.ContractReferenceAssemblySelection);
-      this.contractReferenceAssemblyGroup.Controls.Add(this.EmitContractDocumentationCheckBox);
-      resources.ApplyResources(this.contractReferenceAssemblyGroup, "contractReferenceAssemblyGroup");
-      this.contractReferenceAssemblyGroup.Name = "contractReferenceAssemblyGroup";
-      this.contractReferenceAssemblyGroup.TabStop = false;
-      // 
-      // AssemblyModeLabel
-      // 
-      resources.ApplyResources(this.AssemblyModeLabel, "AssemblyModeLabel");
-      this.AssemblyModeLabel.Name = "AssemblyModeLabel";
-      // 
-      // AssemblyModeDropDown
-      // 
-      this.AssemblyModeDropDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.AssemblyModeDropDown.FormattingEnabled = true;
-      this.AssemblyModeDropDown.Items.AddRange(new object[] {
+            resources.ApplyResources(this.ContractReferenceAssemblySelection, "ContractReferenceAssemblySelection");
+            this.ContractReferenceAssemblySelection.Name = "ContractReferenceAssemblySelection";
+            this.ContractReferenceAssemblySelection.SelectedIndexChanged += new System.EventHandler(this.ContractReferenceAssemblySelection_SelectedIndexChanged);
+            // 
+            // VersionLabel
+            // 
+            resources.ApplyResources(this.VersionLabel, "VersionLabel");
+            this.VersionLabel.Name = "VersionLabel";
+            this.VersionLabel.TabStop = true;
+            this.VersionLabel.Click += new System.EventHandler(this.VersionLabel_Click);
+            // 
+            // contractReferenceAssemblyGroup
+            // 
+            this.contractReferenceAssemblyGroup.Controls.Add(this.ContractReferenceAssemblySelection);
+            this.contractReferenceAssemblyGroup.Controls.Add(this.EmitContractDocumentationCheckBox);
+            resources.ApplyResources(this.contractReferenceAssemblyGroup, "contractReferenceAssemblyGroup");
+            this.contractReferenceAssemblyGroup.Name = "contractReferenceAssemblyGroup";
+            this.contractReferenceAssemblyGroup.TabStop = false;
+            // 
+            // AssemblyModeLabel
+            // 
+            resources.ApplyResources(this.AssemblyModeLabel, "AssemblyModeLabel");
+            this.AssemblyModeLabel.Name = "AssemblyModeLabel";
+            // 
+            // AssemblyModeDropDown
+            // 
+            this.AssemblyModeDropDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.AssemblyModeDropDown.FormattingEnabled = true;
+            this.AssemblyModeDropDown.Items.AddRange(new object[] {
             resources.GetString("AssemblyModeDropDown.Items"),
             resources.GetString("AssemblyModeDropDown.Items1")});
-      resources.ApplyResources(this.AssemblyModeDropDown, "AssemblyModeDropDown");
-      this.AssemblyModeDropDown.Name = "AssemblyModeDropDown";
-      this.AssemblyModeDropDown.SelectedIndexChanged += new System.EventHandler(this.AssemblyModeDropDown_SelectedIndexChanged);
-      // 
-      // docLink
-      // 
-      resources.ApplyResources(this.docLink, "docLink");
-      this.docLink.Name = "docLink";
-      this.docLink.TabStop = true;
-      this.docLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.docLink_LinkClicked);
-      // 
-      // help_Link
-      // 
-      resources.ApplyResources(this.help_Link, "help_Link");
-      this.help_Link.Name = "help_Link";
-      this.help_Link.TabStop = true;
-      this.help_Link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.help_Link_LinkClicked);
-      // 
-      // InferEnsuresAutoPropertiesCheckBox
-      // 
-      resources.ApplyResources(this.InferEnsuresAutoPropertiesCheckBox, "InferEnsuresAutoPropertiesCheckBox");
-      this.InferEnsuresAutoPropertiesCheckBox.Checked = true;
-      this.InferEnsuresAutoPropertiesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-      this.InferEnsuresAutoPropertiesCheckBox.Name = "InferEnsuresAutoPropertiesCheckBox";
-      this.InferEnsuresAutoPropertiesCheckBox.UseVisualStyleBackColor = true;
-      this.InferEnsuresAutoPropertiesCheckBox.CheckedChanged += new System.EventHandler(this.InferEnsuresAutoPropertiesCheckBox_CheckedChanged);
-      // 
-      // PropertyPane
-      // 
-      resources.ApplyResources(this, "$this");
-      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-      this.Controls.Add(this.help_Link);
-      this.Controls.Add(this.docLink);
-      this.Controls.Add(this.AssemblyModeDropDown);
-      this.Controls.Add(this.AssemblyModeLabel);
-      this.Controls.Add(this.contractReferenceAssemblyGroup);
-      this.Controls.Add(this.VersionLabel);
-      this.Controls.Add(this.StaticCheckingGroup);
-      this.Controls.Add(this.AdvancedGroup);
-      this.Controls.Add(this.RuntimeCheckingGroup);
-      this.Name = "PropertyPane";
-      this.Load += new System.EventHandler(this.PropertyPane_Load);
-      this.RuntimeCheckingGroup.ResumeLayout(false);
-      this.RuntimeCheckingGroup.PerformLayout();
-      this.AdvancedGroup.ResumeLayout(false);
-      this.AdvancedGroup.PerformLayout();
-      this.StaticCheckingGroup.ResumeLayout(false);
-      this.StaticCheckingGroup.PerformLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.WarningLevelTrackBar)).EndInit();
-      this.contractReferenceAssemblyGroup.ResumeLayout(false);
-      this.contractReferenceAssemblyGroup.PerformLayout();
-      this.ResumeLayout(false);
-      this.PerformLayout();
+            resources.ApplyResources(this.AssemblyModeDropDown, "AssemblyModeDropDown");
+            this.AssemblyModeDropDown.Name = "AssemblyModeDropDown";
+            this.AssemblyModeDropDown.SelectedIndexChanged += new System.EventHandler(this.AssemblyModeDropDown_SelectedIndexChanged);
+            // 
+            // docLink
+            // 
+            resources.ApplyResources(this.docLink, "docLink");
+            this.docLink.Name = "docLink";
+            this.docLink.TabStop = true;
+            this.docLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.docLink_LinkClicked);
+            // 
+            // help_Link
+            // 
+            resources.ApplyResources(this.help_Link, "help_Link");
+            this.help_Link.Name = "help_Link";
+            this.help_Link.TabStop = true;
+            this.help_Link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.help_Link_LinkClicked);
+            // 
+            // DeferAnalysisCheckBox
+            // 
+            resources.ApplyResources(this.DeferAnalysisCheckBox, "DeferAnalysisCheckBox");
+            this.DeferAnalysisCheckBox.Name = "DeferAnalysisCheckBox";
+            this.DeferAnalysisCheckBox.UseVisualStyleBackColor = true;
+            this.DeferAnalysisCheckBox.CheckedChanged += new System.EventHandler(this.DeferAnalysisCheckBox_CheckedChanged);
+            // 
+            // PropertyPane
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.help_Link);
+            this.Controls.Add(this.docLink);
+            this.Controls.Add(this.AssemblyModeDropDown);
+            this.Controls.Add(this.AssemblyModeLabel);
+            this.Controls.Add(this.contractReferenceAssemblyGroup);
+            this.Controls.Add(this.VersionLabel);
+            this.Controls.Add(this.StaticCheckingGroup);
+            this.Controls.Add(this.AdvancedGroup);
+            this.Controls.Add(this.RuntimeCheckingGroup);
+            this.Name = "PropertyPane";
+            this.Load += new System.EventHandler(this.PropertyPane_Load);
+            this.RuntimeCheckingGroup.ResumeLayout(false);
+            this.RuntimeCheckingGroup.PerformLayout();
+            this.AdvancedGroup.ResumeLayout(false);
+            this.AdvancedGroup.PerformLayout();
+            this.StaticCheckingGroup.ResumeLayout(false);
+            this.StaticCheckingGroup.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.WarningLevelTrackBar)).EndInit();
+            this.contractReferenceAssemblyGroup.ResumeLayout(false);
+            this.contractReferenceAssemblyGroup.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
     }
 
@@ -731,5 +740,6 @@ namespace Microsoft.Contracts.VisualStudio {
     private System.Windows.Forms.CheckBox skipAnalysisIfCannotConnectToCache;
     private System.Windows.Forms.CheckBox SuggestCalleeAssumptionsCheckBox;
     private System.Windows.Forms.CheckBox InferEnsuresAutoPropertiesCheckBox;
+    private System.Windows.Forms.CheckBox DeferAnalysisCheckBox;
   }
 }

--- a/Microsoft.Research/ManagedContractsVSPropertyPane/PropertyPane.cs
+++ b/Microsoft.Research/ManagedContractsVSPropertyPane/PropertyPane.cs
@@ -76,7 +76,9 @@ namespace Microsoft.Contracts.VisualStudio
         new CheckBoxProperty("CodeContractsCacheAnalysisResults", CacheResultsCheckBox, true),
         new CheckBoxProperty("CodeContractsSkipAnalysisIfCannotConnectToCache", skipAnalysisIfCannotConnectToCache, false),
         new CheckBoxProperty("CodeContractsFailBuildOnWarnings", FailBuildOnWarningsCheckBox, false),
-        new CheckBoxProperty("CodeContractsBeingOptimisticOnExternal", BeingOptmisticOnExternalCheckBox, true)
+        new CheckBoxProperty("CodeContractsBeingOptimisticOnExternal", BeingOptmisticOnExternalCheckBox, true),
+
+        new CheckBoxProperty("CodeContractsDeferCodeAnalysis", DeferAnalysisCheckBox, false)
       };
         }
 
@@ -173,6 +175,8 @@ namespace Microsoft.Contracts.VisualStudio
             AssertsToContractsCheckBox.Enabled = enabled;
             NecessaryEnsuresCheckBox.Enabled = enabled;
             RedundantTestsCheckBox.Enabled = enabled;
+
+            DeferAnalysisCheckBox.Enabled = enabled;
 #endif
         }
 
@@ -199,8 +203,14 @@ namespace Microsoft.Contracts.VisualStudio
         private void EnableDisableBackgroundDependentUI()
         {
             // Enable/Disable dependent options
-            FailBuildOnWarningsCheckBox.Enabled = IsUnChecked(RunInBackgroundBox.CheckState) && IsChecked(EnableStaticCheckingBox.CheckState);
+            FailBuildOnWarningsCheckBox.Enabled = IsUnChecked(RunInBackgroundBox.CheckState) && IsChecked(EnableStaticCheckingBox.CheckState) && IsUnChecked(DeferAnalysisCheckBox.CheckState);
         }
+
+		private void EnableDisableDeferDependentUI()
+		{
+			RunInBackgroundBox.Enabled = IsUnChecked(DeferAnalysisCheckBox.CheckState) && IsChecked(EnableStaticCheckingBox.CheckState);
+			EnableDisableBackgroundDependentUI();
+		}
 
         private void EnableDisableCacheDependendUI()
         {
@@ -297,7 +307,8 @@ namespace Microsoft.Contracts.VisualStudio
 
             EnableDisableBaseLineUI();
 
-            EnableDisableBackgroundDependentUI();
+            EnableDisableDeferDependentUI();
+			EnableDisableBackgroundDependentUI();
 
             EnableDisableCacheDependendUI();
 
@@ -427,6 +438,8 @@ namespace Microsoft.Contracts.VisualStudio
         {
             PropertiesChanged();
             EnableDisableStaticDependentUI();
+			EnableDisableDeferDependentUI();
+			EnableDisableBackgroundDependentUI();
         }
 
         private void LibPathTextBox_TextChanged(object sender, EventArgs e)
@@ -746,6 +759,12 @@ namespace Microsoft.Contracts.VisualStudio
         private void InferEnsuresAutoPropertiesCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             this.PropertiesChanged();
+        }
+
+        private void DeferAnalysisCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            this.PropertiesChanged();
+			EnableDisableDeferDependentUI();
         }
     }
 }

--- a/Microsoft.Research/ManagedContractsVSPropertyPane/PropertyPane.resx
+++ b/Microsoft.Research/ManagedContractsVSPropertyPane/PropertyPane.resx
@@ -123,14 +123,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="EnableRuntimeCheckingBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 29</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="EnableRuntimeCheckingBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>8, 19</value>
   </data>
   <data name="EnableRuntimeCheckingBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>290, 24</value>
+    <value>195, 17</value>
   </data>
   <data name="EnableRuntimeCheckingBox.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -154,13 +150,10 @@
     <value>True</value>
   </data>
   <data name="EnableStaticCheckingBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 37</value>
-  </data>
-  <data name="EnableStaticCheckingBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>8, 24</value>
   </data>
   <data name="EnableStaticCheckingBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 24</value>
+    <value>183, 17</value>
   </data>
   <data name="EnableStaticCheckingBox.TabIndex" type="System.Int32, mscorlib">
     <value>41</value>
@@ -178,16 +171,13 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;EnableStaticCheckingBox.ZOrder" xml:space="preserve">
-    <value>35</value>
+    <value>36</value>
   </data>
   <data name="LibPathTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 35</value>
-  </data>
-  <data name="LibPathTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>186, 23</value>
   </data>
   <data name="LibPathTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>544, 26</value>
+    <value>364, 20</value>
   </data>
   <data name="LibPathTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>92</value>
@@ -208,13 +198,10 @@
     <value>True</value>
   </data>
   <data name="LibPathLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>38, 42</value>
-  </data>
-  <data name="LibPathLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>25, 27</value>
   </data>
   <data name="LibPathLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>207, 20</value>
+    <value>138, 13</value>
   </data>
   <data name="LibPathLabel.TabIndex" type="System.Int32, mscorlib">
     <value>91</value>
@@ -238,13 +225,10 @@
     <value>True</value>
   </data>
   <data name="ExtraRuntimeCheckerOptionsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>38, 83</value>
-  </data>
-  <data name="ExtraRuntimeCheckerOptionsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>25, 54</value>
   </data>
   <data name="ExtraRuntimeCheckerOptionsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>232, 20</value>
+    <value>155, 13</value>
   </data>
   <data name="ExtraRuntimeCheckerOptionsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>93</value>
@@ -265,13 +249,10 @@
     <value>5</value>
   </data>
   <data name="ExtraRuntimeCheckingOptionsBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 78</value>
-  </data>
-  <data name="ExtraRuntimeCheckingOptionsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>186, 51</value>
   </data>
   <data name="ExtraRuntimeCheckingOptionsBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>544, 26</value>
+    <value>364, 20</value>
   </data>
   <data name="ExtraRuntimeCheckingOptionsBox.TabIndex" type="System.Int32, mscorlib">
     <value>94</value>
@@ -289,13 +270,10 @@
     <value>3</value>
   </data>
   <data name="CustomRewriterMethodsClassTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>390, 85</value>
-  </data>
-  <data name="CustomRewriterMethodsClassTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>260, 55</value>
   </data>
   <data name="CustomRewriterMethodsClassTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 26</value>
+    <value>100, 20</value>
   </data>
   <data name="CustomRewriterMethodsClassTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -316,13 +294,10 @@
     <value>True</value>
   </data>
   <data name="CustomRewriterMethodsClassLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>334, 89</value>
-  </data>
-  <data name="CustomRewriterMethodsClassLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>223, 58</value>
   </data>
   <data name="CustomRewriterMethodsClassLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 20</value>
+    <value>32, 13</value>
   </data>
   <data name="CustomRewriterMethodsClassLabel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -346,13 +321,10 @@
     <value>True</value>
   </data>
   <data name="CustomRewriterMethodsAssemblyLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>38, 89</value>
-  </data>
-  <data name="CustomRewriterMethodsAssemblyLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>25, 58</value>
   </data>
   <data name="CustomRewriterMethodsAssemblyLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 20</value>
+    <value>51, 13</value>
   </data>
   <data name="CustomRewriterMethodsAssemblyLabel.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -373,13 +345,10 @@
     <value>9</value>
   </data>
   <data name="CustomRewriterMethodsAssemblyTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>118, 85</value>
-  </data>
-  <data name="CustomRewriterMethodsAssemblyTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>79, 55</value>
   </data>
   <data name="CustomRewriterMethodsAssemblyTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 26</value>
+    <value>138, 20</value>
   </data>
   <data name="CustomRewriterMethodsAssemblyTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -400,13 +369,10 @@
     <value>True</value>
   </data>
   <data name="CustomRewriterMethodsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>38, 60</value>
-  </data>
-  <data name="CustomRewriterMethodsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>25, 39</value>
   </data>
   <data name="CustomRewriterMethodsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 20</value>
+    <value>128, 13</value>
   </data>
   <data name="CustomRewriterMethodsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -487,16 +453,10 @@
     <value>4</value>
   </data>
   <data name="RuntimeCheckingGroup.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 52</value>
-  </data>
-  <data name="RuntimeCheckingGroup.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="RuntimeCheckingGroup.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 34</value>
   </data>
   <data name="RuntimeCheckingGroup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>836, 148</value>
+    <value>557, 96</value>
   </data>
   <data name="RuntimeCheckingGroup.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -519,17 +479,15 @@
   <data name="SkipQuantifiersBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="SkipQuantifiersBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="SkipQuantifiersBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>574, 117</value>
-  </data>
-  <data name="SkipQuantifiersBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>383, 76</value>
   </data>
   <data name="SkipQuantifiersBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 24</value>
+    <value>100, 17</value>
   </data>
   <data name="SkipQuantifiersBox.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -553,13 +511,10 @@
     <value>True</value>
   </data>
   <data name="CallSiteRequiresBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>574, 88</value>
-  </data>
-  <data name="CallSiteRequiresBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>383, 57</value>
   </data>
   <data name="CallSiteRequiresBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>229, 24</value>
+    <value>155, 17</value>
   </data>
   <data name="CallSiteRequiresBox.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -583,13 +538,10 @@
     <value>True</value>
   </data>
   <data name="AssertOnFailureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>574, 58</value>
-  </data>
-  <data name="AssertOnFailureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>383, 38</value>
   </data>
   <data name="AssertOnFailureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>220, 24</value>
+    <value>147, 17</value>
   </data>
   <data name="AssertOnFailureBox.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -613,13 +565,10 @@
     <value>True</value>
   </data>
   <data name="OnlyPublicSurfaceContractsBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>574, 29</value>
-  </data>
-  <data name="OnlyPublicSurfaceContractsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>383, 19</value>
   </data>
   <data name="OnlyPublicSurfaceContractsBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>245, 24</value>
+    <value>167, 17</value>
   </data>
   <data name="OnlyPublicSurfaceContractsBox.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -658,13 +607,10 @@
     <value>None</value>
   </data>
   <data name="RuntimeCheckingLevelDropDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>314, 23</value>
-  </data>
-  <data name="RuntimeCheckingLevelDropDown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>209, 15</value>
   </data>
   <data name="RuntimeCheckingLevelDropDown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 28</value>
+    <value>105, 21</value>
   </data>
   <data name="RuntimeCheckingLevelDropDown.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -706,16 +652,10 @@
     <value>1</value>
   </data>
   <data name="AdvancedGroup.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 914</value>
-  </data>
-  <data name="AdvancedGroup.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="AdvancedGroup.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 594</value>
   </data>
   <data name="AdvancedGroup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>836, 168</value>
+    <value>557, 109</value>
   </data>
   <data name="AdvancedGroup.TabIndex" type="System.Int32, mscorlib">
     <value>90</value>
@@ -736,13 +676,10 @@
     <value>7</value>
   </data>
   <data name="ExtraCodeAnalysisOptionsBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 118</value>
-  </data>
-  <data name="ExtraCodeAnalysisOptionsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>186, 77</value>
   </data>
   <data name="ExtraCodeAnalysisOptionsBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>544, 26</value>
+    <value>364, 20</value>
   </data>
   <data name="ExtraCodeAnalysisOptionsBox.TabIndex" type="System.Int32, mscorlib">
     <value>96</value>
@@ -763,13 +700,10 @@
     <value>True</value>
   </data>
   <data name="AdditionalCodeAnalysisOptionsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>38, 123</value>
-  </data>
-  <data name="AdditionalCodeAnalysisOptionsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>25, 80</value>
   </data>
   <data name="AdditionalCodeAnalysisOptionsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>213, 20</value>
+    <value>143, 13</value>
   </data>
   <data name="AdditionalCodeAnalysisOptionsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>95</value>
@@ -799,13 +733,10 @@
     <value>NoControl</value>
   </data>
   <data name="InferEnsuresAutoPropertiesCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 360</value>
-  </data>
-  <data name="InferEnsuresAutoPropertiesCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>189, 234</value>
   </data>
   <data name="InferEnsuresAutoPropertiesCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>259, 24</value>
+    <value>172, 17</value>
   </data>
   <data name="InferEnsuresAutoPropertiesCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>1009</value>
@@ -832,13 +763,10 @@
     <value>NoControl</value>
   </data>
   <data name="SuggestCalleeAssumptionsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 218</value>
-  </data>
-  <data name="SuggestCalleeAssumptionsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>189, 142</value>
   </data>
   <data name="SuggestCalleeAssumptionsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>229, 24</value>
+    <value>154, 17</value>
   </data>
   <data name="SuggestCalleeAssumptionsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>1008</value>
@@ -865,13 +793,10 @@
     <value>NoControl</value>
   </data>
   <data name="skipAnalysisIfCannotConnectToCache.Location" type="System.Drawing.Point, System.Drawing">
-    <value>330, 437</value>
-  </data>
-  <data name="skipAnalysisIfCannotConnectToCache.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>220, 284</value>
   </data>
   <data name="skipAnalysisIfCannotConnectToCache.Size" type="System.Drawing.Size, System.Drawing">
-    <value>344, 24</value>
+    <value>236, 17</value>
   </data>
   <data name="skipAnalysisIfCannotConnectToCache.TabIndex" type="System.Int32, mscorlib">
     <value>1007</value>
@@ -898,13 +823,10 @@
     <value>NoControl</value>
   </data>
   <data name="checkMissingPublicEnsures.Location" type="System.Drawing.Point, System.Drawing">
-    <value>549, 143</value>
-  </data>
-  <data name="checkMissingPublicEnsures.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>366, 93</value>
   </data>
   <data name="checkMissingPublicEnsures.Size" type="System.Drawing.Size, System.Drawing">
-    <value>243, 24</value>
+    <value>165, 17</value>
   </data>
   <data name="checkMissingPublicEnsures.TabIndex" type="System.Int32, mscorlib">
     <value>1006</value>
@@ -931,13 +853,10 @@
     <value>NoControl</value>
   </data>
   <data name="linkUnderstandingTheStaticChecker.Location" type="System.Drawing.Point, System.Drawing">
-    <value>594, 25</value>
-  </data>
-  <data name="linkUnderstandingTheStaticChecker.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>396, 16</value>
   </data>
   <data name="linkUnderstandingTheStaticChecker.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 20</value>
+    <value>164, 13</value>
   </data>
   <data name="linkUnderstandingTheStaticChecker.TabIndex" type="System.Int32, mscorlib">
     <value>91</value>
@@ -964,13 +883,10 @@
     <value>NoControl</value>
   </data>
   <data name="NecessaryEnsuresCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 289</value>
-  </data>
-  <data name="NecessaryEnsuresCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>189, 188</value>
   </data>
   <data name="NecessaryEnsuresCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>232, 24</value>
+    <value>156, 17</value>
   </data>
   <data name="NecessaryEnsuresCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>1005</value>
@@ -997,13 +913,10 @@
     <value>NoControl</value>
   </data>
   <data name="AssertsToContractsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 289</value>
-  </data>
-  <data name="AssertsToContractsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>27, 188</value>
   </data>
   <data name="AssertsToContractsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>239, 24</value>
+    <value>160, 17</value>
   </data>
   <data name="AssertsToContractsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>1004</value>
@@ -1030,13 +943,10 @@
     <value>NoControl</value>
   </data>
   <data name="RedundantTestsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 183</value>
-  </data>
-  <data name="RedundantTestsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>189, 119</value>
   </data>
   <data name="RedundantTestsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>245, 24</value>
+    <value>167, 17</value>
   </data>
   <data name="RedundantTestsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>1003</value>
@@ -1063,13 +973,10 @@
     <value>NoControl</value>
   </data>
   <data name="SuggestReadonlyCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 254</value>
-  </data>
-  <data name="SuggestReadonlyCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>189, 165</value>
   </data>
   <data name="SuggestReadonlyCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 24</value>
+    <value>135, 17</value>
   </data>
   <data name="SuggestReadonlyCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>1002</value>
@@ -1096,13 +1003,10 @@
     <value>NoControl</value>
   </data>
   <data name="BeingOptmisticOnExternalCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>361, 481</value>
-  </data>
-  <data name="BeingOptmisticOnExternalCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>241, 313</value>
   </data>
   <data name="BeingOptmisticOnExternalCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>237, 24</value>
+    <value>160, 17</value>
   </data>
   <data name="BeingOptmisticOnExternalCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>1001</value>
@@ -1129,13 +1033,10 @@
     <value>NoControl</value>
   </data>
   <data name="missingPublicRequiresAsWarningsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 143</value>
-  </data>
-  <data name="missingPublicRequiresAsWarningsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>189, 93</value>
   </data>
   <data name="missingPublicRequiresAsWarningsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>243, 24</value>
+    <value>165, 17</value>
   </data>
   <data name="missingPublicRequiresAsWarningsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>51</value>
@@ -1162,13 +1063,10 @@
     <value>NoControl</value>
   </data>
   <data name="SQLServerLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>226, 397</value>
-  </data>
-  <data name="SQLServerLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>151, 258</value>
   </data>
   <data name="SQLServerLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 20</value>
+    <value>62, 13</value>
   </data>
   <data name="SQLServerLabel.TabIndex" type="System.Int32, mscorlib">
     <value>62</value>
@@ -1198,16 +1096,13 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;CacheResultsCheckBox.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>21</value>
   </data>
   <data name="SQLServerTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>329, 394</value>
-  </data>
-  <data name="SQLServerTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>219, 256</value>
   </data>
   <data name="SQLServerTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>463, 26</value>
+    <value>310, 20</value>
   </data>
   <data name="SQLServerTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>65</value>
@@ -1231,13 +1126,10 @@
     <value>NoControl</value>
   </data>
   <data name="SuggestAssumptionsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 218</value>
-  </data>
-  <data name="SuggestAssumptionsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>27, 142</value>
   </data>
   <data name="SuggestAssumptionsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 24</value>
+    <value>140, 17</value>
   </data>
   <data name="SuggestAssumptionsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>53</value>
@@ -1264,13 +1156,10 @@
     <value>NoControl</value>
   </data>
   <data name="InferObjectInvariantsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 325</value>
-  </data>
-  <data name="InferObjectInvariantsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>189, 211</value>
   </data>
   <data name="InferObjectInvariantsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>226, 24</value>
+    <value>153, 17</value>
   </data>
   <data name="InferObjectInvariantsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>58</value>
@@ -1290,6 +1179,36 @@
   <data name="&gt;&gt;InferObjectInvariantsCheckBox.ZOrder" xml:space="preserve">
     <value>14</value>
   </data>
+  <data name="DeferAnalysisCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="DeferAnalysisCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="DeferAnalysisCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>366, 119</value>
+  </data>
+  <data name="DeferAnalysisCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>166, 17</value>
+  </data>
+  <data name="DeferAnalysisCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>59</value>
+  </data>
+  <data name="DeferAnalysisCheckBox.Text" xml:space="preserve">
+    <value>Create checking artifacts only</value>
+  </data>
+  <data name="&gt;&gt;DeferAnalysisCheckBox.Name" xml:space="preserve">
+    <value>DeferAnalysisCheckBox</value>
+  </data>
+  <data name="&gt;&gt;DeferAnalysisCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DeferAnalysisCheckBox.Parent" xml:space="preserve">
+    <value>StaticCheckingGroup</value>
+  </data>
+  <data name="&gt;&gt;DeferAnalysisCheckBox.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
   <data name="SuggestObjectInvariantsCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1297,13 +1216,10 @@
     <value>NoControl</value>
   </data>
   <data name="SuggestObjectInvariantsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>549, 254</value>
-  </data>
-  <data name="SuggestObjectInvariantsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>366, 165</value>
   </data>
   <data name="SuggestObjectInvariantsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>217, 24</value>
+    <value>148, 17</value>
   </data>
   <data name="SuggestObjectInvariantsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>59</value>
@@ -1321,7 +1237,7 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;SuggestObjectInvariantsCheckBox.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="WarningFullLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1330,13 +1246,10 @@
     <value>NoControl</value>
   </data>
   <data name="WarningFullLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>283, 458</value>
-  </data>
-  <data name="WarningFullLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>189, 298</value>
   </data>
   <data name="WarningFullLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>21, 20</value>
+    <value>15, 13</value>
   </data>
   <data name="WarningFullLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1000</value>
@@ -1354,19 +1267,16 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;WarningFullLabel.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>17</value>
   </data>
   <data name="WarningLowLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="WarningLowLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>178, 458</value>
-  </data>
-  <data name="WarningLowLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>119, 298</value>
   </data>
   <data name="WarningLowLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 20</value>
+    <value>23, 13</value>
   </data>
   <data name="WarningLowLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1000</value>
@@ -1384,16 +1294,13 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;WarningLowLabel.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="WarningLevelTrackBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>166, 481</value>
-  </data>
-  <data name="WarningLevelTrackBar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>111, 313</value>
   </data>
   <data name="WarningLevelTrackBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 69</value>
+    <value>101, 45</value>
   </data>
   <data name="WarningLevelTrackBar.TabIndex" type="System.Int32, mscorlib">
     <value>74</value>
@@ -1408,7 +1315,7 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;WarningLevelTrackBar.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>19</value>
   </data>
   <data name="WarningLevelLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1417,13 +1324,10 @@
     <value>NoControl</value>
   </data>
   <data name="WarningLevelLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>43, 504</value>
-  </data>
-  <data name="WarningLevelLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>29, 328</value>
   </data>
   <data name="WarningLevelLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>113, 20</value>
+    <value>79, 13</value>
   </data>
   <data name="WarningLevelLabel.TabIndex" type="System.Int32, mscorlib">
     <value>73</value>
@@ -1441,7 +1345,7 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;WarningLevelLabel.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>20</value>
   </data>
   <data name="CacheResultsCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1450,13 +1354,10 @@
     <value>NoControl</value>
   </data>
   <data name="CacheResultsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 393</value>
-  </data>
-  <data name="CacheResultsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>27, 255</value>
   </data>
   <data name="CacheResultsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>132, 24</value>
+    <value>90, 17</value>
   </data>
   <data name="CacheResultsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>61</value>
@@ -1474,19 +1375,16 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;CacheResultsCheckBox.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>21</value>
   </data>
   <data name="redundantAssumptionsCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="redundantAssumptionsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 183</value>
-  </data>
-  <data name="redundantAssumptionsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>27, 119</value>
   </data>
   <data name="redundantAssumptionsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>217, 24</value>
+    <value>147, 17</value>
   </data>
   <data name="redundantAssumptionsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>52</value>
@@ -1504,19 +1402,16 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;redundantAssumptionsCheckBox.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>22</value>
   </data>
   <data name="InferRequiresCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="InferRequiresCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 325</value>
-  </data>
-  <data name="InferRequiresCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>27, 211</value>
   </data>
   <data name="InferRequiresCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 24</value>
+    <value>87, 17</value>
   </data>
   <data name="InferRequiresCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>54</value>
@@ -1534,7 +1429,7 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;InferRequiresCheckBox.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>23</value>
   </data>
   <data name="InferEnsuresCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1546,13 +1441,10 @@
     <value>NoControl</value>
   </data>
   <data name="InferEnsuresCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 359</value>
-  </data>
-  <data name="InferEnsuresCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>27, 233</value>
   </data>
   <data name="InferEnsuresCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 24</value>
+    <value>87, 17</value>
   </data>
   <data name="InferEnsuresCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>56</value>
@@ -1570,7 +1462,7 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;InferEnsuresCheckBox.ZOrder" xml:space="preserve">
-    <value>23</value>
+    <value>24</value>
   </data>
   <data name="SuggestRequiresCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1579,13 +1471,10 @@
     <value>NoControl</value>
   </data>
   <data name="SuggestRequiresCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 254</value>
-  </data>
-  <data name="SuggestRequiresCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>27, 165</value>
   </data>
   <data name="SuggestRequiresCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 24</value>
+    <value>105, 17</value>
   </data>
   <data name="SuggestRequiresCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>55</value>
@@ -1603,16 +1492,13 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;SuggestRequiresCheckBox.ZOrder" xml:space="preserve">
-    <value>24</value>
+    <value>25</value>
   </data>
   <data name="BaseLineUpdateButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>748, 549</value>
-  </data>
-  <data name="BaseLineUpdateButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>499, 357</value>
   </data>
   <data name="BaseLineUpdateButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 35</value>
+    <value>53, 23</value>
   </data>
   <data name="BaseLineUpdateButton.TabIndex" type="System.Int32, mscorlib">
     <value>72</value>
@@ -1630,19 +1516,16 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;BaseLineUpdateButton.ZOrder" xml:space="preserve">
-    <value>25</value>
+    <value>26</value>
   </data>
   <data name="ImplicitArithmeticObligationsBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="ImplicitArithmeticObligationsBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 108</value>
-  </data>
-  <data name="ImplicitArithmeticObligationsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>189, 70</value>
   </data>
   <data name="ImplicitArithmeticObligationsBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>153, 24</value>
+    <value>105, 17</value>
   </data>
   <data name="ImplicitArithmeticObligationsBox.TabIndex" type="System.Int32, mscorlib">
     <value>46</value>
@@ -1660,7 +1543,7 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;ImplicitArithmeticObligationsBox.ZOrder" xml:space="preserve">
-    <value>26</value>
+    <value>27</value>
   </data>
   <data name="FailBuildOnWarningsCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1669,13 +1552,10 @@
     <value>NoControl</value>
   </data>
   <data name="FailBuildOnWarningsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>549, 72</value>
-  </data>
-  <data name="FailBuildOnWarningsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>366, 47</value>
   </data>
   <data name="FailBuildOnWarningsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 24</value>
+    <value>127, 17</value>
   </data>
   <data name="FailBuildOnWarningsCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -1693,19 +1573,16 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;FailBuildOnWarningsCheckBox.ZOrder" xml:space="preserve">
-    <value>27</value>
+    <value>28</value>
   </data>
   <data name="ShowSquiggliesBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="ShowSquiggliesBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 72</value>
-  </data>
-  <data name="ShowSquiggliesBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>189, 47</value>
   </data>
   <data name="ShowSquiggliesBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 24</value>
+    <value>102, 17</value>
   </data>
   <data name="ShowSquiggliesBox.TabIndex" type="System.Int32, mscorlib">
     <value>43</value>
@@ -1723,19 +1600,16 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;ShowSquiggliesBox.ZOrder" xml:space="preserve">
-    <value>28</value>
+    <value>29</value>
   </data>
   <data name="RunInBackgroundBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="RunInBackgroundBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 72</value>
-  </data>
-  <data name="RunInBackgroundBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>27, 47</value>
   </data>
   <data name="RunInBackgroundBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 24</value>
+    <value>128, 17</value>
   </data>
   <data name="RunInBackgroundBox.TabIndex" type="System.Int32, mscorlib">
     <value>42</value>
@@ -1753,7 +1627,7 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;RunInBackgroundBox.ZOrder" xml:space="preserve">
-    <value>29</value>
+    <value>30</value>
   </data>
   <data name="BaseLineBox.AccessibleDescription" xml:space="preserve">
     <value>Produce or use a baseline to filter warnings</value>
@@ -1762,13 +1636,10 @@
     <value>True</value>
   </data>
   <data name="BaseLineBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>42, 558</value>
-  </data>
-  <data name="BaseLineBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>28, 363</value>
   </data>
   <data name="BaseLineBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 24</value>
+    <value>66, 17</value>
   </data>
   <data name="BaseLineBox.TabIndex" type="System.Int32, mscorlib">
     <value>70</value>
@@ -1786,16 +1657,13 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;BaseLineBox.ZOrder" xml:space="preserve">
-    <value>30</value>
+    <value>31</value>
   </data>
   <data name="BaseLineTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 554</value>
-  </data>
-  <data name="BaseLineTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>100, 360</value>
   </data>
   <data name="BaseLineTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>588, 26</value>
+    <value>393, 20</value>
   </data>
   <data name="BaseLineTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>71</value>
@@ -1810,19 +1678,16 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;BaseLineTextBox.ZOrder" xml:space="preserve">
-    <value>31</value>
+    <value>32</value>
   </data>
   <data name="ImplicitArrayBoundObligationsBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="ImplicitArrayBoundObligationsBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>549, 108</value>
-  </data>
-  <data name="ImplicitArrayBoundObligationsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>366, 70</value>
   </data>
   <data name="ImplicitArrayBoundObligationsBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 24</value>
+    <value>124, 17</value>
   </data>
   <data name="ImplicitArrayBoundObligationsBox.TabIndex" type="System.Int32, mscorlib">
     <value>47</value>
@@ -1840,19 +1705,16 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;ImplicitArrayBoundObligationsBox.ZOrder" xml:space="preserve">
-    <value>32</value>
+    <value>33</value>
   </data>
   <data name="ImplicitNonNullObligationsBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="ImplicitNonNullObligationsBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>42, 112</value>
-  </data>
-  <data name="ImplicitNonNullObligationsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>28, 73</value>
   </data>
   <data name="ImplicitNonNullObligationsBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 24</value>
+    <value>100, 17</value>
   </data>
   <data name="ImplicitNonNullObligationsBox.TabIndex" type="System.Int32, mscorlib">
     <value>45</value>
@@ -1870,7 +1732,7 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;ImplicitNonNullObligationsBox.ZOrder" xml:space="preserve">
-    <value>33</value>
+    <value>34</value>
   </data>
   <data name="ImplicitEnumWritesBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1879,13 +1741,10 @@
     <value>NoControl</value>
   </data>
   <data name="ImplicitEnumWritesBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 148</value>
-  </data>
-  <data name="ImplicitEnumWritesBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>27, 96</value>
   </data>
   <data name="ImplicitEnumWritesBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 24</value>
+    <value>119, 17</value>
   </data>
   <data name="ImplicitEnumWritesBox.TabIndex" type="System.Int32, mscorlib">
     <value>50</value>
@@ -1903,19 +1762,13 @@
     <value>StaticCheckingGroup</value>
   </data>
   <data name="&gt;&gt;ImplicitEnumWritesBox.ZOrder" xml:space="preserve">
-    <value>34</value>
+    <value>35</value>
   </data>
   <data name="StaticCheckingGroup.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 209</value>
-  </data>
-  <data name="StaticCheckingGroup.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="StaticCheckingGroup.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 136</value>
   </data>
   <data name="StaticCheckingGroup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>836, 620</value>
+    <value>557, 403</value>
   </data>
   <data name="StaticCheckingGroup.TabIndex" type="System.Int32, mscorlib">
     <value>40</value>
@@ -1942,13 +1795,10 @@
     <value>True</value>
   </data>
   <data name="EmitContractDocumentationCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>360, 29</value>
-  </data>
-  <data name="EmitContractDocumentationCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>240, 19</value>
   </data>
   <data name="EmitContractDocumentationCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>258, 24</value>
+    <value>175, 17</value>
   </data>
   <data name="EmitContractDocumentationCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>82</value>
@@ -1978,13 +1828,10 @@
     <value>DoNotBuild</value>
   </data>
   <data name="ContractReferenceAssemblySelection.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 26</value>
-  </data>
-  <data name="ContractReferenceAssemblySelection.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>8, 17</value>
   </data>
   <data name="ContractReferenceAssemblySelection.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 28</value>
+    <value>105, 21</value>
   </data>
   <data name="ContractReferenceAssemblySelection.TabIndex" type="System.Int32, mscorlib">
     <value>81</value>
@@ -2005,13 +1852,10 @@
     <value>True</value>
   </data>
   <data name="VersionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>730, 42</value>
-  </data>
-  <data name="VersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>487, 27</value>
   </data>
   <data name="VersionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
+    <value>41, 13</value>
   </data>
   <data name="VersionLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -2035,16 +1879,10 @@
     <value>5</value>
   </data>
   <data name="contractReferenceAssemblyGroup.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 838</value>
-  </data>
-  <data name="contractReferenceAssemblyGroup.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="contractReferenceAssemblyGroup.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 545</value>
   </data>
   <data name="contractReferenceAssemblyGroup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>836, 66</value>
+    <value>557, 43</value>
   </data>
   <data name="contractReferenceAssemblyGroup.TabIndex" type="System.Int32, mscorlib">
     <value>80</value>
@@ -2068,13 +1906,10 @@
     <value>True</value>
   </data>
   <data name="AssemblyModeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 18</value>
-  </data>
-  <data name="AssemblyModeLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>3, 12</value>
   </data>
   <data name="AssemblyModeLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 20</value>
+    <value>84, 13</value>
   </data>
   <data name="AssemblyModeLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2101,13 +1936,10 @@
     <value>Standard Contract Requires</value>
   </data>
   <data name="AssemblyModeDropDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>138, 12</value>
-  </data>
-  <data name="AssemblyModeDropDown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>92, 8</value>
   </data>
   <data name="AssemblyModeDropDown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>336, 28</value>
+    <value>225, 21</value>
   </data>
   <data name="AssemblyModeDropDown.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2131,13 +1963,10 @@
     <value>True</value>
   </data>
   <data name="docLink.Location" type="System.Drawing.Point, System.Drawing">
-    <value>726, 17</value>
-  </data>
-  <data name="docLink.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>484, 11</value>
   </data>
   <data name="docLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 20</value>
+    <value>79, 13</value>
   </data>
   <data name="docLink.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2164,13 +1993,10 @@
     <value>NoControl</value>
   </data>
   <data name="help_Link.Location" type="System.Drawing.Point, System.Drawing">
-    <value>664, 17</value>
-  </data>
-  <data name="help_Link.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>443, 11</value>
   </data>
   <data name="help_Link.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 20</value>
+    <value>29, 13</value>
   </data>
   <data name="help_Link.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -2194,16 +2020,13 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>9, 20</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>867, 1102</value>
+    <value>578, 716</value>
   </data>
   <data name="&gt;&gt;WarningLevelToolTip.Name" xml:space="preserve">
     <value>WarningLevelToolTip</value>


### PR DESCRIPTION
This PR adds a new flag to the MSBuild properties, `CodeContractsDeferCodeAnalysis`. If this is set, Code Contracts will do everything it need to do for static analysis except actually run `cccheck.exe`.

This allows developers and automated build processes to manually run the static check at a later time by invoking `cccheck.exe @MyAssemblyName.rsp`.

This option is exposed in the Visual Studio properties pane as 'Create checking artifacts only'. If this option is selected, 'Check in background' and 'Fail build on warnings' are disabled as they are no longer relevant.

This PR also includes minor fixes observed from the BuildCC.bat build log, and renames the RSP files from `MyAssemblyNameccrewrite.rsp`, for example, to `MyAssemblyName.ccrewrite.rsp`.

This has been functionally tested in Visual Studio 2015.
