### PR TITLE
Target correct reference assemblies for .Net 4.6.2 and 4.5.2

### DIFF
--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -45,34 +45,29 @@
     </When>
     <Otherwise>
       <Choose>
+        <When Condition="'$(TargetFrameworkVersion)' &lt; 'v4.0'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
         <When Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.0</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
-        <When Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
+        <When Condition="'$(TargetFrameworkVersion)'.StartsWith('v4.5')">
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
-        <When Condition="'$(TargetFrameworkVersion)' == 'v4.5.1'">
-          <PropertyGroup>
-            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
-          </PropertyGroup>
-        </When>
-        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6'">
-          <PropertyGroup>
-            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
-          </PropertyGroup>
-        </When>
-        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.1'">
+        <When Condition="'$(TargetFrameworkVersion)'.StartsWith('v4.6')">
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
         <Otherwise>
           <PropertyGroup>
-            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.0</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </Otherwise>
       </Choose>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -45,39 +45,29 @@
     </When>
     <Otherwise>
       <Choose>
+        <When Condition="'$(TargetFrameworkVersion)' &lt; 'v4.0'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
         <When Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.0</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
-        <When Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
+        <When Condition="'$(TargetFrameworkVersion)'.StartsWith('v4.5')">
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
-        <When Condition="'$(TargetFrameworkVersion)' == 'v4.5.1'">
-          <PropertyGroup>
-            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
-          </PropertyGroup>
-        </When> 
-        <When Condition="'$(TargetFrameworkVersion)' == 'v4.5.2'">
-          <PropertyGroup>
-            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
-          </PropertyGroup>
-        </When>        
-        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6'">
-          <PropertyGroup>
-            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
-          </PropertyGroup>
-        </When>
-        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.1'">
+        <When Condition="'$(TargetFrameworkVersion)'.StartsWith('v4.6')">
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
         <Otherwise>
           <PropertyGroup>
-            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.0</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </Otherwise>
       </Choose>


### PR DESCRIPTION
* Add support for .Net 4.6.2 
** Any possible future 4.6.x release would also choose correct reference assemblies
** Fixes #475 
* Add support for .Net 4.5.2 for toolset version 12

Default TargetFramework (if target framework is missing) changed from 3.5 to 4.0

