### PR TITLE
Add options to cccheck to find source in a different location

### DIFF
--- a/Foxtrot/Foxtrot/Documentation/GenerateDocumentationFromPDB.cs
+++ b/Foxtrot/Foxtrot/Documentation/GenerateDocumentationFromPDB.cs
@@ -25,18 +25,26 @@ namespace Microsoft.Contracts.Foxtrot
 {
     public class GenerateDocumentationFromPDB : Inspector
     {
-        private int tabWidth;
+        readonly Func<string, string> sourceFileLocator;
+        readonly int tabWidth;
+        readonly bool writeOutput;
+        readonly ContractNodes contracts;
         private int tabStops;
-        private bool writeOutput;
-        private ContractNodes contracts;
 
-        public GenerateDocumentationFromPDB(ContractNodes contracts) : this(contracts, 2, false)
+        public GenerateDocumentationFromPDB(ContractNodes contracts)
+          : this(contracts, null)
         {
         }
 
-        public GenerateDocumentationFromPDB(ContractNodes contracts, int tabWidth, bool writeOutput)
+        public GenerateDocumentationFromPDB(ContractNodes contracts, Func<string, string> sourceFileLocator)
+          : this(contracts, sourceFileLocator, 2, false)
+        {
+        }
+
+        public GenerateDocumentationFromPDB(ContractNodes contracts, Func<string, string> sourceFileLocator, int tabWidth, bool writeOutput)
         {
             this.contracts = contracts;
+            this.sourceFileLocator = sourceFileLocator;
             this.tabWidth = tabWidth;
             this.tabStops = 0;
             this.writeOutput = writeOutput;
@@ -798,7 +806,13 @@ namespace Microsoft.Contracts.Foxtrot
             SourceDocument result;
             if (!sourceTexts.TryGetValue(sourceName, out result))
             {
-                result = new SourceDocument(sourceName);
+                var sourceFilePath = sourceName;
+                if (sourceFileLocator != null)
+                {
+                    sourceFilePath = sourceFileLocator(sourceFilePath);
+                }
+
+                result = new SourceDocument(sourceFilePath);
                 sourceTexts.Add(sourceName, result);
             }
 

--- a/Microsoft.Research/ClousotMain/ClousotMain.cs
+++ b/Microsoft.Research/ClousotMain/ClousotMain.cs
@@ -911,7 +911,7 @@ namespace Microsoft.Research.CodeAnalysis
         foreach (string assembly in options.Assemblies)
         {
           Assembly assem;
-          if (!this.driver.MetaDataDecoder.TryLoadAssembly(assembly, assemblyCache, this.output.EmitError, out assem, options.IsLegacyAssemblyMode, options.reference, options.extractSourceText))
+          if (!this.driver.MetaDataDecoder.TryLoadAssembly(assembly, assemblyCache, this.output.EmitError, out assem, options.IsLegacyAssemblyMode, options.reference, options.extractSourceText, GetSourceFileLocator()))
           {
             output.WriteLine("Cannot load assembly '{0}'", assembly);
             this.options.AddError();
@@ -1345,7 +1345,7 @@ namespace Microsoft.Research.CodeAnalysis
         foreach (string contractAssembly in options.ContractAssemblies)
         {
           Assembly assem;
-          if (!driver.MetaDataDecoder.TryLoadAssembly(contractAssembly, assemblyCache, null, out assem, this.options.IsLegacyAssemblyMode, this.options.reference, this.options.extractSourceText))
+          if (!driver.MetaDataDecoder.TryLoadAssembly(contractAssembly, assemblyCache, null, out assem, this.options.IsLegacyAssemblyMode, this.options.reference, this.options.extractSourceText, null))
           {
             output.WriteLine("Cannot load contract assembly '{0}'", contractAssembly);
             options.AddError();
@@ -3440,6 +3440,26 @@ namespace Microsoft.Research.CodeAnalysis
           query.TraceSequentially(entryPoint);
           return Unit.Value;
         }
+      }
+
+      private SourceFileLocator GetSourceFileLocator()
+      {
+        if (!options.extractSourceText)
+        {
+          return null;
+        }
+
+        if (options.sourcePaths == null || options.sourcePaths.Count == 0)
+        {
+          return null;
+        }
+
+        if (options.alternativeSourcePaths == null || options.alternativeSourcePaths.Count == 0)
+        {
+          return null;
+        }
+
+        return new SourceFileFinder(options.sourcePaths, options.alternativeSourcePaths).Find;
       }
     }
 

--- a/Microsoft.Research/ClousotMain/ClousotMain.csproj
+++ b/Microsoft.Research/ClousotMain/ClousotMain.csproj
@@ -235,6 +235,7 @@
     <Compile Include="PriortizerOutput.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegressionOutput.cs" />
+    <Compile Include="SourceFileFinder.cs" />
     <Compile Include="SwallowedCounterOutput.cs" />
     <Compile Include="WarningSuggestionLinkOutput.cs" />
     <Compile Include="XmlBaseLine.cs" />

--- a/Microsoft.Research/ClousotMain/Options.cs
+++ b/Microsoft.Research/ClousotMain/Options.cs
@@ -360,6 +360,14 @@ namespace Microsoft.Research.CodeAnalysis
     [OptionDescription("Extract the source text for the contracts")]
     public bool extractSourceText = true;
 
+    [OptionDescription("Paths to source files")]
+    [DoNotHashInCache]
+    public List<string> sourcePaths = new List<string>();
+
+    [OptionDescription("Alternative paths to search for source files")]
+    [DoNotHashInCache]
+    public List<string> alternativeSourcePaths = new List<string>();
+
     [OptionDescription("Redirect the output to this output file")]
     [DoNotHashInCache]
     public string outFile;

--- a/Microsoft.Research/ClousotMain/SourceFileFinder.cs
+++ b/Microsoft.Research/ClousotMain/SourceFileFinder.cs
@@ -1,0 +1,81 @@
+﻿// CodeContracts
+// 
+// Copyright (c) Microsoft Corporation
+// 
+// All rights reserved. 
+// 
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Research.CodeAnalysis
+{
+    [ContractVerification(true)]
+    class SourceFileFinder
+    {
+        public SourceFileFinder(IEnumerable<string> originalSourcePaths, IEnumerable<string> alternativeSourcePaths)
+        {
+            Contract.Requires(originalSourcePaths != null);
+            Contract.Requires(alternativeSourcePaths != null);
+
+            this.originalSourcePaths = originalSourcePaths;
+            this.alternativeSourcePaths = alternativeSourcePaths;
+        }
+
+        readonly IEnumerable<string> originalSourcePaths;
+        readonly IEnumerable<string> alternativeSourcePaths;
+        const StringComparison Comparison = StringComparison.OrdinalIgnoreCase; // Ignore case in Windows. Re-evalute this for Mono/.NET Core
+
+        public string Find(string originalPath)
+        {
+            if (originalPath == null || File.Exists(originalPath))
+            {
+                return originalPath;
+            }
+
+            foreach (var originalSourcePath in originalSourcePaths)
+            {
+                // Find the source path that this is a sub-path of.
+                if (!originalPath.StartsWith(originalSourcePath, Comparison))
+                {
+                    continue;
+                }
+
+                // Extract the path relative to the source path;
+                var relativePath = originalPath.Substring(originalSourcePath.Length);
+
+                foreach (var alternativeSourcePath in alternativeSourcePaths)
+                {
+                    // Graft the relative path onto the alternative source path, as though the file
+                    // exists within that source tree instead.
+                    var alternativePath = alternativeSourcePath + relativePath;
+
+                    if (File.Exists(alternativePath))
+                    {
+                        return alternativePath;
+                    }
+                }
+            }
+
+            return originalPath;
+        }
+
+        [ContractInvariantMethod]
+        void ObjectInvariant()
+        {
+            Contract.Invariant(originalSourcePaths != null);
+            Contract.Invariant(alternativeSourcePaths != null);
+        }
+    }
+}

--- a/Microsoft.Research/CodeProviders/CCI1/CodeProvider.cs
+++ b/Microsoft.Research/CodeProviders/CCI1/CodeProvider.cs
@@ -2194,7 +2194,7 @@ namespace System.Compiler.Analysis
     {
         return assem.Mvid;
     }
-    public bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out AssemblyNode assem, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText)
+    public bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out AssemblyNode assem, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText, SourceFileLocator sourceFileLocator)
     {
       var attacher = this.contractAttacher;
       if (attacher == null)
@@ -2223,7 +2223,7 @@ namespace System.Compiler.Analysis
         if (extractContractText)
         {
           // extract doc first, then run checker
-          var gd = new Microsoft.Contracts.Foxtrot.GenerateDocumentationFromPDB(usedContracts);
+          var gd = new Microsoft.Contracts.Foxtrot.GenerateDocumentationFromPDB(usedContracts, AdaptSourceFileLocator(sourceFileLocator));
           gd.VisitForDoc(assem);
         }
 
@@ -2258,6 +2258,15 @@ namespace System.Compiler.Analysis
           yield return assembly.AssemblyReferences[i].Assembly;
         }
       }
+    }
+
+    private static Func<string, string> AdaptSourceFileLocator(SourceFileLocator locator)
+    {
+      if (locator == null)
+      {
+        return null;
+      }
+      return new Func<string, string>(locator);
     }
 
     #endregion

--- a/Microsoft.Research/CodeProviders/CCI2/CodeProvider.cs
+++ b/Microsoft.Research/CodeProviders/CCI2/CodeProvider.cs
@@ -9916,7 +9916,7 @@ namespace Microsoft.Cci.Analysis
     /// <param name="unit">The unit the locations are from. (Locations don't necessarily have a link to the unit they
     /// belong to.) The unit is used to find a source location provider for that unit. (Providers are maintained
     /// in a cache in the MetadataDecoder.) If a provider cannot be found for the <paramref name="unit"/> then
-    /// an emtpy enumerable is returned.
+    /// an empty enumerable is returned.
     /// </param>
     /// <param name="operations">
     /// If a source location provider is found, then the location of the operation indexed in <paramref name="operations"/>
@@ -9929,7 +9929,7 @@ namespace Microsoft.Cci.Analysis
     /// The index of the operation from whose location the corresponding primary source locations are to be found.
     /// </param>
     /// <param name="exact">
-    /// True iff the client wants primary source locations only for the operation indexed by <paramref name="startingIndex"/>.
+    /// True if the client wants primary source locations only for the operation indexed by <paramref name="startingIndex"/>.
     /// </param>
     /// <param name="foundIndex">
     /// If <paramref name="exact"/> is false, then this will be the greatest index of the operation in <paramref name="operations"/>
@@ -9984,7 +9984,7 @@ namespace Microsoft.Cci.Analysis
     /// <summary>
     /// </summary>
     /// <returns>Must return null if assembly cannot be loaded!</returns>
-    public bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out IAssemblyReference assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText)
+    public bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out IAssemblyReference assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText, SourceFileLocator sourceFileLocator)
     {
       IUnit unit = host.PossiblyCompileFirstLoadUnitFrom(fileName, referencedAssemblies, this.RegisterSourceLocationProvider);
       if (unit is Dummy) { assembly = null; return false; }

--- a/Microsoft.Research/ControlFlow/MetadataInterfaces.cs
+++ b/Microsoft.Research/ControlFlow/MetadataInterfaces.cs
@@ -34,6 +34,11 @@ namespace Microsoft.Research.CodeAnalysis
     /// </summary>
     public delegate void BlockInfoPrinter<Label>(Label at, string prefix, TextWriter writer);
 
+    /// <summary>
+    /// Used to find the current location of a source file's path, e.g. from PDB
+    /// </summary>
+    public delegate string SourceFileLocator(string originalSourceFilePath);
+
     #endregion
 
     #region IL visitor data types
@@ -1647,7 +1652,7 @@ namespace Microsoft.Research.CodeAnalysis
         /// </summary>
         /// <returns>false if assembly cannot be loaded.</returns>
         [Pure]
-        bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractSourceText);
+        bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractSourceText, SourceFileLocator sourceFileLocator);
 
         /// <summary>
         /// Returns all (and only) the top-level types in the given assembly.
@@ -3749,7 +3754,7 @@ namespace Microsoft.Research.CodeAnalysis
             throw new NotImplementedException();
         }
 
-        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText)
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText, SourceFileLocator sourceFileLocator)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
`cccheck` currently reads the paths to source files out of the PDBs. This is required for some suppressions to work, e.g. `RequiresAtCall`.

What I need to be able to do for distributed testing is build in one path, e.g. `C:\Build\MyProject`, and then invoke `cccheck` from another computer entirely in a different path, e.g. `C:\Testing\TestRun001\MyProject`.

This pull request adds two command-line flags.

* `-sourcePaths` lists partial paths that the project was built from.
* `-alternativeSourcePaths` lists alternative/substitute paths that can be used to replace a partial path from `-sourcePaths`.

For example, with these changes I can successfully test an assembly in the scenario above by running:

```
C:\Testing\TestRun001\MyProject\bin\CodeContractsDeclarative>C:\path\to\cccheck.exe @MyProject.rsp -sourcePaths:C:\Build\MyProject -alternativeSourcePaths:C:\Testing\TestRun001\MyProject
```

If you don't supply both `-sourcePaths` and `-alternativeSourcePaths`, these changes have no other effect.

This goes hand-in-hand with #459.