### PR TITLE
Fix nuget package

### DIFF
--- a/Microsoft.Research/ManagedContract.Setup/DotNet.Contracts.nuspec
+++ b/Microsoft.Research/ManagedContract.Setup/DotNet.Contracts.nuspec
@@ -12,6 +12,7 @@
     <licenseUrl>https://github.com/Microsoft/CodeContracts/blob/master/LICENSE.txt</licenseUrl>
   </metadata>
   <files>
-     <file src="**\*" />
+     <file src="**\*" target="build\" />
+	 <file src="..\..\..\..\..\..\Dotnet.Contracts.targets" target="build\" />
   </files>
 </package>

--- a/Microsoft.Research/ManagedContract.Setup/DotNet.Contracts.nuspec
+++ b/Microsoft.Research/ManagedContract.Setup/DotNet.Contracts.nuspec
@@ -13,6 +13,6 @@
   </metadata>
   <files>
      <file src="**\*" target="build\" />
-	 <file src="..\..\..\..\..\..\Dotnet.Contracts.targets" target="build\" />
+     <file src="..\..\..\..\..\..\Dotnet.Contracts.targets" target="build\" />
   </files>
 </package>

--- a/Microsoft.Research/ManagedContract.Setup/DotNet.Contracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/DotNet.Contracts.targets
@@ -1,0 +1,14 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <CodeContractsInstallDir>$(MSBuildThisFileDirectory)</CodeContractsInstallDir>
+  </PropertyGroup>
+
+  <!-- Use MsBuild specific targets file if availible -->
+  <Import Project="$(CodeContractsInstallDir)\MsBuild\v$(MSBuildToolsVersion)\Microsoft.CodeContracts.targets"
+   Condition="Exists('$(CodeContractsInstallDir)\MsBuild\v$(VisualStudioVersion)\Microsoft.CodeContracts.targets')" />
+  <!-- Fallback to Version 14 in hope that it is the most up to date version otherwise --> 
+   <Import Project="$(CodeContractsInstallDir)\MsBuild\v14\Microsoft.CodeContracts.targets"
+   Condition="!Exists('$(CodeContractsInstallDir)\MsBuild\v$(MSBuildToolsVersion)\Microsoft.CodeContracts.targets')" />
+  <!-- End Microsoft Code Contracts -->
+</Project>

--- a/Microsoft.Research/ManagedContract.Setup/DotNet.Contracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/DotNet.Contracts.targets
@@ -6,7 +6,7 @@
 
   <!-- Use MsBuild specific targets file if availible -->
   <Import Project="$(CodeContractsInstallDir)\MsBuild\v$(MSBuildToolsVersion)\Microsoft.CodeContracts.targets"
-   Condition="Exists('$(CodeContractsInstallDir)\MsBuild\v$(VisualStudioVersion)\Microsoft.CodeContracts.targets')" />
+   Condition="Exists('$(CodeContractsInstallDir)\MsBuild\v$(MSBuildToolsVersion)\Microsoft.CodeContracts.targets')" />
   <!-- Fallback to Version 14 in hope that it is the most up to date version otherwise --> 
    <Import Project="$(CodeContractsInstallDir)\MsBuild\v14\Microsoft.CodeContracts.targets"
    Condition="!Exists('$(CodeContractsInstallDir)\MsBuild\v$(MSBuildToolsVersion)\Microsoft.CodeContracts.targets')" />

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -216,7 +216,7 @@
     <CodeContractRewriteOptions
        Condition="'$(CodeContractsExtraRewriteOptions)' != ''"
        >$(CodeContractRewriteOptions) $(CodeContractsExtraRewriteOptions)</CodeContractRewriteOptions>
-    <CodeContractRewriteOptions>/level:$(CodeContractsRuntimeLevel) /nologo /rewrite $(CodeContractRewriteOptions) "/resolvedPaths:@(ReferencePath,';')" "/libpaths:@(CodeContractsAllLibPaths) " "$(TargetName)$(TargetExt)"</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions>/level:$(CodeContractsRuntimeLevel) /nologo /rewrite $(CodeContractRewriteOptions) "/resolvedPaths:@(ReferencePath,';')" "/libpaths:@(CodeContractsAllLibPaths)" "$(TargetName)$(TargetExt)"</CodeContractRewriteOptions>
     <CodeContractRewriteCommand>$(CodeContractsInstallDir)Bin\ccrewrite.exe</CodeContractRewriteCommand>
 
     <CodeContractsRewriterOutput>$(IntermediateOutputPath)$(TargetName).rewritten</CodeContractsRewriterOutput>
@@ -338,7 +338,7 @@
      Outputs="@(ContractReferenceAssemblyAbsolute)">
 
     <PropertyGroup>
-      <_CodeContractsCCRefGenArguments>"/resolvedPaths:@(ReferencePath,';')" "/libPaths:@(CodeContractsAllLibPaths) " /pdb "/out:@(ContractReferenceAssembly)" "@(ContractDeclarativeAssembly)"</_CodeContractsCCRefGenArguments>
+      <_CodeContractsCCRefGenArguments>"/resolvedPaths:@(ReferencePath,';')" "/libPaths:@(CodeContractsAllLibPaths)" /pdb "/out:@(ContractReferenceAssembly)" "@(ContractDeclarativeAssembly)"</_CodeContractsCCRefGenArguments>
     </PropertyGroup>
 
     <ItemGroup>
@@ -648,7 +648,7 @@
       Include Code Analysis target if present
     ======================================================================-->
   <PropertyGroup>
-    <CodeContractAnalysisTargets>$(CodeContractsInstallDir)MsBuild\v12.0\Microsoft.CodeContractAnalysis.targets</CodeContractAnalysisTargets>
+    <CodeContractAnalysisTargets>$(MSBuildThisFileDirectory)Microsoft.CodeContractAnalysis.targets</CodeContractAnalysisTargets>
   </PropertyGroup>
   <Import Project="$(CodeContractAnalysisTargets)" Condition="Exists('$(CodeContractAnalysisTargets)')"/>
 

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -221,7 +221,7 @@
     <CodeContractRewriteOptions
        Condition="'$(CodeContractsExtraRewriteOptions)' != ''"
        >$(CodeContractRewriteOptions) $(CodeContractsExtraRewriteOptions)</CodeContractRewriteOptions>
-    <CodeContractRewriteOptions>/level:$(CodeContractsRuntimeLevel) /nologo /rewrite $(CodeContractRewriteOptions) "/resolvedPaths:@(ReferencePath,';')" "/libpaths:@(CodeContractsAllLibPaths) " "$(TargetName)$(TargetExt)"</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions>/level:$(CodeContractsRuntimeLevel) /nologo /rewrite $(CodeContractRewriteOptions) "/resolvedPaths:@(ReferencePath,';')" "/libpaths:@(CodeContractsAllLibPaths)" "$(TargetName)$(TargetExt)"</CodeContractRewriteOptions>
     <CodeContractRewriteCommand>$(CodeContractsInstallDir)Bin\ccrewrite.exe</CodeContractRewriteCommand>
 
     <CodeContractsRewriterOutput>$(IntermediateOutputPath)$(TargetName).rewritten</CodeContractsRewriterOutput>
@@ -343,7 +343,7 @@
      Outputs="@(ContractReferenceAssemblyAbsolute)">
 
     <PropertyGroup>
-      <_CodeContractsCCRefGenArguments>"/resolvedPaths:@(ReferencePath,';')" "/libPaths:@(CodeContractsAllLibPaths) " /pdb "/out:@(ContractReferenceAssembly)" "@(ContractDeclarativeAssembly)"</_CodeContractsCCRefGenArguments>
+      <_CodeContractsCCRefGenArguments>"/resolvedPaths:@(ReferencePath,';')" "/libPaths:@(CodeContractsAllLibPaths)" /pdb "/out:@(ContractReferenceAssembly)" "@(ContractDeclarativeAssembly)"</_CodeContractsCCRefGenArguments>
     </PropertyGroup>
 
     <ItemGroup>
@@ -629,7 +629,7 @@
      Outputs="@(DocFileItem)">
 
     <PropertyGroup>
-      <_CodeContractsCCDocGenArguments>-assembly "@(ContractReferenceAssembly)" -xmlFile "@(DocFileItem)" "-resolvedPaths:@(ReferencePath)" -libpaths "@(CodeContractsAllLibPaths) "</_CodeContractsCCDocGenArguments>
+      <_CodeContractsCCDocGenArguments>-assembly "@(ContractReferenceAssembly)" -xmlFile "@(DocFileItem)" "-resolvedPaths:@(ReferencePath)" -libpaths "@(CodeContractsAllLibPaths)"</_CodeContractsCCDocGenArguments>
     </PropertyGroup>
 
     <ItemGroup>
@@ -653,7 +653,7 @@
       Include Code Analysis target if present
     ======================================================================-->
   <PropertyGroup>
-    <CodeContractAnalysisTargets>$(CodeContractsInstallDir)MsBuild\v14.0\Microsoft.CodeContractAnalysis.targets</CodeContractAnalysisTargets>
+    <CodeContractAnalysisTargets>$(MSBuildThisFileDirectory)Microsoft.CodeContractAnalysis.targets</CodeContractAnalysisTargets>
   </PropertyGroup>
   <Import Project="$(CodeContractAnalysisTargets)" Condition="Exists('$(CodeContractAnalysisTargets)')"/>
 


### PR DESCRIPTION
This PR makes it possible to use the code contracts nuget package by just adding Dotnet.Contracts as a nuget reference. (first commit)
It also makes some minor improvements to the target files such as adding support for .Net 4.6.2 (second commit). This can be moved to a second PR if requested.

## Nuget improvements
The .targets files will be automatically included in the Project and no further action is required unless the MSI is also installed .

It should solve the following issues
* #313 Nuget package refuse to install 
* #454 Cant install Nuget for DotNet.Contracts 1.10.20606.1
* #13 CodeContracts as NuGet package

It should also allowing code contract rewriter to run for VS 2017 #451 

However *if you have installed the MSI* you do need to *include the following workaround at the top of your project file* (it must be before "Microsoft.CSharp.targets" is included) which is mentioned in Issue #368 

 ```
  <PropertyGroup>
    <DontImportCodeContracts>True</DontImportCodeContracts>
  </PropertyGroup>
```

## .target file improvements 

* Remove extra space from library path
 Use relative path when including analysis targets so that the same file can be used for multiple MsBuild versions