### PR TITLE
Add MSBuild targets for VS2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Microsoft.Research/CCDoc/Sandcastle/Sandcastle.zip
 *.user
 *.userosscache
 *.sln.docstates
+.vs
 
 # Build results
 [Dd]ebug/

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -70,6 +70,11 @@
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.2'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
         <Otherwise>
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -75,6 +75,11 @@
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
           </PropertyGroup>
         </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.2'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
         <Otherwise>
           <PropertyGroup>
             <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v15.0/Microsoft.CodeContractAnalysis.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v15.0/Microsoft.CodeContractAnalysis.targets
@@ -1,0 +1,260 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--=====================================================================
+      Begin Microsoft Code Contracts Analysis 
+  ======================================================================-->
+
+
+  <!--=====================================================================
+        Add post build step for static contract checker
+    ======================================================================-->
+  <PropertyGroup>
+    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);CodeContractsRunCodeAnalysisOnTarget;CodeContractsPerformCodeAnalysis</PrepareForRunDependsOn>
+    <CodeContractsCodeAnalysisOutput>$(IntermediateOutputPath)CodeContractAnalysisRun.log</CodeContractsCodeAnalysisOutput>
+  </PropertyGroup>
+
+  <!--=====================================================================
+        Define tool options
+    ======================================================================-->
+
+  <PropertyGroup>
+    <CodeContractRunCodeAnalysisCommand>$(CodeContractsInstallDir)Bin\cccheck.exe</CodeContractRunCodeAnalysisCommand>
+  </PropertyGroup>
+
+  <!--=====================================================================
+        Running Static Code Analysis
+    ======================================================================-->
+    
+  <Target
+    Name="CodeContractsPerformCodeAnalysis"
+    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true'"
+    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsCodeAnalysisWriteRSPFile;CodeContractsRunCodeAnalysis">
+  </Target>
+
+  <Target
+    Name="CodeContractsComputeCodeAnalysisDependencies"
+    DependsOnTargets="ContractDeclarativeAssembly">
+
+    <ItemGroup>
+      <CodeContractsCodeAnalysisInput
+        Include="@(ReferencePath)"/>
+      <CodeContractsCodeAnalysisInput
+        Include="@(ContractDeclarativeAssemblies)"/>
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="CodeContractsLoadEnvVars">
+    <PropertyGroup>
+      <CodeContractsTargetMember>$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetMember`))</CodeContractsTargetMember>
+      <CodeContractsTargetType>$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetType`))</CodeContractsTargetType>
+      <CodeContractsTargetNamespace>$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetNamespace`))</CodeContractsTargetNamespace>
+      <CodeContractsTargetProjectGuid>$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetProjectGuid`))</CodeContractsTargetProjectGuid>
+    </PropertyGroup>
+  </Target>
+
+  <Target
+    Name="CodeContractsRunCodeAnalysisOnTarget"
+    Condition="'$(ProjectGuid)' != '' and '$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetProjectGuid`))' == '$(ProjectGuid)'"
+    DependsOnTargets="CodeContractsComputeCodeAnalysisDependencies;CodeContractsLoadEnvVars">
+    <CallTarget Targets="CodeContractsRunCodeAnalysisInternal" />
+  </Target>
+
+  <Target
+    Name="CodeContractsRunCodeAnalysis"
+    Condition="'$(CodeContractsRunCodeAnalysis)' == 'true' and '$(CodeContractsDeferCodeAnalysis)' != 'true' and '$([System.Environment]::GetEnvironmentVariable(`CodeContractsTargetProjectGuid`))' == '' and '$(BuildingProject)'=='true'"
+    Inputs="@(CodeContractsCodeAnalysisInput)"
+    Outputs="$(CodeContractsCodeAnalysisOutput)"
+    >
+    <CallTarget Targets="CodeContractsRunCodeAnalysisInternal"/>
+    <Touch
+      Files="$(CodeContractsCodeAnalysisOutput)"
+      AlwaysCreate="true"
+      ForceTouch="true"/>
+    <ItemGroup>
+      <FileWrites
+        Include="$(CodeContractsCodeAnalysisOutput)"/>
+    </ItemGroup>
+  </Target>
+
+  <!-- The code contracts task -->
+  <UsingTask TaskName="Microsoft.Research.CodeContractsAnalysis" AssemblyFile="$(CodeContractsInstallDir)Bin\MsBuildCodeContracts.dll" />
+
+  <!-- Get the warning level -->
+  <Choose>
+    <When Condition="'$(CodeContractsAnalysisWarningLevel)'==''">
+      <PropertyGroup>
+        <CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='0'">
+      <PropertyGroup>
+        <CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='1'">
+      <PropertyGroup>
+        <CodeContractsAnalysisWarning>mediumlow</CodeContractsAnalysisWarning>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='2'">
+      <PropertyGroup>
+        <CodeContractsAnalysisWarning>medium</CodeContractsAnalysisWarning>
+      </PropertyGroup>
+    </When>
+     <When Condition="'$(CodeContractsAnalysisWarningLevel)'=='3'">
+      <PropertyGroup>
+        <CodeContractsAnalysisWarning>full</CodeContractsAnalysisWarning>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+    <CodeContractsAnalysisWarning>low</CodeContractsAnalysisWarning>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+
+  <!-- Get Bounds obligations -->
+  <Choose>
+    <When Condition="'$(CodeContractsBoundsObligations)'!='true'">
+      <PropertyGroup>
+        <CodeContractsBounds>noObl</CodeContractsBounds>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(CodeContractsBoundsObligations)'=='true'">
+      <PropertyGroup>
+        <CodeContractsBounds></CodeContractsBounds>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+  <Target
+    Name="CodeContractsCodeAnalysisWriteRSPFile"
+    DependsOnTargets="CodeContractsComputeAllLibPaths;EnsureContractReferenceAssemblyOfDependeeProjects;CodeContractsLoadEnvVars"
+    >
+    <PropertyGroup>
+      <DeclarativeAssemblyDir>@(ContractDeclarativeAssembly->'%(RootDir)')@(ContractDeclarativeAssembly->'%(Directory)')</DeclarativeAssemblyDir>
+      <DeclarativeAssemblyPath>@(ContractDeclarativeAssembly->'%(FullPath)')</DeclarativeAssemblyPath>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsPlatformPath)' != ''">-platform "$(CodeContractsPlatformPath)"</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsClassLibrary)' != ''">$(CodeContractCodeAnalysisOptions) -cclib "$(CodeContractsClassLibrary)"</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsAssemblyMode)' == '1'">$(CodeContractCodeAnalysisOptions) -assemblyMode=standard</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions>$(CodeContractCodeAnalysisOptions) -maxwarnings 1200</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsNonNullObligations)' != 'true'">$(CodeContractCodeAnalysisOptions) -nonnull:noObl</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsNonNullObligations)' == 'true'">$(CodeContractCodeAnalysisOptions) -nonnull</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions>$(CodeContractCodeAnalysisOptions) -bounds:$(CodeContractsBounds) -arrays -wp=true -bounds:type=subpolyhedra,reduction=simplex,diseq=false </CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsPointerObligations)' == 'true'">$(CodeContractCodeAnalysisOptions) -buffers:type=subpolyhedra,fastcheck=false</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions>$(CodeContractCodeAnalysisOptions) -arrays -adaptive</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsArithmeticObligations)' == 'true'">$(CodeContractCodeAnalysisOptions) -arithmetic</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsEnumObligations)' == 'true'">$(CodeContractCodeAnalysisOptions) -enum</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsRedundantAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -check assumptions</CodeContractCodeAnalysisOptions>        
+     <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsAssertsToContractsCheckBox)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest asserttocontracts</CodeContractCodeAnalysisOptions>        
+        <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsRedundantTests)' == 'true'">$(CodeContractCodeAnalysisOptions) -check conditionsvalidity</CodeContractCodeAnalysisOptions>        		
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsMissingPublicRequiresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicRequiresAreErrors</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsMissingPublicEnsuresAsWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -missingPublicEnsuresAreErrors</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestAssumptionsForCallees)' == 'true'">$(CodeContractCodeAnalysisOptions)  -suggest calleeassumes</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestAssumptions)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest assumes</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestRequires)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest requires</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest methodensures -suggest propertyensures</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsNecessaryEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest necessaryensures</CodeContractCodeAnalysisOptions>
+        <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestObjectInvariants)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest objectinvariants</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSuggestReadonly)' == 'true'">$(CodeContractCodeAnalysisOptions) -suggest readonlyfields</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsInferRequires)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer requires</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsInferEnsures)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer methodensures</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsInferEnsuresAutoProperties)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer autopropertiesensures</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsInferObjectInvariants)' == 'true'">$(CodeContractCodeAnalysisOptions) -infer objectinvariants</CodeContractCodeAnalysisOptions>     
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsCacheAnalysisResults)' == 'true'">$(CodeContractCodeAnalysisOptions) -cache</CodeContractCodeAnalysisOptions>
+    <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSkipAnalysisIfCannotConnectToCache)' == 'true'">$(CodeContractCodeAnalysisOptions) -forcecacheserver=true</CodeContractCodeAnalysisOptions>
+     <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsFailBuildOnWarnings)' == 'true'">$(CodeContractCodeAnalysisOptions) -failOnWarnings</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsCacheDirectory)' != ''">$(CodeContractCodeAnalysisOptions) -cacheFileDirectory "$(CodeContractsCacheDirectory)"</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsCacheVersion)' != ''">$(CodeContractCodeAnalysisOptions) -cacheVersion "$(CodeContractsCacheVersion)"</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsCacheMaxSize)' != ''">$(CodeContractCodeAnalysisOptions) -cacheMaxSize "$(CodeContractsCacheMaxSize)"</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsTargetMember)' != ''">$(CodeContractCodeAnalysisOptions) -memberNameSelect:$(CodeContractsTargetMember)</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsTargetType)' != ''">$(CodeContractCodeAnalysisOptions) -typeNameSelect:$(CodeContractsTargetType)</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsBeingOptimisticOnExternal)' == 'false'">$(CodeContractCodeAnalysisOptions)  -lowScoreForExternal=false</CodeContractCodeAnalysisOptions>
+     <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsTargetNamespace)' != ''">$(CodeContractCodeAnalysisOptions) -namespaceSelect:$(CodeContractsTargetNamespace)</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsUseBaseLine)' == 'true' and '$(CodeContractsBaseLineFile)' != ''">$(CodeContractCodeAnalysisOptions) -baseline "$(CodeContractsBaseLineFile)"</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions
+        Condition="'$(CodeContractsSQLServerOption)' != ''">$(CodeContractCodeAnalysisOptions) -cacheserver:$(CodeContractsSQLServerOption)</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisOptions>$(CodeContractCodeAnalysisOptions) $(CodeContractsExtraAnalysisOptions)</CodeContractCodeAnalysisOptions>
+      <CodeContractCodeAnalysisHideMarkers Condition="'$(CodeContractsShowSquigglies)' == 'true'">false</CodeContractCodeAnalysisHideMarkers>
+      <CodeContractCodeAnalysisHideMarkers Condition="'$(CodeContractsShowSquigglies)' != 'true'">true</CodeContractCodeAnalysisHideMarkers>
+      <CodeContractCodeAnalysisRunInBackground Condition="'$(CodeContractsRunInBackground)' != 'false'">true</CodeContractCodeAnalysisRunInBackground>
+      <CodeContractCodeAnalysisRunInBackground Condition="'$(CodeContractsRunInBackground)' == 'false'">false</CodeContractCodeAnalysisRunInBackground>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <_CodeContractsCCCheckArguments>-nobox -nologo -nopex -remote  -suggest=!! -premode combined -suggest codefixes -framework:$(TargetFrameworkVersion) -warninglevel $(CodeContractsAnalysisWarning) $(CodeContractCodeAnalysisOptions) "-resolvedPaths:@(ReferencePath)" "-libPaths:@(CodeContractsAllLibPaths)" "$(DeclarativeAssemblyPath)"</_CodeContractsCCCheckArguments>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_CodeContractsCCCheckArgumentLines
+         Include="$(_CodeContractsCCCheckArguments)"
+         />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(DeclarativeAssemblyDir)$(AssemblyName).cccheck.rsp"
+      Lines="@(_CodeContractsCCCheckArgumentLines, ';')"
+      Overwrite="true"
+      />
+      
+  </Target>
+    
+  <Target
+      Name="CodeContractsRunCodeAnalysisInternal"
+      DependsOnTargets="CodeContractsCodeAnalysisWriteRSPFile">
+      
+    <Message Text="Run Contract Code Analysis on project guid $(ProjectGuid)" Importance="Low"/>
+
+    <CodeContractsAnalysis
+      Verbose="false"
+      RunInBackground="$(CodeContractCodeAnalysisRunInBackground)"
+      WorkingDirectory="$(DeclarativeAssemblyDir)"
+      ProjectName="$(ProjectName)"
+      HideMarkers="$(CodeContractCodeAnalysisHideMarkers)"
+      MultiLineMarkers="false"
+      HideOutput="false"
+      KeepErrors="$(CodeContractsFailBuildOnWarnings)"
+      OutputPrefix="CodeContracts: "
+      Command='$(CodeContractRunCodeAnalysisCommand)'
+      CommandOptions='"@$(AssemblyName).cccheck.rsp"'
+      />
+  </Target>
+
+  <!-- End Microsoft Code Contract Analysis -->
+</Project>

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v15.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v15.0/Microsoft.CodeContracts.targets
@@ -1,0 +1,666 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Multiple Import Guard -->
+  <PropertyGroup>
+    <CodeContractsImported>True</CodeContractsImported>
+  </PropertyGroup>
+
+  <!--=====================================================================
+      Begin Microsoft Code Contracts 
+  ======================================================================-->
+
+  <PropertyGroup>
+    <CodeContractsDeclDir>$(OutDir)CodeContractsDeclarative\</CodeContractsDeclDir>
+    <CodeContractsContractSubDir>CodeContracts\</CodeContractsContractSubDir>
+    <CodeContractsCCRefgenCommand>$(CodeContractsInstallDir)Bin\ccrefgen.exe</CodeContractsCCRefgenCommand>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(TargetFrameworkIdentifier)' == 'Silverlight'">
+      <Choose>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v5.0'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\Silverlight\v5.0</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
+          <Choose>
+            <When Condition="'$(TargetFrameworkProfile)' == 'WindowsPhone'">
+              <PropertyGroup>
+                <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\Silverlight\v4.0\Profile\WindowsPhone</CodeContractsReferenceAssemblyLibPath>
+              </PropertyGroup>
+            </When>
+            <Otherwise>
+              <PropertyGroup>
+                <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\Silverlight\v4.0</CodeContractsReferenceAssemblyLibPath>
+              </PropertyGroup>
+            </Otherwise>
+          </Choose>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\Silverlight\v3.0</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
+    </When>
+    <Otherwise>
+      <Choose>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.0</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.5.1'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When> 
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.5.2'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.5</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>        
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.1'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(TargetFrameworkVersion)' == 'v4.6.2'">
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\.NETFramework\v4.6</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <CodeContractsReferenceAssemblyLibPath>$(CodeContractsInstallDir)Contracts\v3.5</CodeContractsReferenceAssemblyLibPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
+    </Otherwise>
+  </Choose>
+
+  <!--=====================================================================
+      Build Contract reference assemblies on all builds.
+      (rather than recursively on demand)
+
+      Also define CONTRACTS_FULL and CODE_ANALYSIS dynamically, otherwise
+      VS property build pane picks it up and may persist it into the project
+      settings!
+    =====================================================================-->
+  
+  <PropertyGroup>
+    <CompileDependsOn>CodeContractsSlipInDefineSymbolDynamically;$(CompileDependsOn);CodeContractReferenceAssembly</CompileDependsOn>
+  </PropertyGroup>
+
+  <Target
+     Name="CodeContractsSlipInDefineSymbolDynamically"
+     Condition="'$(CodeContractsEnableRuntimeChecking)' == 'true'"
+     >
+
+    <CreateProperty
+       Condition="'$(Language)'=='C#'"
+       Value="CONTRACTS_FULL;CODE_ANALYSIS;$(DefineConstants)">
+      <Output
+         TaskParameter="Value"
+         PropertyName="DefineConstants" />
+    </CreateProperty>
+    <CreateProperty
+       Condition="'$(Language)'=='VB'"
+       Value="CONTRACTS_FULL=-1,CODE_ANALYSIS=-1,$(FinalDefineConstants)">
+      <Output
+         TaskParameter="Value"
+         PropertyName="FinalDefineConstants" />
+    </CreateProperty>
+
+  </Target>
+
+  <!--=====================================================================
+        Determine level of runtime checking
+    ======================================================================-->
+  <Choose>
+    <When Condition="'$(CodeContractsRuntimeCheckingLevel)'=='Full'">
+      <PropertyGroup>
+        <CodeContractsRuntimeLevel>4</CodeContractsRuntimeLevel>
+      </PropertyGroup>
+    </When>
+    <!-- default -->
+    <When Condition="'$(CodeContractsRuntimeCheckingLevel)'==''">
+      <PropertyGroup>
+        <CodeContractsRuntimeLevel>4</CodeContractsRuntimeLevel>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(CodeContractsRuntimeCheckingLevel)'=='Pre and Post'">
+      <PropertyGroup>
+        <CodeContractsRuntimeLevel>3</CodeContractsRuntimeLevel>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(CodeContractsRuntimeCheckingLevel)'=='Preconditions'">
+      <PropertyGroup>
+        <CodeContractsRuntimeLevel>2</CodeContractsRuntimeLevel>
+      </PropertyGroup>
+    </When>
+    <!-- for backward compatibility -->
+    <When Condition="'$(CodeContractsRuntimeCheckingLevel)'=='RequiresAlways'">
+      <PropertyGroup>
+        <CodeContractsRuntimeLevel>1</CodeContractsRuntimeLevel>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(CodeContractsRuntimeCheckingLevel)'=='ReleaseRequires'">
+      <PropertyGroup>
+        <CodeContractsRuntimeLevel>1</CodeContractsRuntimeLevel>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <CodeContractsRuntimeLevel>0</CodeContractsRuntimeLevel>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <PropertyGroup
+    Condition="'$(CodeContractsEnableRuntimeChecking)' == 'true'">
+
+    <!--=====================================================================
+      C# and VB specific extra defined constants and rewrite post
+      build step
+
+      Must run prior to other CreateManifests steps in order to properly capture signature in manifest.
+      Need to run right after the compilation; otherwise other tools (such as the one that creates
+      a winmd file) will use the pre-rewritten assembly.
+    ======================================================================-->
+
+    <CompileDependsOn>$(CompileDependsOn); CodeContractInstrument</CompileDependsOn>
+  </PropertyGroup>
+
+  <!--=====================================================================
+        Add post build step for contract XML documentation generation
+    ======================================================================-->
+  <PropertyGroup
+      Condition="'$(CodeContractsEmitXMLDocs)' == 'true'">
+    <CompileDependsOn>$(CompileDependsOn);ContractXmlDocumentation</CompileDependsOn>
+  </PropertyGroup>
+
+  <!--=====================================================================
+        Define tool options
+    ======================================================================-->
+
+  <PropertyGroup
+      Condition="'$(CodeContractsEnableRuntimeChecking)' == 'true'">
+    <CodeContractRewriteOptions
+       Condition="'$(TargetFrameworkVersion)' != ''"
+       >$(CodeContractRewriteOptions) "/framework:$(TargetFrameworkVersion)"</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions
+       Condition="'$(CodeContractsPlatformPath)' != ''"
+       >$(CodeContractRewriteOptions) "/targetplatform:$(CodeContractsPlatformPath)"</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions
+       Condition="'$(CodeContractsClassLibrary)' != ''"
+       >$(CodeContractRewriteOptions) "/contractLibrary:$(CodeContractsClassLibrary)"</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions
+       Condition="'$(CodeContractsAssemblyMode)' == '1'"
+       >$(CodeContractRewriteOptions) "/assemblyMode=standard"</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions
+       Condition="'$(CodeContractsRuntimeOnlyPublicSurface)' == 'true'"
+       >$(CodeContractRewriteOptions) /publicsurface</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions
+       Condition="'$(CodeContractsRuntimeThrowOnFailure)' != 'false'"
+       >$(CodeContractRewriteOptions) /throwonfailure</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions
+       Condition="'$(CodeContractsRuntimeCallSiteRequires)' == 'true'"
+       >$(CodeContractRewriteOptions) /callsiterequires</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions
+       Condition="'$(CodeContractsRuntimeSkipQuantifiers)' == 'true'"
+       >$(CodeContractRewriteOptions) /skipQuantifiers</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions
+       Condition="'$(CodeContractsCustomRewriterAssembly)' != '' and '$(CodeContractsCustomRewriterClass)' != ''"
+       >$(CodeContractRewriteOptions) "/rewriterMethods:$(CodeContractsCustomRewriterAssembly),$(CodeContractsCustomRewriterClass)"</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions
+       Condition="'$(CodeContractsExtraRewriteOptions)' != ''"
+       >$(CodeContractRewriteOptions) $(CodeContractsExtraRewriteOptions)</CodeContractRewriteOptions>
+    <CodeContractRewriteOptions>/level:$(CodeContractsRuntimeLevel) /nologo /rewrite $(CodeContractRewriteOptions) "/resolvedPaths:@(ReferencePath,';')" "/libpaths:@(CodeContractsAllLibPaths) " "$(TargetName)$(TargetExt)"</CodeContractRewriteOptions>
+    <CodeContractRewriteCommand>$(CodeContractsInstallDir)Bin\ccrewrite.exe</CodeContractRewriteCommand>
+
+    <CodeContractsRewriterOutput>$(IntermediateOutputPath)$(TargetName).rewritten</CodeContractsRewriterOutput>
+
+  </PropertyGroup>
+
+  <ItemGroup
+     Condition="'$(CodeContractsEnableRuntimeChecking)' == 'true'">
+    <CodeContractsRewriterInputs
+       Include="@(ReferencePath)"/>
+    <CodeContractsRewriterInputs
+       Include="@(IntermediateAssembly)"/>
+    <CodeContractsRewriterInputs
+       Include="$(IntermediateOutputPath)$(TargetName).pdb"/>
+  </ItemGroup>
+
+
+  <!--=====================================================================
+        Runtime check instrumentation
+    ======================================================================-->
+
+  <Target
+     Name="CodeContractRewrite"
+     Condition="'$(CodeContractsEnableRuntimeChecking)' == 'true'"
+     DependsOnTargets="CodeContractsComputeAllLibPaths;EnsureContractReferenceAssemblyOfDependeeProjects;$(CodeContractRewriteDependsOn)"
+     Inputs="@(CodeContractsRewriterInputs)"
+     Outputs="$(CodeContractsRewriterOutput)"
+     >
+
+    <PropertyGroup>
+      <_CodeContractsCCRewriteArguments>$(CodeContractRewriteOptions)</_CodeContractsCCRewriteArguments>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_CodeContractsCCRewriteArgumentLines
+         Include="$(_CodeContractsCCRewriteArguments)"
+         />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrewrite.rsp"
+      Lines="@(_CodeContractsCCRewriteArgumentLines, ';')"
+      Overwrite="true"
+      />
+
+    <Exec
+       WorkingDirectory="$(IntermediateOutputPath)"
+       Command='"$(CodeContractRewriteCommand)" "@$(AssemblyName).ccrewrite.rsp"'
+       />
+
+    <CallTarget Targets="CodeContractReSign"/>
+
+    <WriteLinesToFile
+       File="$(CodeContractsRewriterOutput)"
+       />
+    <Touch Files="$(CodeContractsRewriterOutput)"/>
+    <ItemGroup>
+      <FileWrites
+         Include="$(CodeContractsRewriterOutput)"/>
+    </ItemGroup>
+  </Target>
+
+  <Target
+     Name="CodeContractReSign"
+     Condition="'$(DelaySign)' != 'true'"   
+     >
+    <GetFrameworkSdkPath>
+      <Output
+         TaskParameter="Path"
+         PropertyName="CodeContractsSdkPath" />
+    </GetFrameworkSdkPath>
+    <PropertyGroup>
+      <!-- SN is in the Framework SDK tools path, but TargetFrameworkSDKToolsDirectory isn't always available  -->
+      <CodeContractsSnExe Condition=" '$(TargetFrameworkSDKToolsDirectory)' != '' ">$(TargetFrameworkSDKToolsDirectory)sn.exe</CodeContractsSnExe>
+      <CodeContractsSnExe Condition=" '$(TargetFrameworkSDKToolsDirectory)' == '' ">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6 Tools\sn.exe</CodeContractsSnExe>
+    </PropertyGroup>
+    <Exec
+       Condition="'$(KeyOriginatorFile)' != ''"   
+       Command='&quot;$(CodeContractsSnExe)&quot; /R "@(IntermediateAssembly)" "$(KeyOriginatorFile)"' />
+    <Exec
+       Condition="'$(KeyContainerName)' != ''"   
+       Command='&quot;$(CodeContractsSnExe)&quot; /Rc "@(IntermediateAssembly)" "$(KeyContainerName)"' />
+  </Target>
+  
+  <Target
+     Name="CodeContractInstrument"
+     Condition="'$(CodeContractsEnableRuntimeChecking)' == 'true' and '$(BuildingProject)'=='true'"
+     DependsOnTargets="CodeContractRewrite"
+     >
+  </Target>
+
+  <!--=====================================================================
+      Building Contract Reference Assemblies
+   ======================================================================-->
+  <ItemGroup>
+    <_CodeContractOutputDirectory Include="$(OutDir)$(CodeContractsContractSubDir)"/>
+    <_ContractDummyReferenceAssembly Include="$(OutDir)$(CodeContractsContractSubDir)$(TargetName).noReferenceAssembly"/>
+    <ContractReferenceAssembly Include="$(OutDir)$(CodeContractsContractSubDir)$(TargetName).Contracts.dll"/>
+    <ContractReferenceAssemblyAbsolute Include="@(ContractReferenceAssembly->'%(FullPath)')"/>
+    <ContractReferenceAssemblyPDB Include="$(OutDir)$(CodeContractsContractSubDir)$(TargetName).Contracts.pdb"/>
+    <ContractDeclarativeAssembly Include="$(CodeContractsDeclDir)$(TargetName)$(TargetExt)"/>
+    <ContractDeclarativeAssemblyPDB Include="$(CodeContractsDeclDir)$(TargetName).pdb"/>
+    <ContractReferenceAssemblies Include="@(ContractReferenceAssembly);@(ContractReferenceAssemblyPDB)"/>
+    <ContractDeclarativeAssemblies Include="@(ContractDeclarativeAssembly);@(ContractDeclarativeAssemblyPDB)"/>
+    <CodeContractOutputDirectory Include="@(_CodeContractOutputDirectory->'%(RootDir)%(Directory)')"/>
+    <ContractDummyReferenceAssembly Include="@(_ContractDummyReferenceAssembly->'%(FullPath)')"/>
+  </ItemGroup>
+  <Target
+     Condition="'$(BuildingProject)'=='true'"
+     Name="CodeContractReferenceAssembly"
+     DependsOnTargets="CreateCodeContractReferenceAssembly;CodeContractDummyReferenceAssembly"
+     />
+
+  <Target
+     Name="CreateCodeContractReferenceAssembly"
+     Condition="'$(TargetName)' != 'Microsoft.Contracts' and '$(CodeContractsReferenceAssembly)' == 'build'"
+     DependsOnTargets="ContractDeclarativeAssembly;$(CodeContractReferenceAssemblyDependsOn);MakeCodeContractOutputDirectory;CodeContractsComputeAllLibPaths"
+     Inputs="@(ContractDeclarativeAssemblies)"
+     Outputs="@(ContractReferenceAssemblyAbsolute)">
+
+    <PropertyGroup>
+      <_CodeContractsCCRefGenArguments>"/resolvedPaths:@(ReferencePath,';')" "/libPaths:@(CodeContractsAllLibPaths) " /pdb "/out:@(ContractReferenceAssembly)" "@(ContractDeclarativeAssembly)"</_CodeContractsCCRefGenArguments>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_CodeContractsCCRefGenArgumentLines
+         Include="$(_CodeContractsCCRefGenArguments)"
+         />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"
+      Lines="@(_CodeContractsCCRefGenArgumentLines, ';')"
+      Overwrite="true"
+      />
+
+    <Exec
+       Condition="Exists('@(ContractDeclarativeAssembly)')"
+       Command='"$(CodeContractsCCRefgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"'
+       />
+    <ItemGroup
+       Condition="Exists('@(ContractReferenceAssemblyAbsolute)')">
+      <FileWrites
+         Include="@(ContractReferenceAssemblies);$(IntermediateOutputPath)$(AssemblyName).ccrefgen.rsp"/>
+    </ItemGroup>
+
+  </Target>
+
+  <Target
+     Name="CodeContractDummyReferenceAssembly"
+     Condition="'$(CodeContractsReferenceAssembly)' == 'doNotBuild'"
+     DependsOnTargets="MakeCodeContractOutputDirectory"
+     Outputs="@(ContractDummyReferenceAssembly)">
+
+    <Touch
+       Condition="!Exists(@(ContractDummyReferenceAssembly))"
+       AlwaysCreate="true"
+       Files="@(ContractDummyReferenceAssembly)"
+       />
+    <ItemGroup>
+      <FileWrites
+         Include="@(ContractDummyReferenceAssembly)"/>
+    </ItemGroup>
+  </Target>
+
+  <Target
+     Name="MakeCodeContractOutputDirectory"
+     Condition="!Exists(@(CodeContractOutputDirectory))"
+     >
+    <Message 
+       Text="Making directory @(CodeContractOutputDirectory)"
+       />
+    <MakeDir
+       Directories="@(CodeContractOutputDirectory)"/>
+  </Target>
+
+  <Target
+     Name="EnsureContractReferenceAssemblyOfDependeeProjects"
+     Condition="'@(_ResolvedProjectReferencePaths)' != ''"
+     >
+
+    <Message
+       Text="EnsureContractReferenceAssemblies: @(_ResolvedProjectReferencePaths)"
+       Importance="low"
+       />
+
+    <!--
+         Issue the warning *only* for C# and VB projects because those are the only ones that the user
+         can shut off the warning by changing the settings.
+      -->
+    <Warning
+       Condition="!Exists('%(RootDir)%(Directory)CodeContracts\%(Filename).Contracts.dll') and !Exists('%(RootDir)%(Directory)\CodeContracts\%(Filename).noReferenceAssembly') and ('$([System.IO.Path]::GetExtension(%(_ResolvedProjectReferencePaths.OriginalItemSpec)))' == '.csproj' or '$([System.IO.Path]::GetExtension(%(_ResolvedProjectReferencePaths.OriginalItemSpec)))' == '.vbproj')"
+       Text="Contract reference assembly for project '%(Filename)' not found. Select 'Build' or 'DoNotBuild' for Contract Reference in project settings."
+       HelpKeyword="@(_ResolvedProjectReferencePaths)"
+       />
+  </Target>
+
+  <!--=====================================================================
+      Building Contract Declarative Assemblies
+    ======================================================================-->
+  <Target
+     Name="ContractDeclarativeAssembly"
+     DependsOnTargets="ContractsMakeDeclDir;ResolveReferences;ResolveKeySource;ContractDeclarativeAssemblyCS;ContractDeclarativeAssemblyVB"
+     />
+
+  <Target Name="ContractsMakeDeclDir">
+    <MakeDir
+       Condition="!Exists('$(CodeContractsDeclDir)')"
+       Directories="$(CodeContractsDeclDir)"/>
+  </Target>
+  
+  <Target
+     Name="ContractDeclarativeAssemblyVB"
+     Condition="'$(Language)'=='VB'"
+     DependsOnTargets=""
+     Inputs="$(MSBuildAllProjects);
+             @(Compile)"
+     Outputs="@(ContractDeclarativeAssembly->'%(FullPath)')"
+     >
+    <ItemGroup>
+      <ContractDeclarativeSources Include="@(Compile);$(CodeContractsInstallDir)Languages\VisualBasic\ContractDeclarativeAssemblyAttribute.vb"/>
+    </ItemGroup>
+    <Message Text="Build Declarative Contract Assembly for VB $(TargetPath)"/>
+    <Vbc  Condition=" '%(_CoreCompileResourceInputs.WithCulture)' != 'true' "
+          AdditionalLibPaths="$(AdditionalLibPaths)"
+          AddModules="@(AddModules)"
+          BaseAddress="$(BaseAddress)"          
+          CodePage="$(CodePage)"
+          DebugType="$(DebugType)"
+          DefineConstants="$(FinalDefineConstants),CONTRACTS_FULL=-1,CODE_ANALYSIS=-1"
+          DelaySign="$(DelaySign)"
+          DisabledWarnings="$(NoWarn)"
+          DocumentationFile=""
+          EmitDebugInformation="$(DebugSymbols)"
+          ErrorReport="$(ErrorReport)"
+          FileAlignment="$(FileAlignment)"
+          GenerateDocumentation=""
+          Imports="@(Import)"
+          KeyContainer="$(KeyContainerName)"
+          KeyFile="$(KeyOriginatorFile)"
+          LangVersion="$(LangVersion)"
+          MainEntryPoint="$(StartupObject)"
+          ModuleAssemblyName="$(ModuleAssemblyName)"
+          NoConfig="true"
+          NoStandardLib="$(NoCompilerStandardLib)"
+          NoVBRuntimeReference="$(NoVBRuntimeReference)"
+          NoWarnings="$(_NoWarnings)"
+          NoWin32Manifest="$(NoWin32Manifest)"
+          Optimize="true"
+          OptionCompare="$(OptionCompare)"
+          OptionExplicit="$(OptionExplicit)"
+          OptionInfer="$(OptionInfer)"
+          OptionStrict="$(OptionStrict)"
+          OptionStrictType="$(OptionStrictType)" 
+          OutputAssembly="@(ContractDeclarativeAssembly)"
+          Platform="$(PlatformTarget)"
+          References="@(ReferencePath)"
+          RemoveIntegerChecks="$(RemoveIntegerChecks)"
+          Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
+          ResponseFiles="$(CompilerResponseFile)"
+          RootNamespace="$(RootNamespace)"
+          SdkPath="$(FrameworkPathOverride)"
+          Sources="@(ContractDeclarativeSources)"
+          TargetCompactFramework="$(TargetCompactFramework)"
+          TargetType="$(OutputType)"
+          ToolExe="$(VbcToolExe)"
+          ToolPath="$(VbcToolPath)"
+          TreatWarningsAsErrors="false"
+          UseHostCompilerIfAvailable="$(UseHostCompilerIfAvailable)"
+          Utf8Output="$(Utf8Output)"
+          Verbosity="$(VbcVerbosity)"
+          WarningsAsErrors=""
+          WarningsNotAsErrors="$(WarningsNotAsErrors)"
+          Win32Icon="$(ApplicationIcon)"
+          Win32Manifest="$(Win32Manifest)"              
+          Win32Resource="$(Win32Resource)"
+          />
+    
+    <ItemGroup>
+      <FileWrites
+         Include="@(ContractDeclarativeAssemblies)"/>
+    </ItemGroup>
+  </Target>
+
+  <Target
+     Name="ContractDeclarativeAssemblyCS"
+     Condition="'$(Language)'=='C#'"
+     DependsOnTargets=""
+     Inputs="$(MSBuildAllProjects);
+             @(Compile)"
+     Outputs="@(ContractDeclarativeAssembly->'%(FullPath)')"
+     >
+    <ItemGroup>
+      <ContractDeclarativeSources Include="@(Compile);$(CodeContractsInstallDir)Languages\CSharp\ContractDeclarativeAssemblyAttribute.cs"/>
+    </ItemGroup>
+    <Message Text="Build Declarative Contract Assembly for C# $(TargetPath)"/>
+    <Csc
+       AdditionalLibPaths="$(AdditionalLibPaths)"
+       AddModules="@(AddModules)"
+       AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
+       BaseAddress="$(BaseAddress)"
+       CheckForOverflowUnderflow="$(CheckForOverflowUnderflow)"
+       CodePage="$(CodePage)"
+       DebugType="full"
+       DefineConstants="$(DefineConstants);CONTRACTS_FULL;CODE_ANALYSIS"
+       DelaySign="$(DelaySign)"
+       DisabledWarnings="$(NoWarn)"
+       DocumentationFile=""
+       EmitDebugInformation="true"
+       ErrorReport="$(ErrorReport)"
+       FileAlignment="$(FileAlignment)"
+       GenerateFullPaths="$(GenerateFullPaths)"
+       KeyContainer="$(KeyContainerName)"
+       KeyFile="$(KeyOriginatorFile)"
+       LangVersion="$(LangVersion)"
+       MainEntryPoint="$(StartupObject)"
+       ModuleAssemblyName="$(ModuleAssemblyName)"
+       NoConfig="true"
+       NoLogo="$(NoLogo)"
+       NoStandardLib="$(NoCompilerStandardLib)"
+       NoWin32Manifest="$(NoWin32Manifest)"
+       Optimize="true"
+       OutputAssembly="@(ContractDeclarativeAssembly)"
+       PdbFile="@(ContractDeclarativeAssemblyPDB)" 
+       Platform="$(PlatformTarget)"
+       References="@(ReferencePath)"
+       Resources=""
+       ResponseFiles="$(CompilerResponseFile)"
+       Sources="@(ContractDeclarativeSources)"
+       TargetType="$(OutputType)"
+       ToolExe="$(CscToolExe)"
+       ToolPath="$(CscToolPath)"
+       TreatWarningsAsErrors="false"
+       UseHostCompilerIfAvailable="$(UseHostCompilerIfAvailable)"
+       Utf8Output="$(Utf8Output)"
+       WarningLevel="0"
+       WarningsAsErrors=""
+       WarningsNotAsErrors="$(WarningsNotAsErrors)"
+       Win32Icon=""
+       Win32Manifest="$(Win32Manifest)"
+       Win32Resource="$(Win32Resource)"
+       />            
+    
+    <ItemGroup>
+      <FileWrites
+         Include="@(ContractDeclarativeAssemblies)"/>
+    </ItemGroup>
+  </Target>
+
+
+  <Target
+     Name="CodeContractsComputeReferencedLibPaths">
+    <ItemGroup>
+      <_CodeContractsBuildReferences
+         Include="@(ReferencePath->'%(RootDir)%(Directory)')"/>
+      <_CodeContractsBuildReferences
+         Include="@(ReferencePath->'%(RootDir)%(Directory)CodeContracts')"/>
+    </ItemGroup>
+    <RemoveDuplicates
+       Inputs="@(_CodeContractsBuildReferences)">
+      <Output
+         TaskParameter="Filtered"
+         ItemName="CodeContractsBuildLibPaths"/>
+    </RemoveDuplicates>
+  </Target>
+
+  <Target
+     Name="CodeContractsComputeAllLibPaths"
+     DependsOnTargets="CodeContractsComputeReferencedLibPaths"
+     >
+    <Message Text="CodeContractsComputeAllLibPaths" Importance="low"/>
+    <RemoveDuplicates
+       Inputs="@(CodeContractsBuildLibPaths);$(CodeContractsReferenceAssemblyLibPath);$(CodeContractsLibPaths)">
+      <Output
+         TaskParameter="Filtered"
+         ItemName="CodeContractsAllLibPaths"/>
+    </RemoveDuplicates>
+  </Target>
+
+  <!--=====================================================================
+      Building XML Documentation for Contracts
+    ======================================================================-->
+
+  <Target
+    Name="CompensateForVBSettingOfDocFileItem">
+     <!--
+     ** VB sets DocFileItem to the obj/x86/Debug (or whatever configuration) directory for some reason.
+     ** Updating the value of that variable has to be done in a task prior to the ContractXmlDocumentation target.
+     -->
+    <ItemGroup Condition="'$(Language)' == 'VB'"> <!-- see this defined at the top of m.visualbasic.targets -->
+        <DocFileItem Remove="@(DocFileItem)"/>  <!-- empty out existing value -->
+        <DocFileItem Include="$(OutputPath)$(DocumentationFile)"  Condition="'$(DocumentationFile)'!=''"/> <!-- use path into final bin dir instead -->
+    </ItemGroup>
+  </Target>
+
+  <PropertyGroup>
+    <CodeContractsCCDocgenCommand>$(CodeContractsInstallDir)Bin\ccdocgen.exe</CodeContractsCCDocgenCommand>
+  </PropertyGroup>
+
+  <Target
+     Name="ContractXmlDocumentation"
+     Condition="Exists('@(DocFileItem)') and Exists('@(ContractReferenceAssemblyAbsolute)') and '$(BuildingProject)'=='true'"
+     DependsOnTargets="CodeContractReferenceAssembly;CodeContractsComputeAllLibPaths;CompensateForVBSettingOfDocFileItem"
+     Inputs="@(ContractReferenceAssembly);@(DocFileItem)"
+     Outputs="@(DocFileItem)">
+
+    <PropertyGroup>
+      <_CodeContractsCCDocGenArguments>-assembly "@(ContractReferenceAssembly)" -xmlFile "@(DocFileItem)" "-resolvedPaths:@(ReferencePath)" -libpaths "@(CodeContractsAllLibPaths) "</_CodeContractsCCDocGenArguments>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_CodeContractsCCDocGenArgumentLines
+         Include="$(_CodeContractsCCDocGenArguments)"
+         />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"
+      Lines="@(_CodeContractsCCDocGenArgumentLines, ';')"
+      Overwrite="true"
+      />
+
+    <Exec
+       Command='"$(CodeContractsCCdocgenCommand)" "@$(IntermediateOutputPath)$(AssemblyName).ccdocgen.rsp"' 
+       />
+  </Target>
+
+  <!--=====================================================================
+      Include Code Analysis target if present
+    ======================================================================-->
+  <PropertyGroup>
+    <CodeContractAnalysisTargets>$(CodeContractsInstallDir)MsBuild\v14.0\Microsoft.CodeContractAnalysis.targets</CodeContractAnalysisTargets>
+  </PropertyGroup>
+  <Import Project="$(CodeContractAnalysisTargets)" Condition="Exists('$(CodeContractAnalysisTargets)')"/>
+
+  <!-- End Microsoft Code Contracts -->
+</Project>

--- a/Microsoft.Research/ManagedContract.Setup/ManagedContracts.wxs
+++ b/Microsoft.Research/ManagedContract.Setup/ManagedContracts.wxs
@@ -84,7 +84,7 @@
 <?define var.VS14VsixManifestCompGuid         = "{990ACB0B-1AAE-4fa6-A178-9BF28206012F}" ?>
 <?define var.ContractsTargets120CompGuid      = "{990ACB09-1AAE-4fa6-A178-9BF28206012F}" ?>
 <?define var.ContractsTargets140CompGuid      = "{990ACB0C-1AAE-4fa6-A178-9BF28206012F}" ?>
-<?define var.ContractsTargets150CompGuid      = "{990ACB0C-1AAE-4fa6-A178-9BF28206012F}" ?>
+<?define var.ContractsTargets150CompGuid      = "{990ACB0E-1AAE-4fa6-A178-9BF28206012F}" ?>
 
 
   <!--=====================================================================

--- a/Microsoft.Research/ManagedContract.Setup/ManagedContracts.wxs
+++ b/Microsoft.Research/ManagedContract.Setup/ManagedContracts.wxs
@@ -1300,6 +1300,7 @@
         <ComponentRef Id='ContractsTargets40' />
         <ComponentRef Id='ContractsTargets120' />
         <ComponentRef Id='ContractsTargets140' />
+        <ComponentRef Id='ContractsTargets150' />
         <ComponentRef Id='ContractsPropertyPane' />
         <ComponentRef Id='CodeContractTools' />
         <ComponentRef Id='OutOfBandContracts35' />

--- a/Microsoft.Research/ManagedContract.Setup/ManagedContracts.wxs
+++ b/Microsoft.Research/ManagedContract.Setup/ManagedContracts.wxs
@@ -84,6 +84,7 @@
 <?define var.VS14VsixManifestCompGuid         = "{990ACB0B-1AAE-4fa6-A178-9BF28206012F}" ?>
 <?define var.ContractsTargets120CompGuid      = "{990ACB09-1AAE-4fa6-A178-9BF28206012F}" ?>
 <?define var.ContractsTargets140CompGuid      = "{990ACB0C-1AAE-4fa6-A178-9BF28206012F}" ?>
+<?define var.ContractsTargets150CompGuid      = "{990ACB0C-1AAE-4fa6-A178-9BF28206012F}" ?>
 
 
   <!--=====================================================================
@@ -1082,6 +1083,16 @@
                   <?if $(var.Feature_CCCheck) = true ?>
                     <File Id='ContractsAnalysisTargets140' Name="$(var.CodeContractsTargets2)"
                           Source="MsBuild\v14.0\$(var.CodeContractsTargets2)" Vital='yes' />
+                  <?endif?>
+                </Component>                   
+              </Directory>
+              <Directory Id='MsBuildv150' Name='v15.0'>
+                <Component Id='ContractsTargets150' Guid='$(var.ContractsTargets150CompGuid)'>
+                  <File Id='ContractsTargets150' Name="$(var.CodeContractsTargets)"
+                        Source="MsBuild\v15.0\$(var.CodeContractsTargets)" Vital='yes' />
+                  <?if $(var.Feature_CCCheck) = true ?>
+                    <File Id='ContractsAnalysisTargets150' Name="$(var.CodeContractsTargets2)"
+                          Source="MsBuild\v15.0\$(var.CodeContractsTargets2)" Vital='yes' />
                   <?endif?>
                 </Component>                   
               </Directory>


### PR DESCRIPTION
This PR adds MSBuild targets for MSBuild 15.0 (Visual Studio 2017).

It also uses the .NET 4.6 Contract BCLs when targeting .NET 4.6.2.

I haven't done anything on the IDE integration side, partly because Visual Studio 2017 has moved a whole lot of cheeses and it's not a simple case of incrementing "14" to "15" and calling it a day.