### PR TITLE
Support SQL Local DB 2016

### DIFF
--- a/Microsoft.Research/Clousot.Cache/SQLCacheModel.cs
+++ b/Microsoft.Research/Clousot.Cache/SQLCacheModel.cs
@@ -796,6 +796,7 @@ namespace Microsoft.Research.CodeAnalysis.Caching
         {
             { @"11.0", @"(LocalDb)\v11.0" },
             { @"12.0", @"(LocalDb)\MSSQLLocalDB" },
+            { @"13.0", @"(LocalDb)\MSSQLLocalDB" },
         };
 
         using (var rootKey = Registry.LocalMachine.OpenSubKey(registryKeyPath))


### PR DESCRIPTION
In my SQLLocalDB-2016-only setup (this is what you get by installing VS2015 Update 3 on a fresh machine), CC fails to connect to default cache. I tracked down to this; I am not sure if you would consider the current approach tenable. I would rather try to connect to `(LocalDb)\MSSQLLocalDB` to see what happens. But I think this is how CC worked pre- b4b89e6a and there was a reason it was changed to be like it is now.

I kinda fixed it by creating an empty "12.0" subkey there, but this is just a hotwired workaround, mostly to confirm that I did find the correct spot.

/cc @tom-englert 
